### PR TITLE
Fix double arrow on select field

### DIFF
--- a/webapp/app/templates/lotse/form_person_b.html
+++ b/webapp/app/templates/lotse/form_person_b.html
@@ -38,7 +38,7 @@
 
   <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-religion') }}</h2>
   <div class="form-row-center">
-    {{ macros.render_field(form.person_b_religion, 6, class=" custom-select") }}
+    {{ macros.render_field(form.person_b_religion, 6) }}
   </div>
 
   <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-beh') }}</h2>


### PR DESCRIPTION
# Short Description
- Previously, sometimes on the person_b page, there were two arrows on the religion dropdown
- I could reproduce it by narrowing the screen size, have default data turned off and navigate to person B step through the normal flow.

# Changes
- The class `custom-select` was set in the person_b template *and* in the field construction and they were connected without space -> no class was actually added -> I removed the class in the person_b template

# Feedback
- Does this fix the error for you, too?
