### PR TITLE
Add exception for ElsterRequestIdUnkownError to cron

### DIFF
--- a/webapp/app/cli.py
+++ b/webapp/app/cli.py
@@ -5,7 +5,7 @@ from flask.cli import AppGroup
 from sqlalchemy.exc import IntegrityError
 
 from app.elster_client.elster_errors import ElsterProcessNotSuccessful, \
-    ElsterRequestAlreadyRevoked
+    ElsterRequestAlreadyRevoked, ElsterRequestIdUnkownError
 
 
 def register_commands(app):
@@ -123,7 +123,7 @@ def _revoke_permission_and_delete_users(users_to_delete, success_message):
             elster_client.send_unlock_code_revocation_with_elster(form_data, 'CRONJOB-IP')
             db.session.delete(user_to_delete)
             app.logger.info(success_message)
-        except ElsterRequestAlreadyRevoked as e:
+        except (ElsterRequestAlreadyRevoked, ElsterRequestIdUnkownError) as e:
             app.logger.warn(str(e))
             db.session.delete(user_to_delete)
             app.logger.info(success_message)


### PR DESCRIPTION
# Short Description
We noticed that we do not catch errors related to unknown elster request ids in the cron job. However, we also want to delete users, if elster does not know about the stored request id anymore.

# Changes
- Add additional exception for ElsterRequestIdUnkownError in `_revoke_permission_and_delete_users`

# Feedback
- Is that what you imagined or do you see any problem?