### PR TITLE
Change eric log decoding to be able to read with stick

### DIFF
--- a/erica_app/erica/pyeric/eric.py
+++ b/erica_app/erica/pyeric/eric.py
@@ -51,7 +51,7 @@ def get_eric_wrapper():
             yield eric
         finally:
             eric.shutdown()
-            with open(os.path.join(tmp_dir, 'eric.log')) as eric_log:
+            with open(os.path.join(tmp_dir, 'eric.log'), encoding='latin-1') as eric_log:
                 logger.debug(eric_log.read())
 
 


### PR DESCRIPTION
# Short Description
We noticed that we get decoding problems if we run the tests on Mac with a stick. (`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 5616: invalid start byte`). I therefore tried to change the encoding to latin-1 and it works for all combinations of Mac/Linux and Stick/Software-Certificate.

# Changes
- Use 'latin-1' decoding for the log

# Feedback
- It works on linux both ways, so I decided to not make a differentiation here and always read the log as latin-1. Do you think this could become a problem? And we should therefore differentiate between the operating systems?
