### PR TITLE
Avoid familienstand flashing

### DIFF
--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -823,3 +823,7 @@ img.icon {
 .cursor-pointer{
     cursor: pointer;
 }
+
+.hidden {
+    display: none;
+}

--- a/webapp/app/templates/lotse/form_familienstand.html
+++ b/webapp/app/templates/lotse/form_familienstand.html
@@ -6,28 +6,28 @@
     <div id="familienstand_field" class="mb-3">
         {{ macros.render_field(form.familienstand, 10) }}
     </div>
-    <div id="familienstand_date_field" class="form-row-center">
+    <div id="familienstand_date_field" class="form-row-center hidden">
         {{ macros.render_field(form.familienstand_date) }}
     </div>
-    <div id="familienstand_married_lived_separated_field">
+    <div id="familienstand_married_lived_separated_field" class="hidden">
         {{ macros.render_field(form.familienstand_married_lived_separated) }}
     </div>
-    <div id="familienstand_married_lived_separated_since_field">
+    <div id="familienstand_married_lived_separated_since_field" class="hidden">
         {{ macros.render_field(form.familienstand_married_lived_separated_since) }}
     </div>
-    <div id="familienstand_widowed_lived_separated_field">
+    <div id="familienstand_widowed_lived_separated_field" class="hidden">
         {{ macros.render_field(form.familienstand_widowed_lived_separated) }}
     </div>
-    <div id="familienstand_widowed_lived_separated_since_field">
+    <div id="familienstand_widowed_lived_separated_since_field" class="hidden">
         {{ macros.render_field(form.familienstand_widowed_lived_separated_since) }}
     </div>
-    <div id="familienstand_zusammenveranlagung_field">
+    <div id="familienstand_zusammenveranlagung_field" class="hidden">
         {{ macros.render_field(form.familienstand_zusammenveranlagung) }}
     </div>
-    <div id="familienstand_confirm_zusammenveranlagung_field">
+    <div id="familienstand_confirm_zusammenveranlagung_field" class="hidden">
         {{ macros.render_field(form.familienstand_confirm_zusammenveranlagung, 10, hide_label=True) }}
     </div>
-    <div id="familienstand_zusammenveranlagung_clause" class="mb-3 font-weight-bold">
+    <div id="familienstand_zusammenveranlagung_clause" class="mb-3 font-weight-bold hidden">
         {{ _('form.lotse.familienstand.zusamenveranlagung-clause') }}
     </div>
 

--- a/webapp/app/templates/lotse/form_person_b.html
+++ b/webapp/app/templates/lotse/form_person_b.html
@@ -21,7 +21,7 @@
   <h3 class="mt-5 my-3">{{ _('form.lotse.person-header-addresse') }}</h3>
   {{ macros.render_field(form.person_b_same_address, 10) }}
 
-  <div id="form_address_fields">
+  <div id="form_address_fields" class="hidden">
     <div class="form-row-center">
       {{ macros.render_field(form.person_b_street) }}
       {{ macros.render_field(form.person_b_street_number, 2) }}


### PR DESCRIPTION
# Short Description
- When loading the familienstand page, the hidden fields where flashed shortly. Now they're hidden by default.

# Changes
- Add `hidden` class - fun fact: there actually is the same class in styles.css and a class called `hide` with the same content of bootstrap. Those are not applied on the element though, apparently because they are overridden by other classes? (At least, I still saw the flashing) So I just rewrote the class. 
- Add `hidden` class to all conditionally shown familienstand fields
- Add `hidden` class to all conditionally shown person b address fields

# Feedback
- Can you think of another place where we conditionally show fields?
- Sooo, this might add a problem: When you have javascript disabled, now the fields are not shown. Meaning you can't send a valid POST, except you're single. In my head it's actually better than when you can see and fill all fields, but I wanted to run it by you, if you think this is a problem.