### PR TITLE
Remove duplicate id

### DIFF
--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -154,8 +154,7 @@
 {% macro details(title, paragraphs, list_items=None, details_id='') %}
     <div id="details-{{ details_id }}" class="details-card ml-0 pl-0">
         <div class="card">
-            <div class="card-header unstyled-card-header d-sm-flex justify-content-between align-items-center cursor-pointer mb-0"
-                 id="heading-card_id">
+            <div class="card-header unstyled-card-header d-sm-flex justify-content-between align-items-center cursor-pointer mb-0">
                 <div class="row collapsed" data-toggle="collapse"
                             data-target="#details-body-{{ details_id }}"
                             aria-expanded="false" aria-controls="collapseOne">

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -1883,7 +1883,7 @@ msgstr ""
 "Sie: Die Gesamtausgaben sind nicht in voller Höhe absetzbar. Nur der "
 "Betrag, der höher ist als Ihre zumutbare Belastung, wirkt sich "
 "steuermindernd aus. Die zumutbare Belastung hängt von der Höhe Ihres "
-"Einkommens ab und wird von Ihrem Finanzamt automatisch berechnet.</p>"
+"Einkommens ab und wird von Ihrem Finanzamt automatisch berechnet."
 
 #: app/forms/steps/lotse/steuerminderungen_steps.py:160
 msgid "form.lotse.step_haushaltsnahe.label"


### PR DESCRIPTION
# Short Description
- Duplicate IDs in the html are suboptimal, so we want to remove them.
- I tested every site in the eligibility, registration, activation and lotse flow for duplicate IDs with [this tool](https://validator.w3.org/) and only found this one.
- We also have quite some additional errors and warnings on the sites, so we should probably have a look at that at some point.

# Changes
- Remove duplicate ID
- Remove unnecessary `</p>`

# Feedback
- /