### PR TITLE
Remove button divs

### DIFF
--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -177,6 +177,8 @@
 .accordion .card-header:not(.collapsed) .control-show-more {
     /* We need to still show it to keep focus on the element */
     height: 1px;
+    width: 1px;
+    background-color: inherit;
     overflow: hidden;
     position: absolute;
 }
@@ -184,6 +186,8 @@
 .accordion .card-header.collapsed .control-show-less {
     /* We need to still show it to keep focus on the element */
     height: 1px;
+    width: 1px;
+    background-color: inherit;
     overflow: hidden;
     position: absolute;
 }
@@ -284,6 +288,7 @@
     /* We need to still show it to keep focus on the element */
     height: 1px;
     width: 1px;
+    background-color: inherit;
     padding: 0;
     overflow: hidden;
     position: absolute;
@@ -293,6 +298,7 @@
     /* We need to still show it to keep focus on the element */
     height: 1px;
     width: 1px;
+    background-color: inherit;
     padding: 0;
     overflow: hidden;
     position: absolute;

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -280,20 +280,22 @@
     outline: none;
 }
 
-.details-card .card-header .control-show-more{
-    display: none;
+.details-card .card-header:not(.collapsed) .control-show-more {
+    /* We need to still show it to keep focus on the element */
+    height: 1px;
+    width: 1px;
+    padding: 0;
+    overflow: hidden;
+    position: absolute;
 }
 
-.details-card .card-header .control-show-less{
-    display: block;
-}
-
-.details-card .card-header .collapsed .control-show-more{
-    display: block;
-}
-
-.details-card .card-header .collapsed .control-show-less{
-    display: none;
+.details-card .card-header.collapsed .control-show-less {
+    /* We need to still show it to keep focus on the element */
+    height: 1px;
+    width: 1px;
+    padding: 0;
+    overflow: hidden;
+    position: absolute;
 }
 
 

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -128,7 +128,7 @@
 
 
 /* ACCORDION */
-.accordion .card{
+.accordion .card {
     border: 0;
     border-bottom: 1px solid var(--link-underline-color);
     border-radius: 0;
@@ -136,56 +136,56 @@
     padding-bottom: .75rem;
 }
 
-.accordion .card-header{
-    border: 0;
-    background: inherit;
+.accordion .card-header {
     padding: .75rem 0;
-}
-
-.accordion .card-header:focus, .accordion .card-header:active{
-    outline:none;
-    box-shadow: none;
-    border: 0;
-}
-
-.accordion .card-header h5{
-    font-size: var(--text-medium);
-    font-weight: var( --font-bold);
-
-    display: inline;
-}
-
-.accordion .card-header:focus h5{
-    color: var(--text-color);
-    background: var(--focus-color);
-    border-bottom: 4px solid var(--focus-border-color);
-}
-
-.accordion .card-header{
     text-align: left;
     color: var(--text-color);
     background: inherit;
     border: 0;
 }
 
-.accordion .card-header:hover, .accordion .card-header:active{
+.accordion .card-header button {
+    border: 0;
+    background: inherit;
+}
+
+.accordion .card-header button:focus,
+.accordion .card-header button:active {
+    outline:none;
+    box-shadow: none;
+    border: 0;
+}
+
+.accordion .card-header button span {
+    font-size: var(--text-medium);
+    font-weight: var(--font-bold);
+
+    display: inline;
+}
+
+.accordion .card-header:focus-within button span {
+    color: var(--text-color);
+    background: var(--focus-color);
+    border-bottom: 4px solid var(--focus-border-color);
+}
+
+.accordion .card-header button:hover,
+.accordion .card-header button:active{
     color: var(--link-hover-color);
 }
 
-.accordion .card-header .control-show-more{
-    display: none;
+.accordion .card-header:not(.collapsed) .control-show-more {
+    /* We need to still show it to keep focus on the element */
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
 }
 
-.accordion .card-header .control-show-less{
-    display: block;
-}
-
-.accordion .card-header.collapsed .control-show-more{
-    display: block;
-}
-
-.accordion .card-header.collapsed .control-show-less{
-    display: none;
+.accordion .card-header.collapsed .control-show-less {
+    /* We need to still show it to keep focus on the element */
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
 }
 
 /* DETAILS */

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -156,7 +156,7 @@
         <div class="card">
             <div class="card-header unstyled-card-header d-sm-flex justify-content-between align-items-center cursor-pointer mb-0"
                  id="heading-card_id">
-                <div class="row collapsed" data-toggle="collapse"
+                <div class="collapsed" data-toggle="collapse"
                             data-target="#details-body-{{ details_id }}"
                             aria-expanded="false" aria-controls="collapseOne">
                     <button class="btn container" type="button">
@@ -174,7 +174,7 @@
             </div>
             <div id="details-body-{{ details_id }}" class="collapse" aria-labelledby="heading-{{ card_id }}"
                 data-parent="#details-{{ details_id }}">
-                <div class="card-body pt-0 pl-0">
+                <div class="card-body container pt-0">
                     <div class="row">
                         <div class="col-1 px-0">
                             <div class="block-quote-line"></div>

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -120,13 +120,13 @@
                          id="heading-{{ card_id }}" data-toggle="collapse"
                          data-target="#{{ card_id }}" aria-expanded="false"
                          aria-controls="collapseOne">
-                         <button class="col text-left">
+                         <button class="col text-left" type="button">
                             <span class="mb-0">{{ card['heading'] }}</span>
                          </button>
-                         <button class="col-1 control-show-more" tabindex="-1" aria-hidden="true">
+                         <button class="col-1 control-show-more" type="button" tabindex="-1" aria-hidden="true">
                              <img src="{{ url_for('static', filename='icons/plus.svg') }}"/>
                          </button>
-                         <button class="col-1 control-show-less" tabindex="-1" aria-hidden="true">
+                         <button class="col-1 control-show-less" type="button" tabindex="-1" aria-hidden="true">
                             <img src="{{ url_for('static', filename='icons/minus.svg') }}"/>
                          </button>
                     </div>
@@ -159,18 +159,16 @@
                 <div class="collapsed" data-toggle="collapse"
                             data-target="#details-body-{{ details_id }}"
                             aria-expanded="false" aria-controls="collapseOne">
-                    <button class="btn container" type="button">
+                    <div class="container">
                         <div class="row">
-                            <div class="details-icon col-1 control-show-more"></div>
-                            <div class="details-icon col-1 control-show-less"></div>
-                            <div class="col">
+                            <button class="btn details-icon col-1 control-show-more" type="button" tabindex="-1" aria-hidden="true"></button>
+                            <button class="btn details-icon col-1 control-show-less" type="button" tabindex="-1" aria-hidden="true"></button>
+                            <button class="btn col" type="button">
                                 <span class="mb-0">{{title}}</span>
-                            </div>
+                            </button>
                         </div>
-                    </button>
-
+                    </div>
                 </div>
-
             </div>
             <div id="details-body-{{ details_id }}" class="collapse" aria-labelledby="heading-{{ card_id }}"
                 data-parent="#details-{{ details_id }}">

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -116,20 +116,20 @@
             {% for id, card in accordion.entries.items() -%}
                 {% set card_id = 'card-' + id -%}
                 <div class="card mt-2">
-                    <button class="card-header d-sm-flex justify-content-between align-items-center btn-accordion row collapsed w-100"
+                    <div class="card-header d-sm-flex justify-content-between align-items-center row collapsed w-100"
                          id="heading-{{ card_id }}" data-toggle="collapse"
                          data-target="#{{ card_id }}" aria-expanded="false"
                          aria-controls="collapseOne">
-                         <div class="col">
-                            <h5 class="mb-0">{{ card['heading'] }}</h5>
-                         </div>
-                         <div class="col-1 control-show-more">
+                         <button class="col text-left">
+                            <span class="mb-0">{{ card['heading'] }}</span>
+                         </button>
+                         <button class="col-1 control-show-more" tabindex="-1" aria-hidden="true">
                              <img src="{{ url_for('static', filename='icons/plus.svg') }}"/>
-                         </div>
-                         <div class="col-1 control-show-less">
+                         </button>
+                         <button class="col-1 control-show-less" tabindex="-1" aria-hidden="true">
                             <img src="{{ url_for('static', filename='icons/minus.svg') }}"/>
-                         </div>
-                    </button>
+                         </button>
+                    </div>
                     <div id="{{ card_id }}" class="collapse" aria-labelledby="heading-{{ card_id }}"
                         data-parent="#{{accordion.id}}">
                         <div class="card-body-less-padding">


### PR DESCRIPTION
# Short Description
- It is, especially for accessibility reasons, not recommended to have divs within buttons.
- This removes the internal divs and instead uses multiple buttons.

# Changes
- Replace h5 with span
- Move button further into the component -> have multiple buttons: Text + icon
- Do not hide elements, instead make them very small (if we hide them, the focus goes to `body` when clicking the button, as the button that would have focus is removed)
- disable tabbing + screen reading of the icon buttons (the text-button should be enough)
- Align details component to not visually overflow on the left side in the form (row had negative margin)

# Feedback
- Do you think the solution with multiple buttons makes sense?
- Do you know any other place where we are using divs in buttons? I scanned all templates for warnings (which we got for details and accordion) but couldn't find any more)

Also: TIL about `focus-within` - so cool!