### PR TITLE
Fix summary error message flashing test

### DIFF
--- a/webapp/tests/forms/flows/test_lotse_flow.py
+++ b/webapp/tests/forms/flows/test_lotse_flow.py
@@ -1057,6 +1057,7 @@ class TestLotseHandleSpecificsForStep(unittest.TestCase):
         missing_fields_error = MandatoryFieldMissingValidationError(missing_fields)
 
         with patch('app.forms.flows.lotse_flow.flash') as mock_flash, \
+            patch('app.model.form_data.ngettext', MagicMock(side_effect=lambda text_id, _, **kwargs: text_id)), \
             patch('app.forms.flows.lotse_flow.LotseMultiStepFlow._get_overview_data'), \
             patch('app.forms.flows.lotse_flow.LotseMultiStepFlow._validate_mandatory_fields',
                   MagicMock(side_effect=missing_fields_error)):


### PR DESCRIPTION
# Short Description
- We test for the content of the message, which locally results in an error because we are compiling the babel identifiers to their actual strings. On GitHub it didn't occur because we do not run babel before running the tests. (My bad to not run the tests locally when I was implementing this)

# Changes
- Mock the used babel functions.

# Feedback
- Does that make sense to you?