### PR TITLE
Make gunicorn workers async

### DIFF
--- a/webapp/gunicorn_config.py
+++ b/webapp/gunicorn_config.py
@@ -13,5 +13,6 @@ with open('logging.json') as f:
 
 
 workers = 4
+worker_class = 'eventlet'
 bind = '0.0.0.0:5000'
 worker_tmp_dir = '/dev/shm'


### PR DESCRIPTION
# Short Description
- We hope to avoid some timeout errors we're getting by making the gunicorn workers async.

# Changes
- Use `worker_class = 'eventlet'` - found this [here](https://docs.gunicorn.org/en/stable/settings.html#worker-class) `eventlet` and `gevent` are both async options and I couldn't find a reason one is better suited than the other, so I just decided to use eventlet. Let me know if you disagree.

# Feedback
- I set the config value on staging and restarted the container so the configuration should take effect and it still worked, *but* I'd be happy if you have another way to test if this change breaks anything.
