### PR TITLE
Separate idnr input

### DIFF
--- a/acceptance_tests/cypress/integration/lotse_flow.spec.js
+++ b/acceptance_tests/cypress/integration/lotse_flow.spec.js
@@ -4,7 +4,10 @@ const authPassword = Cypress.env('STAGING_AUTH_PASSWORD')
 Cypress.config('baseUrl', `https://lotse:${authPassword}@www-staging.stl.ds4g.dev`)
 
 const unlockCodeData = {
-    idnr: '09531672807',
+    idnr1: '09',
+    idnr2: '531',
+    idnr3: '672',
+    idnr4: '807',
     dob: '22.12.1972',
 }
 
@@ -16,7 +19,10 @@ const taxReturnData = {
     marriedDate: '01.01.1990',
     iban: 'DE02500105170137075030',
     personA: {
-        idnr: '04452397687',
+        idnr1: '04',
+        idnr2: '452',
+        idnr3: '397',
+        idnr4: '687',
         dob: '01.01.1990',
         firstName: 'Erika',
         lastName: 'Musterfrau',
@@ -29,7 +35,10 @@ const taxReturnData = {
         behGrad: '25',
     },
     personB: {
-        idnr: '02293417683',
+        idnr1: '02',
+        idnr2: '293',
+        idnr3: '417',
+        idnr4: '683',
         dob: '25.02.1951',
         firstName: 'Gerta',
         lastName: 'Mustername',
@@ -96,7 +105,10 @@ const overviewBtnSelector = '[name="overview_button"]'
 const login = function () {
     // Log in
     cy.get('.nav-link').contains('Ihre Steuererklärung').click()
-    cy.get('#idnr').type(taxReturnData.personA.idnr)
+    cy.get('#idnr_1').type(taxReturnData.personA.idnr1)
+    cy.get('#idnr_2').type(taxReturnData.personA.idnr2)
+    cy.get('#idnr_3').type(taxReturnData.personA.idnr3)
+    cy.get('#idnr_4').type(taxReturnData.personA.idnr4)
     cy.get('#unlock_code_1').type(taxReturnData.unlockCode1)
     cy.get('#unlock_code_2').type(taxReturnData.unlockCode2)
     cy.get('#unlock_code_3').type(taxReturnData.unlockCode3)
@@ -205,7 +217,10 @@ context('Acceptance tests', () => {
                 cy.get('select[id=bundesland]').select('BY')
                 cy.get('#steuernummer').type(taxReturnData.taxNr)
                 cy.get(submitBtnSelector).click()
-                cy.get('#person_a_idnr').type(taxReturnData.personA.idnr)
+                cy.get('#person_a_idnr_1').type(taxReturnData.personA.idnr1)
+                cy.get('#person_a_idnr_2').type(taxReturnData.personA.idnr2)
+                cy.get('#person_a_idnr_3').type(taxReturnData.personA.idnr3)
+                cy.get('#person_a_idnr_4').type(taxReturnData.personA.idnr4)
                 cy.get('#person_a_dob').type(taxReturnData.personA.dob)
                 cy.get('#person_a_first_name').type(taxReturnData.personA.firstName)
                 cy.get('#person_a_last_name').type(taxReturnData.personA.lastName)
@@ -248,7 +263,10 @@ context('Acceptance tests', () => {
                 cy.get('select[id=bundesland]').select('BY')
                 cy.get('#steuernummer').type(taxReturnData.taxNr)
                 cy.get(submitBtnSelector).click()
-                cy.get('#person_a_idnr').type(taxReturnData.personA.idnr)
+                cy.get('#person_a_idnr_1').type(taxReturnData.personA.idnr1)
+                cy.get('#person_a_idnr_2').type(taxReturnData.personA.idnr2)
+                cy.get('#person_a_idnr_3').type(taxReturnData.personA.idnr3)
+                cy.get('#person_a_idnr_4').type(taxReturnData.personA.idnr4)
                 cy.get('#person_a_dob').type(taxReturnData.personA.dob)
                 cy.get('#person_a_first_name').type(taxReturnData.personA.firstName)
                 cy.get('#person_a_last_name').type(taxReturnData.personA.lastName)
@@ -262,7 +280,10 @@ context('Acceptance tests', () => {
                 cy.get('label[for=person_a_blind]').first().click()
                 cy.get('label[for=person_a_gehbeh]').first().click()
                 cy.get(submitBtnSelector).click()
-                cy.get('#person_b_idnr').type(taxReturnData.personB.idnr)
+                cy.get('#person_b_idnr_1').type(taxReturnData.personB.idnr1)
+                cy.get('#person_b_idnr_2').type(taxReturnData.personB.idnr2)
+                cy.get('#person_b_idnr_3').type(taxReturnData.personB.idnr3)
+                cy.get('#person_b_idnr_4').type(taxReturnData.personB.idnr4)
                 cy.get('#person_b_dob').type(taxReturnData.personB.dob)
                 cy.get('#person_b_first_name').type(taxReturnData.personB.firstName)
                 cy.get('#person_b_last_name').type(taxReturnData.personB.lastName)
@@ -347,8 +368,8 @@ context('Acceptance tests', () => {
                 cy.visit('/lotse/step/summary')
                 cy.contains('Sie müssen eingeloggt sein')
                 cy.visit('/unlock_code_activation/step/data_input')
-                cy.get('#idnr').should('have.value', '')
-                cy.get('#unlock_code').should('have.value', '')
+                cy.get('#idnr_1').should('have.value', '')
+                cy.get('#unlock_code_1').should('have.value', '')
             });
         });
         // These tests could be split. However, to avoid hitting rate limits, keep it simple, and reduce the run time it is one test.

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -89,11 +89,12 @@ class IdNrField(SteuerlotseStringField):
         # As we know that it is correct, we can just separate it in chunks here.
         split_data = []
         chunk_sizes = self.widget.input_field_lengths
-        current_idx = 0
+        start_idx = 0
         for chunk_size in chunk_sizes:
+            end_index = start_idx + chunk_size
             if self.data:
-                split_data.append(self.data[current_idx: current_idx + chunk_size])
-            current_idx += chunk_size
+                split_data.append(self.data[start_idx: end_index])
+            start_idx = end_index
         return split_data
 
     def post_validate(self, form, validation_stopped):

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -36,8 +36,8 @@ class MultipleInputFieldWidget(TextInput):
             kwargs['value'] = field._value()[idx] if len(field._value()) >= idx + 1 else ''
             kwargs['id'] = f'{field.id}_{idx + 1}'
             joined_input_fields += (super(MultipleInputFieldWidget, self).__call__(field, **kwargs))
-            if self.separator and idx < len(self.input_field_lengths) - 1:
-                joined_input_fields += Markup(self.separator)
+            if self.sub_field_separator and idx < len(self.input_field_lengths) - 1:
+                joined_input_fields += Markup(self.sub_field_separator)
 
         return Markup(joined_input_fields)
 

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -21,7 +21,7 @@ class SteuerlotseStringField(StringField):
 
 class MultipleInputFieldWidget(TextInput):
     """A divided input field."""
-    separator = ''
+    sub_field_separator = ''
     input_field_lengths = []
 
     def __call__(self, field, **kwargs):
@@ -44,7 +44,7 @@ class MultipleInputFieldWidget(TextInput):
 
 class UnlockCodeWidget(MultipleInputFieldWidget):
     """A divided input field with three text input fields, limited to four chars."""
-    separator = '-'
+    sub_field_separator = '-'
     input_field_lengths = [4, 4, 4]
 
 
@@ -61,6 +61,33 @@ class UnlockCodeField(SteuerlotseStringField):
 
     def _value(self):
         return self.data.split('-') if self.data else ''
+
+
+class IdNrWidget(MultipleInputFieldWidget):
+    """A divided input field with four text input fields, limited to two to three chars."""
+    sub_field_separator = ''
+    input_field_lengths = [2, 3, 3, 3]
+
+class IdNrField(SteuerlotseStringField):
+    def __init__(self, label='', validators=None, **kwargs):
+        super(IdNrField, self).__init__(label, validators, **kwargs)
+        self.widget = IdNrWidget()
+
+    def process_formdata(self, valuelist):
+        if valuelist:
+            self.data = ''.join(valuelist)
+        elif self.data is None:
+            self.data = ''
+
+    def _value(self):
+        split_data = []
+        chunk_sizes = self.widget.input_field_lengths
+        current_idx = 0
+        for chunk_size in chunk_sizes:
+            if self.data:
+                split_data.append(self.data[current_idx: current_idx + chunk_size])
+            current_idx += chunk_size
+        return split_data
 
 
 class EuroFieldWidget(TextInput):

--- a/webapp/app/forms/flows/lotse_flow.py
+++ b/webapp/app/forms/flows/lotse_flow.py
@@ -6,7 +6,7 @@ from wtforms.fields.core import UnboundField, SelectField, BooleanField, RadioFi
 from app import app
 from app.data_access.audit_log_controller import create_audit_log_confirmation_entry
 from app.forms.fields import SteuerlotseSelectField, YesNoField, SteuerlotseDateField, SteuerlotseStringField, \
-    ConfirmationField, EntriesField, EuroField
+    ConfirmationField, EntriesField, EuroField, IdNrField
 from app.model.form_data import MandatoryFormData, FamilienstandModel, MandatoryConfirmations, \
     ConfirmationMissingInputValidationError, MandatoryFieldMissingValidationError, InputDataInvalidError, \
     IdNrMismatchInputValidationError
@@ -387,7 +387,7 @@ class LotseMultiStepFlow(MultiStepFlow):
             value_representation = ', '.join(value)
         elif field.field_class == EuroField:
             value_representation = str(value) + " €"
-        elif field.field_class == SteuerlotseStringField:
+        elif field.field_class == SteuerlotseStringField or field.field_class == IdNrField:
             value_representation = value
         elif field.field_class == IntegerField:
             value_representation = value

--- a/webapp/app/forms/steps/lotse/personal_data_steps.py
+++ b/webapp/app/forms/steps/lotse/personal_data_steps.py
@@ -3,7 +3,7 @@ from pydantic import ValidationError
 from app.forms import SteuerlotseBaseForm
 from app.forms.steps.step import FormStep, SectionLink
 from app.forms.fields import YesNoField, SteuerlotseDateField, SteuerlotseSelectField, ConfirmationField, \
-    SteuerlotseStringField
+    SteuerlotseStringField, IdNrField
 
 from flask_babel import _
 from flask_babel import lazy_gettext as _l
@@ -227,11 +227,10 @@ class StepPersonA(FormStep):
     section_link = SectionLink('mandatory_data', StepFamilienstand.name, _l('form.lotse.mandatory_data.label'))
 
     class Form(SteuerlotseBaseForm):
-        person_a_idnr = SteuerlotseStringField(
+        person_a_idnr = IdNrField(
             label=_l('form.lotse.field_person_idnr'),
             validators=[InputRequired(), ValidIdNr()],
-            render_kw={'help': _l('form.lotse.field_person_idnr-help'),
-                       'data_label': _l('form.lotse.field_person_idnr.data_label')})
+            render_kw={'data_label': _l('form.lotse.field_person_idnr.data_label')})
         person_a_dob = SteuerlotseDateField(
             label=_l('form.lotse.field_person_dob'),
             render_kw={'data_label': _l('form.lotse.field_person_dob.data_label')}, validators=[InputRequired()])
@@ -319,10 +318,9 @@ class StepPersonB(FormStep):
             else:
                 validators.Optional()(self, field)
 
-        person_b_idnr = SteuerlotseStringField(
+        person_b_idnr = IdNrField(
             label=_l('form.lotse.field_person_idnr'), validators=[InputRequired(), ValidIdNr()],
-            render_kw={'help': _l('form.lotse.field_person_idnr-help'),
-                       'data_label': _l('form.lotse.field_person_idnr.data_label')})
+            render_kw={'data_label': _l('form.lotse.field_person_idnr.data_label')})
         person_b_dob = SteuerlotseDateField(
             label=_l('form.lotse.field_person_dob'),
             render_kw={'data_label': _l('form.lotse.field_person_dob.data_label')},

--- a/webapp/app/forms/steps/unlock_code_activation_steps.py
+++ b/webapp/app/forms/steps/unlock_code_activation_steps.py
@@ -4,7 +4,7 @@ from flask_babel import lazy_gettext as _l
 from wtforms.validators import InputRequired
 
 from app.forms import SteuerlotseBaseForm
-from app.forms.fields import SteuerlotseStringField, UnlockCodeField
+from app.forms.fields import SteuerlotseStringField, UnlockCodeField, IdNrField
 from app.forms.steps.step import FormStep, DisplayStep
 from app.forms.validators import ValidIdNr, ValidUnlockCode
 
@@ -13,7 +13,11 @@ class UnlockCodeActivationInputStep(FormStep):
     name = 'data_input'
 
     class Form(SteuerlotseBaseForm):
-        idnr = SteuerlotseStringField(_l('unlock-code-activation.idnr'), [InputRequired(), ValidIdNr()])
+        idnr = IdNrField(_l('unlock-code-activation.idnr'), [InputRequired(), ValidIdNr()],
+                         render_kw={'detail': {'title': _l('unlock-code-request.idnr.help-title'),
+                                               'text': _l('unlock-code-request.idnr.help-text')}}
+
+                         )
         unlock_code = UnlockCodeField(_l('unlock-code-activation.unlock-code'), [InputRequired(), ValidUnlockCode()],
                                       render_kw={'detail': {'title': _l('unlock-code-request.unlock-code.help-title'),
                                                             'text': _l('unlock-code-request.unlock-code.help-text')}}

--- a/webapp/app/forms/steps/unlock_code_request_steps.py
+++ b/webapp/app/forms/steps/unlock_code_request_steps.py
@@ -4,7 +4,7 @@ from flask_babel import lazy_gettext as _l
 from wtforms.validators import InputRequired
 
 from app.forms import SteuerlotseBaseForm
-from app.forms.fields import ConfirmationField, SteuerlotseDateField, SteuerlotseStringField
+from app.forms.fields import ConfirmationField, SteuerlotseDateField, SteuerlotseStringField, IdNrField
 from app.forms.steps.step import FormStep, DisplayStep
 from app.forms.validators import ValidIdNr
 
@@ -13,9 +13,9 @@ class UnlockCodeRequestInputStep(FormStep):
     name = 'data_input'
 
     class Form(SteuerlotseBaseForm):
-        idnr = SteuerlotseStringField(label=_l('unlock-code-request.idnr'), validators=[InputRequired(), ValidIdNr()],
-                                      render_kw={'detail': {'title': _l('unlock-code-request.idnr.help-title'),
-                                                            'text': _l('unlock-code-request.idnr.help-text')}})
+        idnr = IdNrField(label=_l('unlock-code-request.idnr'), validators=[InputRequired(), ValidIdNr()],
+                         render_kw={'detail': {'title': _l('unlock-code-request.idnr.help-title'),
+                                               'text': _l('unlock-code-request.idnr.help-text')}})
         dob = SteuerlotseDateField(label=_l('unlock-code-request.dob'), validators=[InputRequired()])
         registration_confirm_data_privacy = ConfirmationField(
             label=_l('form.unlock-code-request.field_registration_confirm_data_privacy'))

--- a/webapp/app/forms/steps/unlock_code_revocation_steps.py
+++ b/webapp/app/forms/steps/unlock_code_revocation_steps.py
@@ -4,7 +4,7 @@ from flask_babel import lazy_gettext as _l
 from wtforms.validators import InputRequired
 
 from app.forms import SteuerlotseBaseForm
-from app.forms.fields import SteuerlotseDateField, SteuerlotseStringField
+from app.forms.fields import SteuerlotseDateField, SteuerlotseStringField, IdNrField
 from app.forms.steps.step import FormStep, DisplayStep
 from app.forms.validators import ValidIdNr
 
@@ -13,7 +13,7 @@ class UnlockCodeRevocationInputStep(FormStep):
     name = 'data_input'
 
     class Form(SteuerlotseBaseForm):
-        idnr = SteuerlotseStringField(_l('unlock-code-revocation.idnr'), [InputRequired(), ValidIdNr()])
+        idnr = IdNrField(_l('unlock-code-revocation.idnr'), [InputRequired(), ValidIdNr()])
         dob = SteuerlotseDateField(label=_l('unlock-code-revocation.dob'), validators=[InputRequired()])
 
     def __init__(self, **kwargs):

--- a/webapp/app/forms/validators.py
+++ b/webapp/app/forms/validators.py
@@ -63,6 +63,8 @@ class ValidIdNr:
         # if not is_valid(idnr_formatted):
         #     raise ValidationError(_('validate.invalid-idnr'))
 
+        # field.data is a list of strings
+        # It only gets concatenated if the validation succeeds (in post_validate() of the field).
         input_str = ''.join(field.data)
         # must contain only digits
         if not input_str.isdigit():

--- a/webapp/app/forms/validators.py
+++ b/webapp/app/forms/validators.py
@@ -63,9 +63,9 @@ class ValidIdNr:
         # if not is_valid(idnr_formatted):
         #     raise ValidationError(_('validate.invalid-idnr'))
 
-        input_str = str(field.data)
+        input_str = ''.join(field.data)
         # must contain only digits
-        if not field.data.isdigit():
+        if not input_str.isdigit():
             raise ValidationError(_('validate.invalid-idnr'))
         # must contain 11 digits
         if len(input_str) != 11:
@@ -84,7 +84,7 @@ class ValidIdNr:
         if not found_repeated_digit:
             raise ValidationError(_('validate.invalid-idnr'))
         # checksum has to be correct
-        if not is_valid(field.data):
+        if not is_valid(input_str):
             raise ValidationError(_('validate.invalid-idnr'))
 
 

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -688,12 +688,12 @@ footer a{
     justify-content: center;
 }
 
-.form-container > * {
+.form-container > .form-row-center, .form-container > .form-row {
     margin-top: var(--spacing-07);
 }
 
 @media (max-width: 1024px) {
-    .form-container > * {
+    .form-container > .form-row-center, .form-container > .form-row {
         margin-top: var(--spacing-06);
     }
 }

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -688,14 +688,13 @@ footer a{
     justify-content: center;
 }
 
-.form-container > .form-row-center, .form-container > .form-row {
-    margin-top: var(--spacing-07);
+.text-input-field-label {
+    padding-top: var(--spacing-06);
+    font-size: var(--text-lg);
 }
 
-@media (max-width: 1024px) {
-    .form-container > .form-row-center, .form-container > .form-row {
-        margin-top: var(--spacing-06);
-    }
+.nav-button-row {
+    margin-top: var(--spacing-06);
 }
 
 .form-row-center {
@@ -766,6 +765,7 @@ ul.reasons-success li.and {
 .simple-card {
     background-color: var(--bg-white);
     padding: var(--spacing-07);
+    margin-top: var(--spacing-06)
 }
 
 .simple-card .field-label{

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -522,8 +522,7 @@ input[type="radio"]:checked:focus + label::before{
 }
 
 .field-label{
-    margin-bottom: 0 !important;
-    font-size: var(--text-l);
+    margin-bottom: var(--spacing-01);
 }
 
 /* ALERTS */

--- a/webapp/app/templates/basis/base_step_form.html
+++ b/webapp/app/templates/basis/base_step_form.html
@@ -41,11 +41,7 @@
     <script src="{{ url_for('static', filename='js/jquery.mask.min.js') }}" type=text/javascript></script>
     <script>
         $(document).ready(function(){
-            const idnr_mask = '00000000000'
           $('.date_input').mask('00.00.0000');
-          $('#idnr').mask(idnr_mask);
-          $('#person_a_idnr').mask(idnr_mask);
-          $('#person_b_idnr').mask(idnr_mask);
         });
     </script>
 {% endblock %}

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -66,7 +66,7 @@
 
 {% macro separated_field(field) -%}
     <fieldset id="{{ field.id }}">
-        {{ field_label(field) }}
+        {{ field_label(field, class="text-input-field-label") }}
         <div class="form-row-center">
             {{ _field(field) }}
         </div>

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -79,7 +79,7 @@
     {%- set help = field.render_kw['help'] -%}
     {%- set detail = field.render_kw['detail'] -%}
 
-    {% if field.type == 'RadioField' or field.type == 'UnlockCodeField' %}
+    {% if field.type == 'RadioField' or field.type == 'UnlockCodeField' or field.type == 'IdNrField' %}
         {% if label.text %} {# Only show legend if there is a legend text to show #}
             <legend class="field-label {{ class }}">{{ label.text }}
                 {% if help %}{{ help_button(label.field_id) }}{% endif %}

--- a/webapp/app/templates/lotse/form_familienstand.html
+++ b/webapp/app/templates/lotse/form_familienstand.html
@@ -24,10 +24,10 @@
     <div id="familienstand_zusammenveranlagung_field" class="hidden">
         {{ macros.render_field(form.familienstand_zusammenveranlagung) }}
     </div>
-    <div id="familienstand_confirm_zusammenveranlagung_field" class="hidden">
+    <div id="familienstand_confirm_zusammenveranlagung_field" class="mt-5 hidden">
         {{ macros.render_field(form.familienstand_confirm_zusammenveranlagung, 10, hide_label=True) }}
     </div>
-    <div id="familienstand_zusammenveranlagung_clause" class="mb-3 font-weight-bold hidden">
+    <div id="familienstand_zusammenveranlagung_clause" class="mt-5 mb-3 font-weight-bold hidden">
         {{ _('form.lotse.familienstand.zusamenveranlagung-clause') }}
     </div>
 

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -54,7 +54,7 @@
         {{ _render_field(field, 12, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors) }}
     {% elif field.type == 'BooleanField' %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors) }}
-    {% elif field.type == 'RadioField' or field.type == 'UnlockCodeField' %}
+    {% elif field.type == 'RadioField' or field.type == 'UnlockCodeField' or field.type == 'IdNrField' %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=True) }}
     {% else %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=hide_label, hide_errors=hide_errors) }}
@@ -84,7 +84,7 @@
                 {{ components.checkbox(field, classes=classes) }}
             {% elif field.type == 'RadioField' %}
                 {{ components.radio_field(field) }}
-            {% elif field.type == 'UnlockCodeField' %}
+            {% elif field.type == 'UnlockCodeField' or field.type == 'IdNrField' %}
                 {{ components.separated_field(field) }}
             {% else %}
                 {% if field.errors %}

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -67,7 +67,11 @@
     {% endif %}
     <div class="col-md-{{ cols }} {% if as_card %} simple-card {% else %} px-0 {% endif %} {{ field_div_classes }}">
         {% if not hide_label and not (field.render_kw and 'hide_label' in field.render_kw and field.render_kw["hide_label"]) %}
-            {{ field_label(field) }}
+            {% if as_card %}
+                {{ field_label(field) }}
+            {% else %}
+                {{ field_label(field, class="text-input-field-label") }}
+            {% endif %}
         {% endif %}
 
         {% set classes = "form-control " + class %}
@@ -101,7 +105,7 @@
 {# ------------------------ #}
 
 {% macro form_nav_buttons(render_info, explanatory_button_text=None) -%}
-    <div class="form-row">
+    <div class="form-row nav-button-row">
         {% if render_info.overview_url %}
             <button type="submit"
                     class="btn btn-outline-primary mr-2"

--- a/webapp/app/templates/unlock_code/registration_data_input.html
+++ b/webapp/app/templates/unlock_code/registration_data_input.html
@@ -2,10 +2,10 @@
 {% import 'components.html' as components %}
 
 {% block form_content %}
-    <div class="form-row-center mt-3">
+    <div class="form-row-center">
         {{ macros.render_field(form.dob) }}
     </div>
-    <div class="form-row-center mt-3">
+    <div class="form-row-center">
         {{ macros.render_field(form.idnr) }}
     </div>
 

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -650,7 +650,7 @@ msgstr ""
 
 #: app/forms/steps/unlock_code_revocation_steps.py:16
 msgid "unlock-code-revocation.idnr"
-msgstr "Steueridentifikationnummer"
+msgstr "Steueridentifikationsnummer"
 
 #: app/forms/steps/unlock_code_revocation_steps.py:17
 msgid "unlock-code-revocation.dob"

--- a/webapp/tests/forms/test_fields.py
+++ b/webapp/tests/forms/test_fields.py
@@ -1,0 +1,99 @@
+import unittest
+
+from werkzeug.datastructures import MultiDict
+
+from app.forms import SteuerlotseBaseForm
+from app.forms.fields import IdNrField
+from app.forms.validators import ValidIdNr
+
+
+class IdNrForm(SteuerlotseBaseForm):
+    idnr_field = IdNrField(validators=[ValidIdNr()])
+
+
+class TestIdNrFieldData(unittest.TestCase):
+    def setUp(self):
+        self.form = IdNrForm()
+
+    def test_if_no_data_and_no_formdata_given_then_return_none(self):
+        """ Simulates a GET request without prefilled data."""
+        self.form.process()
+        self.assertEqual(None, self.form.idnr_field.data)
+
+    def test_if_data_given_and_no_formdata_then_store_data_as_is(self):
+        """ Simulates a GET request with prefilled data."""
+        prefilled_idnr = '02259674819'
+        self.form.process(data={'idnr_field': prefilled_idnr})
+        self.assertEqual(prefilled_idnr, self.form.idnr_field.data)
+
+    def test_if_no_data_given_and_invalid_formdata_then_store_form_data_as_is(self):
+        """ Simulates a POST request with invalid formdata and no prefilled data."""
+        wrong_idnr_input = ['02', '259', '67', '819']
+        self.form.process(formdata=MultiDict({'idnr_field': wrong_idnr_input}))
+        self.form.validate()
+        self.assertEqual(wrong_idnr_input, self.form.idnr_field.data)
+
+    def test_if_no_data_given_and_valid_formdata_then_store_form_data_as_string(self):
+        """ Simulates a POST request with valid formdata and no prefilled data."""
+        correct_idnr_input = ['02', '259', '674', '819']
+        self.form.process(formdata=MultiDict({'idnr_field': correct_idnr_input}))
+        self.form.validate()
+        self.assertEqual('02259674819', self.form.idnr_field.data)
+
+    def test_if_data_given_and_invalid_formdata_then_store_form_data_as_is(self):
+        """ Simulates a POST request with invalid formdata and prefilled data."""
+        wrong_idnr_input = ['02', '259', '67', '819']
+        self.form.process(formdata=MultiDict({'idnr_field': wrong_idnr_input}), data={'idnr_field': '04452397687'})
+        self.form.validate()
+        self.assertEqual(wrong_idnr_input, self.form.idnr_field.data)
+
+    def test_if_data_given_and_valid_formdata_then_store_form_data_as_string(self):
+        """ Simulates a POST request with valid formdata and prefilled data."""
+        correct_idnr_input = ['02', '259', '674', '819']
+        self.form.process(formdata=MultiDict({'idnr_field': correct_idnr_input}), data={'idnr_field': '04452397687'})
+        self.form.validate()
+        self.assertEqual('02259674819', self.form.idnr_field.data)
+
+
+class TestIdNrFieldValue(unittest.TestCase):
+    def setUp(self):
+        self.form = IdNrForm()
+
+    def test_if_no_data_and_no_formdata_given_then_value_equals_empty_list(self):
+        """ Simulates a GET request without prefilled data."""
+        self.form.process()
+        self.assertEqual([], self.form.idnr_field._value())
+
+    def test_if_data_given_and_no_formdata_then_value_equals_list_of_data(self):
+        """ Simulates a GET request with prefilled data."""
+        prefilled_idnr = '02259674819'
+        self.form.process(data={'idnr_field': prefilled_idnr})
+        self.assertEqual(['02', '259', '674', '819'], self.form.idnr_field._value())
+
+    def test_if_no_data_given_and_invalid_formdata_then_value_equals_formdata_as_is(self):
+        """ Simulates a POST request with invalid formdata and no prefilled data."""
+        wrong_idnr_input = ['02', '259', '67', '819']
+        self.form.process(formdata=MultiDict({'idnr_field': wrong_idnr_input}))
+        self.form.validate()
+        self.assertEqual(wrong_idnr_input, self.form.idnr_field._value())
+
+    def test_if_no_data_given_and_valid_formdata_then_value_equals_formdata_as_is(self):
+        """ Simulates a POST request with valid formdata and no prefilled data."""
+        correct_idnr_input = ['02', '259', '674', '819']
+        self.form.process(formdata=MultiDict({'idnr_field': correct_idnr_input}))
+        self.form.validate()
+        self.assertEqual(correct_idnr_input, self.form.idnr_field._value())
+
+    def test_if_data_given_and_invalid_formdata_then_value_equals_formdata_as_is(self):
+        """ Simulates a POST request with invalid formdata and prefilled data."""
+        wrong_idnr_input = ['02', '259', '67', '819']
+        self.form.process(formdata=MultiDict({'idnr_field': wrong_idnr_input}), data={'idnr_field': '04452397687'})
+        self.form.validate()
+        self.assertEqual(wrong_idnr_input, self.form.idnr_field._value())
+
+    def test_if_data_given_and_valid_formdata_then_value_equals_form_data_as_is(self):
+        """ Simulates a POST request with valid formdata and prefilled data."""
+        correct_idnr_input = ['02', '259', '674', '819']
+        self.form.process(formdata=MultiDict({'idnr_field': correct_idnr_input}), data={'idnr_field': '04452397687'})
+        self.form.validate()
+        self.assertEqual(correct_idnr_input, self.form.idnr_field._value())


### PR DESCRIPTION
# Short Description
- This splits the input field of the idnr into four parts

# Changes
- Make the IdNrField
- Remove details/help where not necessary (person a and person b)
- Fix the appearance of form spacing. (previously, I matched too many elements, including all headings etc when I only wanted form-rows to be matched.)

# Feedback
- I am still talking to Nadine whether or not the implementation of the idnr input is okay (you input one digit into every field, click submit -> they appear in pairs of two in the first two fields. Do you have another intuition on how we could possibly avoid this? (I thought about adding separating characters as with the entries field, it just fields awkward to me to store the idnr as a list and I guess this would also change a lot in the code and we'd have to be very careful. Do you have an opinion/idea?
