### PR TITLE
Remove active background color from details component

### DIFF
--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -186,42 +186,46 @@
 }
 
 /* DETAILS */
-.details-card .card{
+.details-card .card {
     border: 0;
     border-radius: 0;
     background: inherit;
 }
 
-.details-card .card-header{
+.details-card .card-header {
     border: 0;
     background: inherit;
 }
 
-.details-card .card-header h5{
+.details-card .card-header span {
     color: var(--text-color);
     font-size: var(--text-medium);
     font-weight: var( --font-bold);
 }
 
-.details-card .card-header button{
+.details-card .card-header button {
     text-align: left;
-    color: var(--text-colour);
+    color: var(--text-color);
     background: inherit;
     border: 0;
 }
 
-.details-card .card-header .collapsed h5{
+.details-card .card-header .collapsed span {
     color: var(--link-color);
     text-decoration: underline;
     text-decoration-color: var(--icon-default-colour);
 }
 
-.details-card .card-header .collapsed h5:hover{
+.details-card .card-header .collapsed span:hover {
     color: var(--link-hover-color);
     text-decoration-color: var(--link-hover-color);
 }
 
-.details-card .card-header button:focus h5{
+.details-card .card-header button:focus {
+    outline:none;
+}
+
+.details-card .card-header button:focus span {
     color: var(--focus-text-colour);
     text-decoration: underline;
     text-decoration-color: var(--focus-text-colour);
@@ -270,8 +274,9 @@
     background-color: var(--border-colour);
 }
 
-.details-card .card-header button:hover, .accordion .card-header button:active{
+.details-card .card-header button:hover, .accordion .card-header button:active {
     color: var(--link-hover-color);
+    outline: none;
 }
 
 .details-card .card-header .control-show-more{

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -208,6 +208,8 @@
     color: var(--text-color);
     background: inherit;
     border: 0;
+    outline: none;
+    box-shadow: none;
 }
 
 .details-card .card-header .collapsed span {
@@ -219,10 +221,6 @@
 .details-card .card-header .collapsed span:hover {
     color: var(--link-hover-color);
     text-decoration-color: var(--link-hover-color);
-}
-
-.details-card .card-header button:focus {
-    outline:none;
 }
 
 .details-card .card-header button:focus span {

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -152,12 +152,12 @@
                 <div class="row collapsed" data-toggle="collapse"
                             data-target="#details-body-{{ details_id }}"
                             aria-expanded="false" aria-controls="collapseOne">
-                    <button class="btn btn-primary container" type="button">
+                    <button class="container" type="button">
                         <div class="row">
                             <div class="details-icon col-1 control-show-more"></div>
                             <div class="details-icon col-1 control-show-less"></div>
                             <div class="col">
-                                    <h5 class="mb-0">{{title}}</h5>
+                                <span class="mb-0">{{title}}</span>
                             </div>
                         </div>
                     </button>

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -152,7 +152,7 @@
                 <div class="row collapsed" data-toggle="collapse"
                             data-target="#details-body-{{ details_id }}"
                             aria-expanded="false" aria-controls="collapseOne">
-                    <button class="container" type="button">
+                    <button class="btn container" type="button">
                         <div class="row">
                             <div class="details-icon col-1 control-show-more"></div>
                             <div class="details-icon col-1 control-show-less"></div>


### PR DESCRIPTION
# Short Description
- The details component seemed to flicker. Now it doesn't anymore^^

# Changes
- Removed the btn and btn-primary classes on the details header button - I think we mostly overwrote them anyways before
- Only thing I had to change then was to set `button:active` and `button:focus` outline to none
- Also changed the h5 to be a simple span, that's gonna help us to clean up the text hierarchy

# Feedback
- Do you see any problems with removing the btn and btn-primary classes?
