### PR TITLE
Fix FAQ click area

### DIFF
--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -136,52 +136,55 @@
     padding-bottom: .75rem;
 }
 
-.accordion .card-header{
+.accordion button.card-header{
     border: 0;
     background: inherit;
     padding: .75rem 0;
 }
 
-.accordion .card-header h5{
-    font-size: var(--text-medium);
-    font-weight: var( --font-bold);
-}
-
-.accordion .card-header button:focus{
-    color: var(--text-colour);
-
-    background: var(--focus-colour);
-
+.accordion button.card-header:focus, .accordion button.card-header:active{
     outline:none;
     box-shadow: none;
     border: 0;
+}
+
+.accordion button.card-header h5{
+    font-size: var(--text-medium);
+    font-weight: var( --font-bold);
+
+    display: inline;
+}
+
+.accordion button.card-header:focus h5 {
+    color: var(--text-colour);
+    background: var(--focus-colour);
     border-bottom: 4px solid var(--focus-border-colour);
 }
 
-.accordion .card-header button{
+.accordion button.card-header {
     text-align: left;
     color: var(--text-colour);
     background: inherit;
     border: 0;
 }
 
-.accordion .card-header button:hover, .accordion .card-header button:active{
+.accordion button.card-header:hover, .accordion button.card-header:active{
     color: var(--link-hover-color);
 }
 
-.accordion .card-header .control-show-more{
+.accordion button.card-header .control-show-more{
     display: none;
 }
 
-.accordion .card-header .control-show-less{
+.accordion button.card-header .control-show-less{
     display: block;
 }
 
-.accordion .card-header .collapsed .control-show-more{
+.accordion button.card-header.collapsed .control-show-more{
     display: block;
 }
 
-.accordion .card-header .collapsed .control-show-less{
+.accordion button.card-header.collapsed .control-show-less{
     display: none;
 }
 

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -136,55 +136,55 @@
     padding-bottom: .75rem;
 }
 
-.accordion button.card-header{
+.accordion .card-header{
     border: 0;
     background: inherit;
     padding: .75rem 0;
 }
 
-.accordion button.card-header:focus, .accordion button.card-header:active{
+.accordion .card-header:focus, .accordion .card-header:active{
     outline:none;
     box-shadow: none;
     border: 0;
 }
 
-.accordion button.card-header h5{
+.accordion .card-header h5{
     font-size: var(--text-medium);
     font-weight: var( --font-bold);
 
     display: inline;
 }
 
-.accordion button.card-header:focus h5 {
+.accordion .card-header:focus h5 {
     color: var(--text-colour);
     background: var(--focus-colour);
     border-bottom: 4px solid var(--focus-border-colour);
 }
 
-.accordion button.card-header {
+.accordion .card-header {
     text-align: left;
     color: var(--text-colour);
     background: inherit;
     border: 0;
 }
 
-.accordion button.card-header:hover, .accordion button.card-header:active{
+.accordion .card-header:hover, .accordion .card-header:active{
     color: var(--link-hover-color);
 }
 
-.accordion button.card-header .control-show-more{
+.accordion .card-header .control-show-more{
     display: none;
 }
 
-.accordion button.card-header .control-show-less{
+.accordion .card-header .control-show-less{
     display: block;
 }
 
-.accordion button.card-header.collapsed .control-show-more{
+.accordion .card-header.collapsed .control-show-more{
     display: block;
 }
 
-.accordion button.card-header.collapsed .control-show-less{
+.accordion .card-header.collapsed .control-show-less{
     display: none;
 }
 

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -104,11 +104,10 @@
             {% for id, card in accordion.entries.items() -%}
                 {% set card_id = 'card-' + id -%}
                 <div class="card mt-2">
-                    <button class="card-header d-sm-flex justify-content-between align-items-center btn-accordion"
+                    <button class="card-header d-sm-flex justify-content-between align-items-center btn-accordion row collapsed w-100"
                          id="heading-{{ card_id }}" data-toggle="collapse"
                          data-target="#{{ card_id }}" aria-expanded="false"
                          aria-controls="collapseOne">
-                        <div class="row collapsed w-100">
                             <div class="col">
                                 <h5 class="mb-0">{{ card['heading'] }}</h5>
                             </div>

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -108,16 +108,15 @@
                          id="heading-{{ card_id }}" data-toggle="collapse"
                          data-target="#{{ card_id }}" aria-expanded="false"
                          aria-controls="collapseOne">
-                            <div class="col">
-                                <h5 class="mb-0">{{ card['heading'] }}</h5>
-                            </div>
-                            <div class="col-1 control-show-more">
-                                <img src="{{ url_for('static', filename='icons/plus.svg') }}"/>
-                            </div>
-                            <div class="col-1 control-show-less">
-                                <img src="{{ url_for('static', filename='icons/minus.svg') }}"/>
-                            </div>
-                        </div>
+                         <div class="col">
+                            <h5 class="mb-0">{{ card['heading'] }}</h5>
+                         </div>
+                         <div class="col-1 control-show-more">
+                             <img src="{{ url_for('static', filename='icons/plus.svg') }}"/>
+                         </div>
+                         <div class="col-1 control-show-less">
+                            <img src="{{ url_for('static', filename='icons/minus.svg') }}"/>
+                         </div>
                     </button>
                     <div id="{{ card_id }}" class="collapse" aria-labelledby="heading-{{ card_id }}"
                         data-parent="#{{accordion.id}}">

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -104,15 +104,13 @@
             {% for id, card in accordion.entries.items() -%}
                 {% set card_id = 'card-' + id -%}
                 <div class="card mt-2">
-                    <div class="card-header d-sm-flex justify-content-between align-items-center cursor-pointer"
-                         id="heading-{{ card_id }}">
-                        <div class="row collapsed w-100" data-toggle="collapse"
-                                    data-target="#{{ card_id }}"
-                                    aria-expanded="false" aria-controls="collapseOne">
+                    <button class="card-header d-sm-flex justify-content-between align-items-center btn-accordion"
+                         id="heading-{{ card_id }}" data-toggle="collapse"
+                         data-target="#{{ card_id }}" aria-expanded="false"
+                         aria-controls="collapseOne">
+                        <div class="row collapsed w-100">
                             <div class="col">
-                                <button class="btn-accordion" >
-                                    <h5 class="mb-0">{{ card['heading'] }}</h5>
-                                </button>
+                                <h5 class="mb-0">{{ card['heading'] }}</h5>
                             </div>
                             <div class="col-1 control-show-more">
                                 <img src="{{ url_for('static', filename='icons/plus.svg') }}"/>
@@ -121,8 +119,7 @@
                                 <img src="{{ url_for('static', filename='icons/minus.svg') }}"/>
                             </div>
                         </div>
-
-                    </div>
+                    </button>
                     <div id="{{ card_id }}" class="collapse" aria-labelledby="heading-{{ card_id }}"
                         data-parent="#{{accordion.id}}">
                         <div class="card-body-less-padding">


### PR DESCRIPTION
# Short Description
This is very nitty-gritty stuff. Having said that, currently, on the FAQ a pointer is shown in an area, even though, nothing happens when clicking (see image). I solved this by expanding the button and therefore the actually clickable area to the entire available space.

![image](https://user-images.githubusercontent.com/5238799/124399001-0acc1580-dd19-11eb-9a5a-11db566b4189.png)

# Changes
- it's fixed now
