### PR TITLE
Fix familienstand date 500 error

### DIFF
--- a/acceptance_tests/cypress/integration/lotse_flow.spec.js
+++ b/acceptance_tests/cypress/integration/lotse_flow.spec.js
@@ -121,7 +121,7 @@ context('Acceptance tests', () => {
             cy.get('#familienstand-1').check()
             cy.get('#familienstand_date').clear().type(older_date)
             cy.get('label[for=familienstand_married_lived_separated-no]').click()
-            cy.get('label[for=familienstand_confirm_zusammenveranlagung]').first().click()
+            cy.get('label[for=familienstand_confirm_zusammenveranlagung]').should('be.visible')
 
             cy.get('label[for=familienstand_married_lived_separated-yes]').click()
             cy.get('#familienstand_married_lived_separated_since').clear().type(older_date)
@@ -136,9 +136,14 @@ context('Acceptance tests', () => {
             cy.get('#familienstand_date').clear().type(older_date)
             cy.get('label[for=familienstand_married_lived_separated-no]').click()
             cy.get('div[id=familienstand_confirm_zusammenveranlagung_field]').should('be.visible')
+            cy.get('label[for=familienstand_confirm_zusammenveranlagung]').first().click()
+            cy.get('#familienstand_confirm_zusammenveranlagung').should('be.checked')
             cy.get('#familienstand-0').check()
             cy.get('#familienstand-1').check()
             cy.get('div[id=familienstand_confirm_zusammenveranlagung_field]').should('not.be.visible')
+            cy.get('label[for=familienstand_married_lived_separated-no]').click()
+            cy.get('div[id=familienstand_confirm_zusammenveranlagung_field]').should('be.visible')
+            cy.get('#familienstand_confirm_zusammenveranlagung').should('not.be.checked')
 
             // Widowed
             cy.get('#familienstand-2').check()

--- a/webapp/app/forms/steps/lotse/personal_data_steps.py
+++ b/webapp/app/forms/steps/lotse/personal_data_steps.py
@@ -78,7 +78,7 @@ class StepFamilienstand(FormStep):
                 validators.InputRequired(_l('form.lotse.validation-familienstand-married-lived-separated-since'))(self, field)
             else:
                 validators.Optional()(self, field)
-            if field.data < self.familienstand_date.data:
+            if field.data and field.data < self.familienstand_date.data:
                 from wtforms.validators import ValidationError
                 raise ValidationError(_('form.lotse.validation.married-after-separated'))
         
@@ -95,7 +95,7 @@ class StepFamilienstand(FormStep):
                 validators.InputRequired(_l('form.lotse.validation-familienstand-widowed-lived-separated-since'))(self, field)
             else:
                 validators.Optional()(self, field)
-            if field.data >= self.familienstand_date.data:
+            if field.data and field.data >= self.familienstand_date.data:
                 from wtforms.validators import ValidationError
                 raise ValidationError(_('form.lotse.validation.widowed-before-separated'))
 

--- a/webapp/app/templates/lotse/form_familienstand.html
+++ b/webapp/app/templates/lotse/form_familienstand.html
@@ -72,6 +72,15 @@
             }
         }
 
+        function show_hide_checkbox_field(show_condition, input_name) {
+            if (show_condition) {
+                $('#' + input_name + '_field').show();
+            } else {
+                $('#' + input_name + '_field').hide();
+                $('#' + input_name).prop('checked', false);
+            }
+        }
+
         function show_hide_familienstand_date_field() {
             show_hide_date_field($('input[value="married"]').is(':checked') ||
                 $('input[value="widowed"]').is(':checked') ||
@@ -103,7 +112,7 @@
         }
 
         function show_hide_familienstand_confirm_zusammenveranlagung_field() {
-            show_hide_yes_no_field(
+            show_hide_checkbox_field(
                 ($('input[value="married"]').is(':checked')
                     && $('#familienstand_married_lived_separated-no').is(':checked')) ||
                 ($('input[value="widowed"]').is(':checked')

--- a/webapp/tests/forms/steps/test_personal_data_steps.py
+++ b/webapp/tests/forms/steps/test_personal_data_steps.py
@@ -192,6 +192,16 @@ class TestFamilienstand(unittest.TestCase):
         self.assertFalse(form.validate())
         self.assertIn('familienstand_married_lived_separated_since', form.errors)
 
+    def test_if_married_and_lived_separated_and_separated_since_is_invalid_date_then_fail_validation(self):
+        data = MultiDict({'familienstand': 'married',
+                          'familienstand_date': '03.04.2008',
+                          'familienstand_married_lived_separated': 'yes',
+                          'familienstand_married_lived_separated_since': '99.99.9999',
+                          'familienstand_confirm_zusammenveranlagung': 'y'})
+        form = self.step.Form(formdata=data)
+        self.assertFalse(form.validate())
+        self.assertIn('familienstand_married_lived_separated_since', form.errors)
+
     def test_if_married_and_lived_separated_and_separated_since_before_married_date_then_fail_validation(self):
         data = MultiDict({'familienstand': 'married',
                           'familienstand_date': '03.04.2008',
@@ -292,6 +302,16 @@ class TestFamilienstand(unittest.TestCase):
                           'familienstand_date': '03.04.2008',
                           'familienstand_widowed_lived_separated': 'yes',
                           'familienstand_widowed_lived_separated_since': '01.01.2010',
+                          'familienstand_confirm_zusammenveranlagung': 'y'})
+        form = self.step.Form(formdata=data)
+        self.assertFalse(form.validate())
+        self.assertIn('familienstand_widowed_lived_separated_since', form.errors)
+    
+    def test_if_widowed_and_lived_separated_and_separated_since_is_invalid_date_then_fail_validation(self):
+        data = MultiDict({'familienstand': 'widowed',
+                          'familienstand_date': '03.04.2008',
+                          'familienstand_widowed_lived_separated': 'yes',
+                          'familienstand_widowed_lived_separated_since': '99.99.9999',
                           'familienstand_confirm_zusammenveranlagung': 'y'})
         form = self.step.Form(formdata=data)
         self.assertFalse(form.validate())

--- a/webapp/tests/forms/steps/test_personal_data_steps.py
+++ b/webapp/tests/forms/steps/test_personal_data_steps.py
@@ -151,6 +151,15 @@ class TestFamilienstand(unittest.TestCase):
         form = self.step.Form(formdata=data)
         self.assertTrue(form.validate())
 
+    def test_if_invalid_familienstand_date_given_then_fail_validation(self):
+        data = MultiDict({'familienstand': 'married',
+                          'familienstand_date': '99.99.9999',
+                          'familienstand_married_lived_separated': 'no',
+                          'familienstand_confirm_zusammenveranlagung': 'y'})
+        form = self.step.Form(formdata=data)
+        self.assertFalse(form.validate())
+        self.assertIn('familienstand_date', form.errors)
+
     def test_if_married_and_no_familienstand_date_given_then_fail_validation(self):
         data = MultiDict({'familienstand': 'married',
                           'familienstand_married_lived_separated': 'no',


### PR DESCRIPTION
# Short Description
- We previously got a 500 error when someone inputted an invalid date into the `familienstand_<married/widowed>_lived_separated` fields. This fixes that error.
- Additionally, I noticed that the `familienstand_confirm_zusammenveranlagung` field was not correctly unchecked when being hidden. This also fixes that.

# Changes
- Correctly uncheck `familienstand_confirm_zusammenveranlagung` on hide
- Check that `familienstand_married_lived_separated` is filled before comparing the value (if the date validation fails, the field's data is not set)
- Check that `familienstand_widowed_lived_separated` is filled before comparing the value (if the date validation fails, the field's data is not set)
- Test all of the above

# Feedback
- Let me know if you see anything problematic with this. I don't think it is though^^
