### PR TITLE
Deactivate register and revoke if logged in

### DIFF
--- a/acceptance_tests/cypress/integration/lotse_flow.spec.js
+++ b/acceptance_tests/cypress/integration/lotse_flow.spec.js
@@ -105,17 +105,25 @@ context('Acceptance tests', () => {
         cy.visit('/')
     });
 
+    it('Check that registration and revocation are clickable', () => {
+        cy.get('a').contains(/^Registrieren$/)
+            .should('have.class', 'nav-link')
+            .should('not.have.class', 'inactive')
+        cy.get('a').contains(/^Freischaltcode Stornierung$/)
+            .should('not.have.class', 'inactive')
+    })
+
     context('When I am logged in', () => {
         beforeEach(() => {
             login()
         })
 
-        it('Check that register and revocation are disabled', () => {
-            cy.visit('/')
-            cy.get('.nav-link').contains('Registrieren')
+        it('Check that registration and revocation are disabled', () => {
+            cy.get('span').contains(/^Registrieren$/)
+                .should('have.class', 'nav-link')
                 .should('have.class', 'inactive')
-                .click()
-            cy.location('pathname').should('eq', '/')
+            cy.get('span').contains(/^Freischaltcode Stornierung$/)
+                .should('have.class', 'inactive')
         })
 
         it('Enter different familienstands', () => {

--- a/acceptance_tests/cypress/integration/lotse_flow.spec.js
+++ b/acceptance_tests/cypress/integration/lotse_flow.spec.js
@@ -110,6 +110,14 @@ context('Acceptance tests', () => {
             login()
         })
 
+        it('Check that register and revocation are disabled', () => {
+            cy.visit('/')
+            cy.get('.nav-link').contains('Registrieren')
+                .should('have.class', 'inactive')
+                .click()
+            cy.location('pathname').should('eq', '/')
+        })
+
         it('Enter different familienstands', () => {
             cy.visit('/lotse/step/familienstand?link_overview=True')
 

--- a/webapp/app/routes.py
+++ b/webapp/app/routes.py
@@ -47,7 +47,7 @@ class SteuerlotseNavItem(nav.Item):
 
     @property
     def is_active(self):
-        return not self.deactivate_when_logged_in or current_user and not current_user.is_authenticated
+        return not self.deactivate_when_logged_in or (current_user and not current_user.is_authenticated)
 
 
 nav.Bar('top', [

--- a/webapp/app/routes.py
+++ b/webapp/app/routes.py
@@ -34,27 +34,31 @@ def add_caching_headers(route_handler, minutes=5):
 # Navigation
 
 
-class MultiEndpointItem(nav.Item):
+class SteuerlotseNavItem(nav.Item):
 
-    def __init__(self, label, endpoint, params, matching_endpoint_prefixes):
-        super(MultiEndpointItem, self).__init__(label, endpoint, params)
-        self.matching_endpoint_prefixes = matching_endpoint_prefixes
+    def __init__(self, label, endpoint, params, matching_endpoint_prefixes=None, deactivate_when_logged_in=False):
+        super(SteuerlotseNavItem, self).__init__(label, endpoint, params)
+        self.matching_endpoint_prefixes = matching_endpoint_prefixes if matching_endpoint_prefixes else [endpoint]
+        self.deactivate_when_logged_in = deactivate_when_logged_in
 
     @property
     def is_current(self):
         return any([request.endpoint.startswith(pfx) for pfx in self.matching_endpoint_prefixes])
 
+    @property
+    def is_active(self):
+        return not self.deactivate_when_logged_in or current_user and not current_user.is_authenticated
+
 
 nav.Bar('top', [
-    nav.Item(_l('nav.home'), 'index'),
-    nav.Item(_l('nav.how-it-works'), 'howitworks'),
-    MultiEndpointItem(_l('nav.eligibility'), 'eligibility', {'step': 'start'},
-                      matching_endpoint_prefixes=['eligibility']),
-    MultiEndpointItem(_l('nav.register'), 'unlock_code_request', {},
-                      matching_endpoint_prefixes=['unlock_code_request']),
-    MultiEndpointItem(_l('nav.lotse-form'), 'unlock_code_activation', {},
-                      matching_endpoint_prefixes=['unlock_code_activation', 'lotse']),
-    nav.Item(_l('nav.logout'), 'logout'),
+    SteuerlotseNavItem(_l('nav.home'), 'index', {}),
+    SteuerlotseNavItem(_l('nav.how-it-works'), 'howitworks', {}),
+    SteuerlotseNavItem(_l('nav.eligibility'), 'eligibility', {'step': 'start'}),
+    SteuerlotseNavItem(_l('nav.register'), 'unlock_code_request', {},
+                       deactivate_when_logged_in=True),
+    SteuerlotseNavItem(_l('nav.lotse-form'), 'unlock_code_activation', {},
+                       matching_endpoint_prefixes=['unlock_code_activation', 'lotse']),
+    SteuerlotseNavItem(_l('nav.logout'), 'logout', {})
 ])
 
 login_manager.login_view = 'unlock_code_activation'

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -534,7 +534,7 @@ ol li::before {
     border-left: 4px solid var(--text-color);
 }
 
-span.nav-link.inactive {
+span.nav-link.inactive, span.inactive {
     color: var(--secondary-text-color);
     cursor: default;
 }

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -534,6 +534,11 @@ ol li::before {
     border-left: 4px solid var(--text-color);
 }
 
+span.nav-link.inactive {
+    color: var(--secondary-text-color);
+    cursor: default;
+}
+
 .bmf-info {
     position: fixed;
     bottom: 0;

--- a/webapp/app/templates/basis/footer.html
+++ b/webapp/app/templates/basis/footer.html
@@ -12,7 +12,11 @@
                             <a href="{{ url_for('contact') }}">{{ _('footer.contact') }}</a>
                         </li>
                         <li class="text-nowrap mt-2">
-                            <a href="{{ url_for('unlock_code_revocation', step='start') }}">{{ _('footer.revocation') }}</a>
+                            {% if current_user.is_authenticated %}
+                                <span class="inactive">{{ _('footer.revocation') }}</span>
+                            {% else %}
+                                <a href="{{ url_for('unlock_code_revocation', step='start') }}">{{ _('footer.revocation') }}</a>
+                            {% endif %}
                         </li>
                     </ul>
                 </div>

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -26,9 +26,13 @@
 
 {% macro nav_item_list(nav, current_user) %}
     <ul class="nav navbar-nav ml-auto">
-        {% for item in nav.top if not item.ident.endpoint == 'logout' or current_user.is_active -%}
-            <li class="nav-item {{ 'active' if item.is_active else '' }} pt-2 pb-2">
-                <a class="nav-link pt-0 pb-0" href="{{ item.url }}">{{ item.label }}</a>
+        {% for item in nav.top if not item.ident.endpoint == 'logout' or current_user.is_active %}
+            <li class="nav-item {{ 'active' if item.is_current else '' }} pt-2 pb-2">
+                {% if item.is_active %}
+                    <a class="nav-link pt-0 pb-0" href="{{ item.url }}">{{ item.label }}</a>
+                {% else %}
+                    <span class="nav-link inactive pt-0 pb-0">{{ item.label }}</span>
+                {% endif %}
             </li>
         {% endfor -%}
     </ul>


### PR DESCRIPTION
# Short Description
- You shouldn't be able to register again or revoke your unlock code if you're currently logged in.
- https://steuerlotse.atlassian.net/browse/STL-892 and https://steuerlotse.atlassian.net/browse/STL-891

# Changes
- Replaced the two links by spans because of this article stating that disabling links is a bad idea: https://css-tricks.com/how-to-disable-links/
- Made them grey + set correct cursor
- Introduced acceptance tests to test that behaviour (used regex to find the exact match, not just some link that contains "Registrieren")
- Refactored the nav items to use custom SteuerlotseNavItems that override the default behaviour of is_active and is_current

# Feedback
- Do you think acceptance tests are the way to go here? And do they and their placement make sense to you?
- What do you think of the SteuerlotseNavItem? In my head it's better to confige the activeness in routes than in the templates but maybe you disagree? (the other way (via templates: `item.ident.endpoint == 'logout'`) is shown with logout, I'd be happy to also move that into the nav items)