### PR TITLE
Correctly align input field with errors

### DIFF
--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -691,6 +691,11 @@ footer a{
 .form-row-center {
     display: flex;
     align-items: baseline;
+    margin: 0 calc(-1 * var(--spacing-02));
+}
+
+.form-row-center > * {
+    margin: 0 var(--spacing-02);
 }
 
 .section-intro p {

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -139,6 +139,7 @@ img.invalid-feedback{
 }
 
 .error-found-line{
+    margin-left: var(--spacing-02);
     padding-left: var(--spacing-04) !important;
     border-left: 2px solid var(--error-colour);
 }
@@ -689,7 +690,7 @@ footer a{
 
 .form-row-center {
     display: flex;
-    align-items: center
+    align-items: baseline;
 }
 
 .section-intro p {

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -691,6 +691,8 @@ footer a{
 .form-row-center {
     display: flex;
     align-items: baseline;
+    /* This moved the border further outside to allow for the children to fill that space with margin,
+    allowing the children to have space between them. See the bootstrap row/column technique. */
     margin: 0 calc(-1 * var(--spacing-02));
 }
 

--- a/webapp/app/templates/lotse/form_person_a.html
+++ b/webapp/app/templates/lotse/form_person_a.html
@@ -24,15 +24,15 @@
     <h3 class="mt-5 my-3">{{ _('form.lotse.person-header-addresse') }}</h3>
     <div class="form-row-center">
         {{ macros.render_field(form.person_a_street) }}
-        {{ macros.render_field(form.person_a_street_number, 2, field_div_classes="px-2") }}
+        {{ macros.render_field(form.person_a_street_number, 2) }}
     </div>
     <div class="form-row-center">
         {{ macros.render_field(form.person_a_street_number_ext) }}
-        {{ macros.render_field(form.person_a_address_ext, field_div_classes="px-2") }}
+        {{ macros.render_field(form.person_a_address_ext) }}
     </div>
     <div class="form-row-center">
         {{ macros.render_field(form.person_a_plz) }}
-        {{ macros.render_field(form.person_a_town, 6, field_div_classes="pl-2") }}
+        {{ macros.render_field(form.person_a_town, 6) }}
     </div>
 
     <h3 class="mt-5 my-3">{{ _('form.lotse.person-header-religion') }}</h3>

--- a/webapp/app/templates/lotse/form_person_a.html
+++ b/webapp/app/templates/lotse/form_person_a.html
@@ -25,10 +25,10 @@
     <div class="form-row-center">
         {{ macros.render_field(form.person_a_street) }}
         {{ macros.render_field(form.person_a_street_number, 2, field_div_classes="px-2") }}
-        {{ macros.render_field(form.person_a_street_number_ext, 4) }}
     </div>
     <div class="form-row-center">
-        {{ macros.render_field(form.person_a_address_ext) }}
+        {{ macros.render_field(form.person_a_street_number_ext) }}
+        {{ macros.render_field(form.person_a_address_ext, field_div_classes="px-2") }}
     </div>
     <div class="form-row-center">
         {{ macros.render_field(form.person_a_plz) }}

--- a/webapp/app/templates/lotse/form_person_b.html
+++ b/webapp/app/templates/lotse/form_person_b.html
@@ -24,15 +24,15 @@
   <div id="form_address_fields">
     <div class="form-row-center">
       {{ macros.render_field(form.person_b_street) }}
-      {{ macros.render_field(form.person_b_street_number, 2) }}
-      {{ macros.render_field(form.person_b_street_number_ext, 4) }}
+      {{ macros.render_field(form.person_b_street_number, 2, field_div_classes="px-2") }}
     </div>
     <div class="form-row-center">
-      {{ macros.render_field(form.person_b_address_ext) }}
+      {{ macros.render_field(form.person_b_street_number_ext) }}
+      {{ macros.render_field(form.person_b_address_ext, field_div_classes="px-2") }}
     </div>
     <div class="form-row-center">
       {{ macros.render_field(form.person_b_plz) }}
-      {{ macros.render_field(form.person_b_town) }}
+      {{ macros.render_field(form.person_b_town, field_div_classes="px-2") }}
     </div>
   </div>
 

--- a/webapp/app/templates/lotse/form_person_b.html
+++ b/webapp/app/templates/lotse/form_person_b.html
@@ -24,15 +24,15 @@
   <div id="form_address_fields">
     <div class="form-row-center">
       {{ macros.render_field(form.person_b_street) }}
-      {{ macros.render_field(form.person_b_street_number, 2, field_div_classes="px-2") }}
+      {{ macros.render_field(form.person_b_street_number, 2) }}
     </div>
     <div class="form-row-center">
       {{ macros.render_field(form.person_b_street_number_ext) }}
-      {{ macros.render_field(form.person_b_address_ext, field_div_classes="px-2") }}
+      {{ macros.render_field(form.person_b_address_ext) }}
     </div>
     <div class="form-row-center">
       {{ macros.render_field(form.person_b_plz) }}
-      {{ macros.render_field(form.person_b_town, field_div_classes="px-2") }}
+      {{ macros.render_field(form.person_b_town) }}
     </div>
   </div>
 


### PR DESCRIPTION
# Short Description
- Before, items "jumped" because the fields were centered. Now we're using baseline - crazy world!
- Also, Nadine asked me to put the number extension into the next line.

# Changes
- Use baseline align instead of center
- Moved number ext into one line with address ext
- Added padding when more items are in one line (this was pretty severe in person_b before^^)

# Feedback
- Maybe just have a look at it. I personally can't think of a place this code could break?