### PR TITLE
Fix back-link alignment on Firefox

### DIFF
--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -313,7 +313,7 @@
 .back-link::before {
     --total-line-height: var(--lineheight-s);
     --size: var(--back-link-size);
-    content: "";
+    content: url("/static/icons/arrow_back.svg");
     margin: 3px;
     position: absolute;
 
@@ -324,8 +324,6 @@
 
     text-align: center;
     color: var(--text-color);
-
-    background: var(--icon-default-color) url("/static/icons/arrow_back.svg") no-repeat center/var(--size);
 
     border-radius: 50%;
 }


### PR DESCRIPTION
# Short Description
- In Firefox, the back-link was not aligned. Except when we tried to inspect it with the developer tools, then it was. Strangest behaviour ever and I could not find anything regarding this by googling. So I basically just tried a different approach to place an image next to a text suggested on [Stackoverflow](https://stackoverflow.com/a/18280604) - and that worked.

# Changes
- Place the image of the back-link's before element into the content instead of the background.

# Feedback
- I'm not sure that I didn't omit any information that was crucial for the component? As far as I can tell, it looks correct on Firefox, Chrome and Safari and works as expected. But maybe have another look?
