### PR TITLE
Use headings semantically

### DIFF
--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -108,9 +108,9 @@
 {% endmacro %}
 
 
-{% macro accordion(accordion) %}
+{% macro accordion(accordion, heading_level=3) %}
     <div id="{{ accordion.id }}" class="accordion mt-5 pb-5">
-        <h3 class="mt-5">{{ accordion.heading }}</h3>
+        <h{{ heading_level }} class="mt-5">{{ accordion.heading }}</h{{ heading_level }}>
         <p class="mt-3 pb-2">{{ accordion.intro }}</p>
         <div class="mt-4 pl-0">
             {% for id, card in accordion.entries.items() -%}
@@ -225,11 +225,11 @@
 </div>
 {%- endmacro %}
 
-{% macro teaserCard(url, title, description, img_url, direction) %}
+{% macro teaserCard(url, title, description, img_url, direction, heading_level=3) %}
     <div class="teaser-card teaser-card--{{direction}}">
         <a href="{{ url }}">
             <div class="teaser-card-body">
-                <h3 class="pb-3">{{ title }}</h3>
+                <h{{ heading_level }} class="pb-3 h3">{{ title }}</h{{ heading_level }}>
                 <p>{{ description }}</p>
                 <img src="{{ img_url }}" width="50px" alt="icon info" />
             </div>

--- a/webapp/app/templates/content/agb.html
+++ b/webapp/app/templates/content/agb.html
@@ -14,7 +14,7 @@
         <h2 class="mb-4">{{ _('agb.leistungen-headline') }}</h2>
         <p class="mb-2">{{ _('agb.leistungen-p1') }}</p>
         <p class="mb-2">{{ _('agb.leistungen-p2') }}</p>
-        <h5 class="mt-5 mb-3">{{ _('agb.programmumfang-headline') }}</h5>
+        <h3 class="mt-5 mb-3 h5">{{ _('agb.programmumfang-headline') }}</h3>
         <p class="mb-2">{{ _('agb.programmumfang-p1') }}</p>
 
         <ul class="form-list">
@@ -25,15 +25,15 @@
         <p class="mt-4 mb-5">{{ _('agb.programmumfang-p2', link=url_for('eligibility', step='start'))}}</p>
 
         <p class="mt-5 mb-2">{{ _('agb.leistungen-p4') }}</p>
-        <h4 class="mt-5 mb-1">{{ _('agb.vorpruefung-headline') }}</h4>
+        <h3 class="mt-5 mb-1 h4">{{ _('agb.vorpruefung-headline') }}</h3>
         <p class="mb-2">{{ _('agb.vorpruefung-p1', link=url_for('eligibility', step='start'))}}</p>
 
-        <h4 class="mt-5 mb-1">{{ _('agb.registrierung-headline') }}</h4>
+        <h3 class="mt-5 mb-1 h4">{{ _('agb.registrierung-headline') }}</h3>
         <p class="mb-2">{{ _('agb.registrierung-p1') }}</p>
         <p class="mb-2">{{ _('agb.registrierung-p2') }}</p>
         <p class="mb-2">{{ _('agb.registrierung-p3') }}</p>
 
-        <h4 class="mt-5 mb-1">{{ _('agb.steuererklärung-headline') }}</h4>
+        <h3 class="mt-5 mb-1 h4">{{ _('agb.steuererklärung-headline') }}</h3>
         <p class="mb-2">{{ _('agb.steuererklärung-p1') }}</p>
         <p class="mb-2">{{ _('agb.steuererklärung-p2') }}</p>
         <p class="mb-2">{{ _('agb.steuererklärung-p3') }}</p>
@@ -55,7 +55,7 @@
 
     </div>
     <div class="mt-5 pb-3">
-        <h3 class="mt-5 mb-3">{{ _('agb.auftragsverhältnis-headline') }}</h3>
+        <h2 class="mt-5 mb-3">{{ _('agb.auftragsverhältnis-headline') }}</h2>
         <p class="mb-2">{{ _('agb.auftragsverhältnis-p1') }}</p>
         <p class="mb-2">{{ _('agb.auftragsverhältnis-p2') }}</p>
         <p class="mb-2">{{ _('agb.auftragsverhältnis-p3') }}</p>
@@ -64,7 +64,7 @@
 
     </div>
     <div class="mt-5 pb-3">
-        <h3 class="mt-5 mb-3">{{ _('agb.urheberrechtsschutz-headline') }}</h3>
+        <h2 class="mt-5 mb-3">{{ _('agb.urheberrechtsschutz-headline') }}</h2>
         <p class="mb-2">{{ _('agb.urheberrechtsschutz-p1') }}</p>
         <p class="mb-2">{{ _('agb.urheberrechtsschutz-p2') }}</p>
         <p class="ml-5 mb-2">{{ _('agb.urheberrechtsschutz-p3') }}</p>
@@ -72,11 +72,11 @@
         <p class="mb-2">{{ _('agb.urheberrechtsschutz-p5') }}</p>
     </div>
     <div class="mt-5 pb-3">
-        <h3 class="mt-5 mb-3">{{ _('agb.datenschutz-headline') }}</h3>
+        <h2 class="mt-5 mb-3">{{ _('agb.datenschutz-headline') }}</h2>
         <p class="mb-2">{{ _('agb.datenschutz-p1', link=url_for('data_privacy')) }}</p>
     </div>
     <div class="mt-5 pb-3">
-        <h3 class="mt-5 mb-3">{{ _('agb.pflichten-headline') }}</h3>
+        <h2 class="mt-5 mb-3">{{ _('agb.pflichten-headline') }}</h2>
         <p class="mb-2">{{ _('agb.pflichten-p1') }}</p>
         <p class="mb-2">{{ _('agb.pflichten-p2') }}</p>
         <p class="mb-2">{{ _('agb.pflichten-p3') }}</p>
@@ -87,7 +87,7 @@
         <p class="mb-2">{{ _('agb.pflichten-p8') }}</p>
     </div>
     <div class="mt-5 pb-3">
-        <h3 class="mt-5 mb-3">{{ _('agb.haftung-headline') }}</h3>
+        <h2 class="mt-5 mb-3">{{ _('agb.haftung-headline') }}</h2>
         <p class="mb-2">{{ _('agb.haftung-p1') }}</p>
         <p class="ml-5 mb-2">{{ _('agb.haftung-p2') }}</p>
 
@@ -96,17 +96,17 @@
         <p class="ml-5 mb-2">{{ _('agb.haftung-p5') }}</p>
     </div>
     <div class="mt-5 pb-3">
-        <h3 class="mt-5 mb-3">{{ _('agb.widerrufsrecht-headline') }}</h3>
+        <h2 class="mt-5 mb-3">{{ _('agb.widerrufsrecht-headline') }}</h2>
         <p class="mb-2">{{ _('agb.widerrufsrecht-p1') }}</p>
     </div>
     <div class="mt-5 pb-3">
-        <h3 class="mt-5 mb-3">{{ _('agb.laufzeit-headline') }}</h3>
+        <h2 class="mt-5 mb-3">{{ _('agb.laufzeit-headline') }}</h2>
         <p class="mb-2">{{ _('agb.laufzeit-p1') }}</p>
         <p class="mb-2">{{ _('agb.laufzeit-p2') }}</p>
         <p class="mb-2">{{ _('agb.laufzeit-p3') }}</p>
     </div>
     <div class="mt-5 pb-3">
-        <h3 class="mt-5 mb-3">{{ _('agb.schlussbestimmungen-headline') }}</h3>
+        <h2 class="mt-5 mb-3">{{ _('agb.schlussbestimmungen-headline') }}</h2>
         <p class="mb-2">{{ _('agb.schlussbestimmungen-p1') }}</p>
         <p class="mb-2">{{ _('agb.schlussbestimmungen-p2') }}</p>
     <ul class="form-list">

--- a/webapp/app/templates/content/barrierefreiheit.html
+++ b/webapp/app/templates/content/barrierefreiheit.html
@@ -21,7 +21,7 @@
     <div class="mt-5 pb-1">
         <h2>{{ _('accessibility.contact-headline') }}</h2>
         <p class="mt-3 pb-3">{{ _('accessibility.contact-text') }}</p>
-        <h4 class="mt-4 pb-2">{{ _('accessibility.conciliation-headline') }}</h4>
+        <h3 class="mt-4 pb-2 h4">{{ _('accessibility.conciliation-headline') }}</h3>
         <p class="mt-3 pb-2">{{ _('accessibility.conciliation-text-p1') }}</p>
         <p class="mt-3 pb-2">{{ _('accessibility.conciliation-text-p2') }}</p>
         <p class="mt-3 pb-2">{{ _('accessibility.conciliation-text-p3') }}</p>

--- a/webapp/app/templates/content/contact.html
+++ b/webapp/app/templates/content/contact.html
@@ -6,19 +6,19 @@
     </div>
 
     <div class="mb-5">
-        <h2>{{ _('contact.service-headline') }}</h2>
+        <h2 class="h3">{{ _('contact.service-headline') }}</h2>
         <p class="mt-2">{{ _('contact.service-infopage', link=url_for('howitworks')) }}</p>
         <p>{{ _('contact.service-mail') }}</p>
         <p>{{ _('contact.service-legal') }}</p>
     </div>
 
     <div class="mt-5 mb-5">
-        <h2>{{ _('contact.feedback-headline') }}</h2>
+        <h2 class="h3">{{ _('contact.feedback-headline') }}</h2>
         <p class="mt-2">{{ _('contact.feedback-text') }}</p>
     </div>
 
     <div class="mt-5 mb-5">
-        <h2>{{ _('contact.security-headline') }}</h2>
+        <h2 class="h3">{{ _('contact.security-headline') }}</h2>
         <p class="mt-2">{{ _('contact.security-text') }}</p>
     </div>
 {% endblock %}

--- a/webapp/app/templates/content/contact.html
+++ b/webapp/app/templates/content/contact.html
@@ -6,19 +6,19 @@
     </div>
 
     <div class="mb-5">
-        <h3>{{ _('contact.service-headline') }}</h3>
+        <h2>{{ _('contact.service-headline') }}</h2>
         <p class="mt-2">{{ _('contact.service-infopage', link=url_for('howitworks')) }}</p>
         <p>{{ _('contact.service-mail') }}</p>
         <p>{{ _('contact.service-legal') }}</p>
     </div>
 
     <div class="mt-5 mb-5">
-        <h3>{{ _('contact.feedback-headline') }}</h3>
+        <h2>{{ _('contact.feedback-headline') }}</h2>
         <p class="mt-2">{{ _('contact.feedback-text') }}</p>
     </div>
 
     <div class="mt-5 mb-5">
-        <h3>{{ _('contact.security-headline') }}</h3>
+        <h2>{{ _('contact.security-headline') }}</h2>
         <p class="mt-2">{{ _('contact.security-text') }}</p>
     </div>
 {% endblock %}

--- a/webapp/app/templates/content/data_privacy.html
+++ b/webapp/app/templates/content/data_privacy.html
@@ -54,31 +54,31 @@
         <p>{{ _('data_privacy.rights-text') }}</p>
 
         <div class="mt-5">
-            <h4>{{ _('data_privacy.rights-information') }}</h4>
+            <h3 class="h4">{{ _('data_privacy.rights-information') }}</h3>
             <p>{{ _('data_privacy.rights-information-text') }}</p>
         </div>
 
         <div class="mt-5">
-            <h4>{{ _('data_privacy.correction-information') }}</h4>
+            <h3 class="h4">{{ _('data_privacy.correction-information') }}</h3>
             <p>{{ _('data_privacy.correction-information-text') }}</p>
         </div>
 
         <div class="mt-5">
-            <h4>{{ _('data_privacy.deletion-information') }}</h4>
+            <h3 class="h4">{{ _('data_privacy.deletion-information') }}</h3>
             <p>{{ _('data_privacy.deletion-information-text') }}</p>
         </div>
 
         <div class="mt-5">
-            <h4>{{ _('data_privacy.restriction-information') }}</h4>
+            <h3 class="h4">{{ _('data_privacy.restriction-information') }}</h3>
             <p>{{ _('data_privacy.restriction-information-text') }}</p>
         </div>
 
         <div class="mt-5">
-            <h4>{{ _('data_privacy.objection-information') }}</h4>
+            <h3 class="h4">{{ _('data_privacy.objection-information') }}</h3>
             <p>{{ _('data_privacy.objection-information-text') }}</p>
         </div>
         <div class="mt-5">
-            <h4>{{ _('data_privacy.appeal-information') }}</h4>
+            <h3 class="h4">{{ _('data_privacy.appeal-information') }}</h3>
             <p>{{ _('data_privacy.appeal-information-text-p1') }}</p>
             <p class="mt-4">{{ _('data_privacy.appeal-information-text-p2') }}</p>
             <p class="mt-4">{{ _('data_privacy.appeal-information-text-p3') }}</p>

--- a/webapp/app/templates/content/howitworks.html
+++ b/webapp/app/templates/content/howitworks.html
@@ -215,7 +215,7 @@
 
 
     {% for accordeon in accordeons %}
-        {{ components.accordion(accordeon) }}
+        {{ components.accordion(accordeon, heading_level=2) }}
     {% endfor %}
 {% endblock %}
 {% block full_width_final_area %}
@@ -225,12 +225,12 @@
                                 _('info.teaser.eligibility.title'),
                                 _('info.teaser.eligibility.description'),
                                 img_url=url_for('static', filename='icons/arrow_left.svg'),
-                                direction='left') }}
+                                direction='left', heading_level=2) }}
             {{ components.teaserCard(url_for('unlock_code_request', step='start'),
                                 _('info.teaser.register.title'),
                                 _('info.teaser.register.description'),
                                 img_url=url_for('static', filename='icons/arrow_left.svg'),
-                                direction='middle') }}
+                                direction='middle', heading_level=2) }}
         </div>
     </div>
 {% endblock %}

--- a/webapp/app/templates/content/imprint.html
+++ b/webapp/app/templates/content/imprint.html
@@ -4,7 +4,7 @@
 {% block content_content %}
     {{ macros.header(title=_('imprint.heading'),
                  hide_intro=True) }}
-    <div >
+    <div>
         <h2 class="pb-1">{{ _('imprint.law-headline') }}</h2>
         <p>{{ _('imprint.operator-text-p1') }}</p>
         <p>{{ _('imprint.ceo-text') }}</p>

--- a/webapp/app/templates/content/landing_page.html
+++ b/webapp/app/templates/content/landing_page.html
@@ -85,7 +85,7 @@
                     title= _('landing.card1.title'),
                     description=_('landing.card1.desc'),
                     img_url=url_for('static', filename='icons/arrow_left.svg'),
-                    direction="left")
+                    direction="left", heading_level=2)
                 }}
 
                 {{ components.teaserCard(
@@ -93,7 +93,7 @@
                     title= _('landing.card2.title'),
                     description=_('landing.card2.desc'),
                     img_url=url_for('static', filename='icons/arrow_left.svg'),
-                    direction="middle")
+                    direction="middle", heading_level=2)
                 }}
 
                 {{ components.teaserCard(
@@ -101,13 +101,13 @@
                     title= _('landing.card3.title'),
                     description=_('landing.card3.desc'),
                     img_url=url_for('static', filename='icons/arrow_left.svg'),
-                    direction="right")
+                    direction="right", heading_level=2)
                 }}
             </div>
         </div>
         <div class="accordion__home col-lg-8 col-md-8 pb-0 g-0">
             {% for accordeon in accordeons %}
-                {{ components.accordion(accordeon) }}
+                {{ components.accordion(accordeon, heading_level=2) }}
             {% endfor %}
             {{ components.primaryButton(text="Zur Informationsseite", url=url_for('howitworks')) }}
         </div>
@@ -115,7 +115,7 @@
             <div class="interview__home__img col-lg-6">
             </div>
             <div class="interview__home__text col-lg-6">
-                <h3 class="mb-4">{{ _('landing.interviews-headline') }}</h3>
+                <h2 class="mb-4">{{ _('landing.interviews-headline') }}</h2>
                 <p class="mb-4">{{ _('landing.interviews-text') }}</p>
                 <a href="{{ url_for('interviews') }}">{{ _('landing.interviews-link') }}</a>
             </div>

--- a/webapp/app/templates/eligibility/display_failure.html
+++ b/webapp/app/templates/eligibility/display_failure.html
@@ -3,7 +3,6 @@
 {% import "components.html" as components %}
 
 {% block errors %}
-
     <div class="row m-0 pt-4 mt-4 simple-card">
         <p class="font-weight-bolder">{{ _('form.eligibility.intro-errors') }}</p>
         {% if errors is defined %}
@@ -20,22 +19,18 @@
                 {% endfor -%}
             </ul>
         {% endif %}
-
     </div>
 {% endblock %}
 
 {% block display_failure_content %}
-
-
     <div class="row m-0 pt-4">
-        <h4>{{ _('form.eligibility.use-elster') }}</h4>
+        <h2 class="h4">{{ _('form.eligibility.use-elster') }}</h2>
         <p>{{ _('form.eligibility.use-elster-text') }}</p>
         <ol>
             <li>{{ _('form.eligibility.use-elster.list-item-1') }}</li>
             <li>{{ _('form.eligibility.use-elster.list-item-2') }}</li>
         </ol>
     </div>
-
 
     <div class="row m-0 pt-4">
         {{ components.primaryButtonWithIcon(
@@ -47,8 +42,7 @@
     </div>
 
     <div class="row m-0 pt-4">
-        <h4>{{ _('form.eligibility.impact-development') }}</h4>
+        <h2 class="h4">{{ _('form.eligibility.impact-development') }}</h2>
         <p>{{ _('form.eligibility.impact-development-text') }}</p>
-
     </div>
 {% endblock %}

--- a/webapp/app/templates/eligibility/display_success.html
+++ b/webapp/app/templates/eligibility/display_success.html
@@ -4,7 +4,7 @@
 
 {% block display_success_content %}
     <div class="row m-0 pt-4">
-        <h4>{{ _('form.eligibility.success-next-step') }}</h4>
+        <h2 class="h4">{{ _('form.eligibility.success-next-step') }}</h2>
         <p>{{ _('form.eligibility.success-next-step-text') }}</p>
     </div>
     <div class="row m-0 pt-4">

--- a/webapp/app/templates/error/404.html
+++ b/webapp/app/templates/error/404.html
@@ -6,6 +6,6 @@
     {{ macros.header(title=_('404.title'),
                      intro= _('404.description')) }}
     <p>
-        {{ components.primaryButton( text=_('form.back-to-home'), url=url_for('index')) }}
+        {{ components.primaryButton(text=_('form.back-to-home'), url=url_for('index')) }}
     </p>
 {% endblock %}

--- a/webapp/app/templates/error/429.html
+++ b/webapp/app/templates/error/429.html
@@ -6,6 +6,6 @@
     {{ macros.header(title=_('429.title'),
                      intro= _('429.description')) }}
     <p>
-        {{ components.primaryButton( text=_('form.back-to-home'), url=url_for('index')) }}
+        {{ components.primaryButton(text=_('form.back-to-home'), url=url_for('index')) }}
     </p>
 {% endblock %}

--- a/webapp/app/templates/error/500.html
+++ b/webapp/app/templates/error/500.html
@@ -6,6 +6,6 @@
     {{ macros.header(title=_('500.title'),
                      intro= _('500.description')) }}
     <p>
-        {{ components.primaryButton( text=_('form.back-to-home'), url=url_for('index')) }}
+        {{ components.primaryButton(text=_('form.back-to-home'), url=url_for('index')) }}
     </p>
 {% endblock %}

--- a/webapp/app/templates/error/incorrect_eligiblity_data.html
+++ b/webapp/app/templates/error/incorrect_eligiblity_data.html
@@ -6,6 +6,6 @@
     {{macros.header(title=_('forms.eligibility.incorrect_data.title'),
                     intro=_('forms.eligibility.incorrect_data.description')) }}
     <p>
-        {{ components.primaryButton( text=_('form.eligibility.back-to-form'), url=url_for('eligibility', step='start')) }}
+        {{ components.primaryButton(text=_('form.eligibility.back-to-form'), url=url_for('eligibility', step='start')) }}
     </p>
 {% endblock %}

--- a/webapp/app/templates/error/pdf_not_found.html
+++ b/webapp/app/templates/error/pdf_not_found.html
@@ -12,12 +12,12 @@
     <p>
         {{ _('pdf_not_found.reasons.intro') }}
     </p>
-    <h4 class="mt-4">{{ _('pdf_not_found.reasons.expired.title') }}</h4>
+    <h2 class="mt-4 h4">{{ _('pdf_not_found.reasons.expired.title') }}</h2>
     <p>{{ _('pdf_not_found.reasons.expired.intro') }}</p>
-    <h4 class="mt-4">{{ _('pdf_not_found.reasons.no_tax_declaration.title') }}</h4>
+    <h2 class="mt-4 h4">{{ _('pdf_not_found.reasons.no_tax_declaration.title') }}</h2>
     <p>{{ _('pdf_not_found.reasons.no_tax_declaration.intro') }}</p>
     {{ components.primaryButton( text=_('pdf_not_found.to_tax_declaration'), url=url_for('lotse', step='start')) }}
-    <h4 class="mt-4">{{ _('pdf_not_found.reasons.not_activated.title') }}</h4>
+    <h2 class="mt-4 h4">{{ _('pdf_not_found.reasons.not_activated.title') }}</h2>
     <p>{{ _('pdf_not_found.reasons.not_activated.intro') }}</p>
     {{ components.primaryButton( text=_('login.input-code'), url=url_for('unlock_code_activation', step='data_input')) }}
 {% endblock %}

--- a/webapp/app/templates/lotse/display_ack.html
+++ b/webapp/app/templates/lotse/display_ack.html
@@ -2,10 +2,10 @@
 
 {% block display_success_content %}
 
-    <h4 class="mt-4">{{ _('form.lotse.ack.next-steps.heading') }}</h4>
+    <h2 class="h4 mt-4">{{ _('form.lotse.ack.next-steps.heading') }}</h2>
     <p>{{ _('form.lotse.ack.next-steps.text') }}</p>
 
-    <h4 class="mt-4">{{ _('form.lotse.ack.logout.heading') }}</h4>
+    <h2 class="h4 mt-4">{{ _('form.lotse.ack.logout.heading') }}</h2>
     <p>{{ _('form.lotse.ack.logout.text') }}</p>
 
 {% endblock %}

--- a/webapp/app/templates/lotse/display_filing_success.html
+++ b/webapp/app/templates/lotse/display_filing_success.html
@@ -3,7 +3,7 @@
 
 {% block display_main_content %}
 
-    <h4>{{ _('form.lotse.filing.transfer_ticket.heading') }}</h4>
+    <h2 class="h4">{{ _('form.lotse.filing.transfer_ticket.heading') }}</h2>
     <p>
         {{ _('form.lotse.filing.transfer_ticket.text') }} <br><br>
         <span class="text-monospace font-weight-bolder">
@@ -12,7 +12,7 @@
     </p>
 
 
-    <h4>{{ _('form.lotse.filing.pdf.heading') }}</h4>
+    <h2 class="h2">{{ _('form.lotse.filing.pdf.heading') }}</h2>
     <p>{{ _('form.lotse.filing.pdf.text') }}</p>
 
     {{ components.downloadLink(text=_('form.lotse.ack-pdf-download-button'), url=url_for('download_pdf'), large=True) }}

--- a/webapp/app/templates/lotse/display_summary.html
+++ b/webapp/app/templates/lotse/display_summary.html
@@ -5,12 +5,12 @@
 {# TODO Restructure how the summary is displayed #}
 {% block form_content %}
 {% for section in render_info.additional_info.section_steps.values() -%}
-  <h5 class="mb-0 mt-5 text-uppercase">{{ section.label }}</h5>
+  <h2 class="mb-0 mt-5 h5 text-uppercase">{{ section.label }}</h2>
   {% for step in section.data.values() -%}
     <div class="my-4 px-0">
       <div class="card">
         <div class="card-header unstyled-card-header d-sm-flex justify-content-between align-items-center">
-          <h5 class="mb-0 bold">{{ step.label }}</h5>
+          <h3 class="mb-0 h5 bold">{{ step.label }}</h3>
           {{ components.editButton(url=step.url) }}
         </div>
         <div class="card-body pt-2">

--- a/webapp/app/templates/lotse/form_person_a.html
+++ b/webapp/app/templates/lotse/form_person_a.html
@@ -4,7 +4,7 @@
 
 {% block form_content %}
 
-    <h3 class="mt-5 my-3">{{ _('form.lotse.person-header-allgemein') }}</h3>
+    <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-allgemein') }}</h2>
     <div class="form-row-center">
         {{ macros.render_field(form.person_a_first_name) }}
     </div>
@@ -21,7 +21,7 @@
         {{ macros.render_field(form.person_a_idnr) }}
     </div>
 
-    <h3 class="mt-5 my-3">{{ _('form.lotse.person-header-addresse') }}</h3>
+    <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-addresse') }}</h2>
     <div class="form-row-center">
         {{ macros.render_field(form.person_a_street) }}
         {{ macros.render_field(form.person_a_street_number, 2) }}
@@ -35,12 +35,12 @@
         {{ macros.render_field(form.person_a_town, 6) }}
     </div>
 
-    <h3 class="mt-5 my-3">{{ _('form.lotse.person-header-religion') }}</h3>
+    <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-religion') }}</h2>
     <div class="form-row-center">
         {{ macros.render_field(form.person_a_religion) }}
     </div>
 
-    <h3 class="mt-5 my-3">{{ _('form.lotse.person-header-beh') }}</h3>
+    <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-beh') }}</h2>
     <p class="mb-4">{{ _('form.lotse.person-header-beh-intro') }}</p>
     <div class="form-row-center">
         {{ macros.render_field(form.person_a_beh_grad, 4) }}

--- a/webapp/app/templates/lotse/form_person_b.html
+++ b/webapp/app/templates/lotse/form_person_b.html
@@ -4,7 +4,7 @@
 
 {% block form_content %}
 
-  <h3 class="mt-5 my-3">{{ _('form.lotse.person-header-allgemein') }}</h3>
+  <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-allgemein') }}</h2>
    <div class="form-row-center">
     {{ macros.render_field(form.person_b_first_name) }}
   </div>
@@ -18,7 +18,7 @@
     {{ macros.render_field(form.person_b_idnr) }}
   </div>
 
-  <h3 class="mt-5 my-3">{{ _('form.lotse.person-header-addresse') }}</h3>
+  <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-addresse') }}</h2>
   {{ macros.render_field(form.person_b_same_address, 10) }}
 
   <div id="form_address_fields" class="hidden">
@@ -36,12 +36,12 @@
     </div>
   </div>
 
-  <h3 class="mt-5 my-3">{{ _('form.lotse.person-header-religion') }}</h3>
+  <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-religion') }}</h2>
   <div class="form-row-center">
     {{ macros.render_field(form.person_b_religion, 6, class=" custom-select") }}
   </div>
 
-  <h3 class="mt-5 my-3">{{ _('form.lotse.person-header-beh') }}</h3>
+  <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-beh') }}</h2>
   <p class="mb-4">{{ _('form.lotse.person-header-beh-intro') }}</p>
   <div class="form-row-center">
     {{ macros.render_field(form.person_b_beh_grad, 4) }}

--- a/webapp/app/templates/unlock_code/registration_data_input.html
+++ b/webapp/app/templates/unlock_code/registration_data_input.html
@@ -9,12 +9,12 @@
         {{ macros.render_field(form.idnr) }}
     </div>
 
-    <h5 class="mt-5 mb-4 bold">{{ _('unlock-code-request.data-privacy-and-agb.title') }}</h5>
+    <h2 class="mt-5 mb-4 h5 bold">{{ _('unlock-code-request.data-privacy-and-agb.title') }}</h2>
     {{ macros.render_field(form.registration_confirm_data_privacy) }}
     {{ macros.render_field(form.registration_confirm_terms_of_service) }}
     {{ macros.render_field(form.registration_confirm_incomes) }}
 
-    <h5 class="mt-5 bold">{{ _('unlock-code-request.edata.title') }}</h5>
+    <h2 class="mt-5 h5 bold">{{ _('unlock-code-request.edata.title') }}</h2>
     {{ components.details(_('unlock-code-request.e-data.help-title'), [_('unlock-code-request.e-data.help-text')], details_id=form.registration_confirm_e_data.id) }}
     {{ macros.render_field(form.registration_confirm_e_data) }}
 

--- a/webapp/app/templates/unlock_code/registration_success.html
+++ b/webapp/app/templates/unlock_code/registration_success.html
@@ -1,7 +1,7 @@
 {% extends 'basis/display_success.html' %}
 
 {% block display_success_content %}
-    <h3 class="mt-5">{{ _('register.success.next-steps.heading') }}</h3>
+    <h2 class="mt-5">{{ _('register.success.next-steps.heading') }}</h2>
     <ol>
         <li>{{ _('register.success.next-steps.step-1') }}</li>
         <li>{{ _('register.success.next-steps.step-2', link=url_for('download_preparation')) }}</li>
@@ -9,13 +9,13 @@
         <li>{{ _('register.success.next-steps.step-4', link=url_for('unlock_code_activation', step='start')) }}</li>
     </ol>
 
-    <h3 class="mt-5">{{ _('register.success.letter.heading') }}</h3>
+    <h2 class="mt-5">{{ _('register.success.letter.heading') }}</h2>
     <p>{{ _('register.success.letter.intro') }}</p>
     <img class="w-50"
          src="{{ url_for('static', filename='images/elster_letter_example.png') }}"
          alt="elster_letter">
 
-    <h3 class="mt-5">{{ _('register.success.preparation.heading') }}</h3>
+    <h2 class="mt-5">{{ _('register.success.preparation.heading') }}</h2>
     <p>{{ _('register.success.preparation.intro') }}</p>
     <a class="btn btn-primary" href="{{ url_for('download_preparation') }}"
        download>{{ _('register.success.preparation.button') }}</a>


### PR DESCRIPTION
# Short Description
- We previously didn't use headings in the correct increasing order. Now we do^^

# Changes
- Went through all templates and adapted the headings so that they are consecutive.
- Added bootstrap's `.h<x>` classes where necessary to contain the look and feel.
- Added a heading_level parameter to accordion and teaser card to be able to configure the level differently for each page.

# Feedback
- How cool is the `h{{ heading_level }}` part?! I thought I'd just try it and it works! So nice. :D 