### PR TITLE
Use fieldset for radio fields

### DIFF
--- a/webapp/app/forms/steps/lotse/steuerminderungen_steps.py
+++ b/webapp/app/forms/steps/lotse/steuerminderungen_steps.py
@@ -19,6 +19,7 @@ class StepSteuerminderungYesNo(FormStep):
 
     class Form(SteuerlotseBaseForm):
         steuerminderung = RadioField(
+            # Field overrides the label with a default value if we don't explicitly set it to an empty string
             label='',
             render_kw={'data_label': _l('form.lotse.field_steuerminderung.data_label'),
                        'hide_label': True},

--- a/webapp/app/forms/steps/lotse/steuerminderungen_steps.py
+++ b/webapp/app/forms/steps/lotse/steuerminderungen_steps.py
@@ -19,7 +19,7 @@ class StepSteuerminderungYesNo(FormStep):
 
     class Form(SteuerlotseBaseForm):
         steuerminderung = RadioField(
-            label=_l('form.lotse.field_steuerminderung'),
+            label='',
             render_kw={'data_label': _l('form.lotse.field_steuerminderung.data_label'),
                        'hide_label': True},
             choices=[

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -33,7 +33,7 @@ html,body{
 }
 
 body {
-    background: var(--body-colour);
+    background: var(--body-color);
     font-size: var(--text-medium);
 }
 
@@ -65,47 +65,47 @@ a:visited{
 /* INPUTS */
 
 input.form-control{
-    border: 2px solid var(--border-colour);
+    border: 2px solid var(--border-color);
     border-radius: 0;
     min-height: 55px;
 }
 
 input.form-control:hover{
-    border: 2px solid var(--hover-border-colour);
+    border: 2px solid var(--hover-border-color);
 }
 
 input.form-control:focus{
-    border: 2px solid var(--border-colour);
-    box-shadow: 0 0 0 2px var(--focus-colour);
+    border: 2px solid var(--border-color);
+    box-shadow: 0 0 0 2px var(--focus-color);
 }
 
 input.form-control:active{
-    border: 2px solid var(--border-colour);
-    box-shadow: 0 0 0 2px var(--active-outline-colour);
+    border: 2px solid var(--border-color);
+    box-shadow: 0 0 0 2px var(--active-outline-color);
 }
 
 input.form-control.field-error-found{
-    border: 2px solid var(--error-colour);
+    border: 2px solid var(--error-color);
 }
 
 .steuerlotse-select{
-    border: 2px solid var(--border-colour);
+    border: 2px solid var(--border-color);
     border-radius: 0;
     background: #fff url("/static/icons/select_icon.svg") no-repeat right .75rem center;
     min-height: 55px;
 }
 
 .input-group input, .input-group input:hover, .input-group input:focus, .input-group input:active{
-    border: 2px solid var(--border-colour);
+    border: 2px solid var(--border-color);
     box-shadow: none;
 }
 
 .input-group.euro-field:focus-within{
-    box-shadow: 0 0 0 2px var(--focus-colour);
+    box-shadow: 0 0 0 2px var(--focus-color);
 }
 
 .input-group.euro-field:active{
-    box-shadow: 0 0 0 2px var(--active-outline-colour);
+    box-shadow: 0 0 0 2px var(--active-outline-color);
 }
 
 .euro-field-appendix{
@@ -115,8 +115,8 @@ input.form-control.field-error-found{
     font-weight: var( --font-bold);
     color: var(--text-color);
 
-    background-color: var(--bg-highlight-colour);
-    border: 2px solid var(--border-colour);
+    background-color: var(--bg-highlight-color);
+    border: 2px solid var(--border-color);
     border-radius: 0;
 }
 
@@ -124,7 +124,7 @@ input.form-control.field-error-found{
 .invalid-feedback{
     font-size: var(--text-sm);
     font-weight: var( --font-bold);
-    color: var(--error-colour);
+    color: var(--error-color);
 }
 img.invalid-feedback{
     display: inline;
@@ -141,7 +141,7 @@ img.invalid-feedback{
 .error-found-line{
     margin-left: var(--spacing-02);
     padding-left: var(--spacing-04) !important;
-    border-left: 2px solid var(--error-colour);
+    border-left: 2px solid var(--error-color);
 }
 
 /* LISTS */
@@ -169,7 +169,7 @@ ol li::before {
   font-weight: var(--font-bold);
   color: var(--text-color);
 
-  background: var(--icon-default-colour);
+  background: var(--icon-default-color);
 
   border-radius: 50%;
 
@@ -287,7 +287,7 @@ ol li::before {
 .interview__home{
     margin: var( --spacing-11) auto var( --spacing-05) auto;
     background-color: white;
-    border: 1px solid var(--bg-highlight-colour);
+    border: 1px solid var(--bg-highlight-color);
 }
 
 .interview__home__img{
@@ -326,7 +326,7 @@ ol li::before {
 
     .landing__section{
         margin-top: var( --spacing-07);
-        background-color: var(--bg-highlight-colour);
+        background-color: var(--bg-highlight-color);
     }
 
     .landing__grid{
@@ -557,7 +557,7 @@ span.nav-link.inactive, span.inactive {
     margin-right: 0;
     min-height: 100vh;
 
-    background: var(--body-colour);
+    background: var(--body-color);
 }
 
 @media (max-width: 1024px) {
@@ -605,7 +605,7 @@ span.nav-link.inactive, span.inactive {
 /* Footer */
 
 footer {
-    border-top: 1px solid var(--icon-default-colour);
+    border-top: 1px solid var(--icon-default-color);
     min-width: 100%;
     margin-top: var(--spacing-10);
 }
@@ -619,7 +619,7 @@ footer {
 footer li a {
     color: var(--text-color);
     display: block;
-    text-decoration-color: var(--icon-default-colour);
+    text-decoration-color: var(--icon-default-color);
     transition: all .3s ease;
 }
 
@@ -637,7 +637,7 @@ footer li a:hover {
 .footer-footer {
     display: flex;
     font-size: var(--text-s);
-    background-color: var(--bg-highlight-colour);
+    background-color: var(--bg-highlight-color);
 }
 
 footer a{
@@ -647,7 +647,7 @@ footer a{
 .footer-footer a{
     padding: var(--spacing-03);
     display: block;
-    text-decoration-color: var(--icon-default-colour);
+    text-decoration-color: var(--icon-default-color);
     color: var(--text-color);
     transition: all .3s ease;
 }
@@ -743,11 +743,11 @@ ul.reasons-success li.and {
 }
 
 .card-body {
-    border: 1px solid var(--border-colour);
+    border: 1px solid var(--border-color);
 }
 
 .unstyled-card-header {
-    background-color: var(--body-colour);
+    background-color: var(--body-color);
     border: none;
     padding-left: 0;
     padding-right: 0;
@@ -776,12 +776,12 @@ img.icon {
 }
 
 .alert-success {
-    background-color: var(--success-colour);
+    background-color: var(--success-color);
     color: white;
 }
 
 .alert-warning {
-    background-color: var(--error-colour);
+    background-color: var(--error-color);
     color: white;
 }
 

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -473,7 +473,7 @@ input[type="radio"] {
     opacity: 0;
 }
 
-input[type="radio"] + *::before {
+input[type="radio"] + label::before {
     content: "";
     display: inline-block;
     vertical-align: bottom;
@@ -485,20 +485,25 @@ input[type="radio"] + *::before {
     background: white;
 }
 
-input[type="radio"]:checked + *::before {
+input[type="radio"]:checked + label::before {
     background: radial-gradient(var(--link-active-color) 40%, var(--bg-white) 40%, transparent 0%, transparent);
     border-color: var(--link-active-color);
 }
 
-input[type="radio"]:checked + *:hover::before{
+input[type="radio"]:checked + label:hover::before{
     background: radial-gradient(var(--hover-border-colour) 40%, var(--bg-white) 40%, transparent 0%, transparent);
     border-color: var(--hover-border-colour);
 }
 
-input[type="radio"]:checked + *:focus::before{
-    background: var(--focus-color);
+input[type="radio"]:not(:checked):focus + label::before{
+    background: var(--focus-colour);
     border-color: black;
-    box-shadow: 0 0 0 2px var(--focus-color);
+    box-shadow: 0 0 0 2px var(--focus-colour);
+}
+
+input[type="radio"]:checked:focus + label::before{
+    border-color: black;
+    box-shadow: 0 0 0 2px var(--focus-colour);
 }
 
 .field-label{

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -35,14 +35,14 @@
 
 
 .btn-primary:focus, a.btn-primary:focus{
-    color: var(--focus-text-colour);
+    color: var(--focus-text-color);
 
-    background: var(--focus-colour);
+    background: var(--focus-color);
 
     outline: none;
     box-shadow: none;
     border: 0;
-    border-bottom: 4px solid var(--focus-border-colour);
+    border-bottom: 4px solid var(--focus-border-color);
 }
 
 .btn-outline-primary, a.btn-outline-primary{
@@ -59,7 +59,7 @@
 
     border: 0;
     border-radius: 0;
-    border: 1px solid var(--border-colour);
+    border: 1px solid var(--border-color);
 }
 
 .btn-outline-primary:not(:disabled):not(.disabled):active, a.btn-outline-primary:not(:disabled):not(.disabled):active{
@@ -75,11 +75,11 @@
 }
 
 .btn-outline-primary:focus, a.btn-outline-primary:focus{
-    color: var(--focus-colour);
+    color: var(--focus-color);
 
     outline:none;
     box-shadow: none;
-    border: 1px solid var(--focus-border-colour);
+    border: 1px solid var(--focus-border-color);
 }
 
 
@@ -96,7 +96,7 @@
 }
 
 .btn-help:focus  {
-    background: var(--focus-colour);
+    background: var(--focus-color);
     color: var(--text-color) !important;
     text-decoration: none;
 }
@@ -121,7 +121,7 @@
 .remove-button:focus{
     text-decoration: none;
     color: var(--text-color) !important;
-    background: var(--focus-colour);
+    background: var(--focus-color);
     box-shadow: none;
     outline: 0;
 }
@@ -148,19 +148,19 @@
 }
 
 .accordion .card-header button:focus{
-    color: var(--text-colour);
+    color: var(--text-color);
 
-    background: var(--focus-colour);
+    background: var(--focus-color);
 
     outline:none;
     box-shadow: none;
     border: 0;
-    border-bottom: 4px solid var(--focus-border-colour);
+    border-bottom: 4px solid var(--focus-border-color);
 }
 
 .accordion .card-header button{
     text-align: left;
-    color: var(--text-colour);
+    color: var(--text-color);
     background: inherit;
     border: 0;
 }
@@ -215,7 +215,7 @@
 .details-card .card-header .collapsed span {
     color: var(--link-color);
     text-decoration: underline;
-    text-decoration-color: var(--icon-default-colour);
+    text-decoration-color: var(--icon-default-color);
 }
 
 .details-card .card-header .collapsed span:hover {
@@ -224,11 +224,11 @@
 }
 
 .details-card .card-header button:focus span {
-    color: var(--focus-text-colour);
+    color: var(--focus-text-color);
     text-decoration: underline;
-    text-decoration-color: var(--focus-text-colour);
+    text-decoration-color: var(--focus-text-color);
 
-    background: var(--focus-colour);
+    background: var(--focus-color);
 
     outline:none;
     box-shadow: none;
@@ -269,7 +269,7 @@
     width: 2px;
     height: 100%;
     margin: 0 auto;
-    background-color: var(--border-colour);
+    background-color: var(--border-color);
 }
 
 .details-card .card-header button:hover, .accordion .card-header button:active {
@@ -322,7 +322,7 @@
     text-align: center;
     color: var(--text-color);
 
-    background: var(--icon-default-colour) url("/static/icons/arrow_back.svg") no-repeat center/var(--size);
+    background: var(--icon-default-color) url("/static/icons/arrow_back.svg") no-repeat center/var(--size);
 
     border-radius: 50%;
 }
@@ -376,7 +376,7 @@ a.back-link:focus a.back-link:active{
     font-weight: var(--font-bold);
     color: var(--text-color);
 
-    background: var(--icon-default-colour) url("/static/icons/download_icon.svg") no-repeat center/var(--size);
+    background: var(--icon-default-color) url("/static/icons/download_icon.svg") no-repeat center/var(--size);
 
     border-radius: 50%;
 
@@ -398,7 +398,7 @@ a.back-link:focus a.back-link:active{
 }
 
 .consent-box {
-    background-color: var(--bg-highlight-colour);
+    background-color: var(--bg-highlight-color);
     padding: var(--spacing-04);
 }
 
@@ -409,8 +409,8 @@ a.back-link:focus a.back-link:active{
 }
 
 .checkbox input:focus + label {
-    box-shadow: 0 0 0 3px var(--focus-colour);
-    background-color: var(--focus-colour);
+    box-shadow: 0 0 0 3px var(--focus-color);
+    background-color: var(--focus-color);
 }
 
 .checkbox input:checked + label {
@@ -439,12 +439,12 @@ a.back-link:focus a.back-link:active{
     font-size: var(--text-s);
     box-shadow: none;
     border-radius: 0;
-    border: 1px solid var(--border-colour) !important;
+    border: 1px solid var(--border-color) !important;
 }
 
 .switch-yes.focus, .switch-no.focus {
-    color: var(--focus-text-colour) !important;
-    background: var(--focus-colour) !important;
+    color: var(--focus-text-color) !important;
+    background: var(--focus-color) !important;
 
     box-shadow: none;
     border: 1px solid var(--text-color) !important;
@@ -459,7 +459,7 @@ a.back-link:focus a.back-link:active{
 }
 
 .switch-yes.active.focus, .switch-no.active.focus {
-    box-shadow: 0 0 0 3px var(--focus-colour) !important;
+    box-shadow: 0 0 0 3px var(--focus-color) !important;
 }
 
 .switch-yes.active:hover, .switch-no.active:hover {
@@ -491,19 +491,19 @@ input[type="radio"]:checked + label::before {
 }
 
 input[type="radio"]:checked + label:hover::before{
-    background: radial-gradient(var(--hover-border-colour) 40%, var(--bg-white) 40%, transparent 0%, transparent);
-    border-color: var(--hover-border-colour);
+    background: radial-gradient(var(--hover-border-color) 40%, var(--bg-white) 40%, transparent 0%, transparent);
+    border-color: var(--hover-border-color);
 }
 
 input[type="radio"]:not(:checked):focus + label::before{
-    background: var(--focus-colour);
+    background: var(--focus-color);
     border-color: black;
-    box-shadow: 0 0 0 2px var(--focus-colour);
+    box-shadow: 0 0 0 2px var(--focus-color);
 }
 
 input[type="radio"]:checked:focus + label::before{
     border-color: black;
-    box-shadow: 0 0 0 2px var(--focus-colour);
+    box-shadow: 0 0 0 2px var(--focus-color);
 }
 
 .field-label{
@@ -514,14 +514,14 @@ input[type="radio"]:checked:focus + label::before{
 /* ALERTS */
 .alert-success{
     color: var(--inverse-text-color);
-    background-color: var(--success-colour);
+    background-color: var(--success-color);
     border: 0;
     border-radius: 0;
 }
 
 .alert-danger{
     color: var(--inverse-text-color);
-        background-color: var(--error-colour);
+        background-color: var(--error-color);
         border: 0;
     border-radius: 0;
 }

--- a/webapp/app/static/css/variables.css
+++ b/webapp/app/static/css/variables.css
@@ -4,9 +4,9 @@
   --secondary-text-color: #5e5e5e;
   --inverse-text-color: #FFFFFF;
 
-  --border-colour: #bababa;
-  --hover-border-colour: #003b52;
-  --active-outline-colour: #CDC0B1;
+  --border-color: #bababa;
+  --hover-border-color: #003b52;
+  --active-outline-color: #CDC0B1;
 
   --link-color: #005576;
   --link-hover-color: #003b52;
@@ -14,19 +14,19 @@
   --link-active-color: #0b0c0c;
   --link-underline-color: rgba(10, 10, 25, 0.2); /* original #0A0A19, 20%; */
 
-  --icon-default-colour: #E3D9CE;
-  --icon-hover-colour: #CDC0B1;
+  --icon-default-color: #E3D9CE;
+  --icon-hover-color: #CDC0B1;
 
-  --focus-colour: #FFC979;
-  --focus-text-colour: #0B0C0C;
-  --focus-border-colour: #0B0C0C;
+  --focus-color: #FFC979;
+  --focus-text-color: #0B0C0C;
+  --focus-border-color: #0B0C0C;
 
-  --body-colour: #FDF8F4;
-  --bg-highlight-colour: #EEE8E1;
+  --body-color: #FDF8F4;
+  --bg-highlight-color: #EEE8E1;
   --bg-white: #FFFFFF;
 
-  --success-colour: #005C45;
-  --error-colour: #C0003C;
+  --success-color: #005C45;
+  --error-color: #C0003C;
   --error-bg-color: #F9E5EB;
 
   /* Font Size */

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -52,12 +52,15 @@
 {% endmacro %}
 
 {% macro radio_field(field) -%}
+    <fieldset>
+    {{ field_label(field) }}
     {% for subfield in field %}
-        <div class="form-row-center">
+        <div>
             {{ subfield(class="") }}
             {{ field_label(subfield, class="col-sm-10 col-form-label") }}
         </div>
     {% endfor %}
+    </fieldset>
 {%- endmacro %}
 
 {% macro field_label(field, class="") %}
@@ -65,10 +68,18 @@
     {%- set help = field.render_kw['help'] -%}
     {%- set detail = field.render_kw['detail'] -%}
 
-    <label for="{{ label.field_id }}"
-           class="field-label  {{ class }}">{{ label.text }}
-        {% if help %}{{ help_button(label.field_id) }}{% endif %}
-    </label>
+    {% if field.type == 'RadioField' %}
+        {% if label.text %} {# Only show legend if there is a legend text to show #}
+            <legend class="field-label {{ class }}">{{ label.text }}
+                {% if help %}{{ help_button(label.field_id) }}{% endif %}
+            </legend>
+        {% endif %}
+    {% else %}
+        <label for="{{ label.field_id }}"
+               class="field-label {{ class }}">{{ label.text }}
+            {% if help %}{{ help_button(label.field_id) }}{% endif %}
+        </label>
+    {% endif %}
     {%- if help %}{{ help_dialog(label.field_id, label.text, help) }}{% endif %}
     {% if field.render_kw and "example_input" in field.render_kw %}
         <div class="example-input">

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -53,13 +53,14 @@
 
 {% macro radio_field(field) -%}
     <fieldset>
-    {{ field_label(field) }}
-    {% for subfield in field %}
-        <div>
-            {{ subfield(class="") }}
-            {{ field_label(subfield, class="col-sm-10 col-form-label") }}
-        </div>
-    {% endfor %}
+        {{ field_label(field) }}
+        {% for subfield in field %}
+            <div>
+                {{ subfield(class="") }}
+                {{ field_label(subfield, class="col-sm-10 col-form-label") }}
+            </div>
+        {% endfor %}
+        {{ field_errors(field) }}
     </fieldset>
 {%- endmacro %}
 

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -52,7 +52,7 @@
 {% macro render_field(field, cols=6, class="", field_div_classes="", d_block=False, as_card=False, hide_label=False) %}
     {% if field.type == 'ConfirmationField' %}
         {{ _render_field(field, 12, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True) }}
-    {% elif field.type == 'BooleanField' %}
+    {% elif field.type in ('BooleanField', 'RadioField') %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True) }}
     {% else %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=hide_label) }}

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -49,17 +49,19 @@
     {{ components.field_errors(field) }}
 {%- endmacro %}
 
-{% macro render_field(field, cols=6, class="", field_div_classes="", d_block=False, as_card=False, hide_label=False) %}
+{% macro render_field(field, cols=6, class="", field_div_classes="", d_block=False, as_card=False, hide_label=False, hide_errors=False) %}
     {% if field.type == 'ConfirmationField' %}
-        {{ _render_field(field, 12, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True) }}
-    {% elif field.type in ('BooleanField', 'RadioField') %}
-        {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True) }}
+        {{ _render_field(field, 12, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors) }}
+    {% elif field.type == 'BooleanField' %}
+        {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors) }}
+    {% elif field.type == 'RadioField' %}
+        {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=True) }}
     {% else %}
-        {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=hide_label) }}
+        {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=hide_label, hide_errors=hide_errors) }}
     {% endif %}
 {% endmacro %}
 
-{% macro _render_field(field, cols, class="", field_div_classes="", d_block=False, as_card=False, hide_label=False) %}
+{% macro _render_field(field, cols, class="", field_div_classes="", d_block=False, as_card=False, hide_label=False, hide_errors=False) %}
     {% if field.errors %}
         {% set field_div_classes = field_div_classes + " error-found-line" %}
     {% endif %}
@@ -90,7 +92,7 @@
                 {% endif %}
             {% endif %}
         {% if d_block %}</div>{% endif %}
-        {{ field_errors(field) }}
+        {% if not hide_errors %}{{ field_errors(field) }}{% endif %}
     </div>
 {% endmacro %}
 


### PR DESCRIPTION
# Short Description
- This is part of the accessibility ticket for error messages: https://steuerlotse.atlassian.net/browse/STL-1066
- `fieldset` and the related `legend` should be used for all radio buttons (not just for yes-no-fields that we did before)
- Additionally I fixed the focus state of radio buttons

# Changes
- Make radio field css more explicit by using `label` instead of `*`
- Fix focus state of radio buttons by setting focus on the input, not the label
- Add possibility to hide errors on the field -> needed to show them within the fieldset instead (as recommended [here](https://design-system.service.gov.uk/components/radios/#:~:text=screen%20multiple%20times.-,Error,-messages))
- Add special case for radio fields to hide label and errors and instead use legend and errors within the fieldset
- Had to remove the label for steuerminderung_yes_no as it wasn't used (and empty anyways) to not show it

# Feedback
- Do you have another idea for showing the error message within the `fieldset` element? Or another idea on how to replace the field's `label` by a `legend`?
