### PR TITLE
Add secret cache version to caching step

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.npm
-        key: ${{ runner.os }}-acceptance-test-node-modules-${{ hashFiles('acceptance_tests/package-lock.json') }}
+        key: ${{ runner.os }}-acceptance-test-node-modules-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('acceptance_tests/package-lock.json') }}
 
     - name: Install dependencies
       run: cd acceptance_tests && npm install

--- a/.github/workflows/cicd-pipeline.yml
+++ b/.github/workflows/cicd-pipeline.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.local/share/virtualenvs
-        key: ${{ runner.os }}-deps-webapp-${{ hashFiles('webapp/Pipfile.lock') }}
+        key: ${{ runner.os }}-deps-webapp-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('webapp/Pipfile.lock') }}
 
     - name: Install dependencies
       if: steps.cache-deps-webapp.outputs.cache-hit != 'true'

--- a/.github/workflows/cicd-pipeline.yml
+++ b/.github/workflows/cicd-pipeline.yml
@@ -82,7 +82,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.local/share/virtualenvs
-        key: ${{ runner.os }}-deps-erica-${{ hashFiles('erica_app/Pipfile.lock') }}
+        key: ${{ runner.os }}-deps-erica-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('erica_app/Pipfile.lock') }}
 
     - name: Install dependencies
       if: steps.cache-deps-erica.outputs.cache-hit != 'true'
@@ -218,7 +218,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.npm
-        key: ${{ runner.os }}-acceptance-test-node-modules-${{ hashFiles('acceptance_tests/package-lock.json') }}
+        key: ${{ runner.os }}-acceptance-test-node-modules-v${{ secrets.CACHE_VERSION }}-${{ hashFiles('acceptance_tests/package-lock.json') }}
 
     - name: Install dependencies
       run: cd acceptance_tests && npm install


### PR DESCRIPTION
# Short Description
This adds a secret value to version the cache we use in our GithubActions. This allows us to reset the version without changing the code and clear the cache if there is a problem with it (got the idea from [here](https://github.community/t/how-to-clear-cache-in-github-actions/129038)).

# Changes
- Add secret cache version to acceptance tests Github Actions
- Add secret cache version to CICD pipeline

# Feedback
- Do you have any problem with this?