### PR TITLE
Revert bump python to 3.10.0b3

### DIFF
--- a/erica_app/Dockerfile
+++ b/erica_app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.0b3-slim-buster
+FROM python:3.9.5-slim-buster
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.0b3-slim-buster AS base
+FROM python:3.9.5-slim-buster AS base
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
# Short Description
- Revert the dependabot commit because this was a bump to [a beta version  ](https://pythoninsider.blogspot.com/2021/06/python-3100b3-is-available.html?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+PythonInsider+%28Python+Insider%29).

# Changes
- Revert the bump of the python version in the webapp and erica_app

# Feedback
- None feedback needed for this as we discussed it already via phone
