### PR TITLE
Separate date input

### DIFF
--- a/acceptance_tests/cypress/integration/lotse_flow.spec.js
+++ b/acceptance_tests/cypress/integration/lotse_flow.spec.js
@@ -5,7 +5,9 @@ Cypress.config('baseUrl', `https://lotse:${authPassword}@www-staging.stl.ds4g.de
 
 const unlockCodeData = {
     idnr: '09531672807',
-    dob: '22.12.1972',
+    dobDay: '22',
+    dobMonth: '12',
+    dobYear: '1972'
 }
 
 const taxReturnData = {
@@ -13,11 +15,15 @@ const taxReturnData = {
     unlockCode2: 'B8JS',
     unlockCode3: '9JE7',
     taxNr: '19811310010',
-    marriedDate: '01.01.1990',
+    marriedDateDay: '01',
+    marriedDateMonth: '01',
+    marriedDateYear: '1990',
     iban: 'DE02500105170137075030',
     personA: {
         idnr: '04452397687',
-        dob: '01.01.1990',
+        dobDay: '01',
+        dobMonth: '01',
+        dobYear: '1990',
         firstName: 'Erika',
         lastName: 'Musterfrau',
         street: 'Musterstr.',
@@ -30,7 +36,9 @@ const taxReturnData = {
     },
     personB: {
         idnr: '02293417683',
-        dob: '25.02.1951',
+        dobDay: '25',
+        dobMonth: '2',
+        dobYear: '1951',
         firstName: 'Gerta',
         lastName: 'Mustername',
         street: 'Musterstr.',
@@ -87,9 +95,15 @@ const taxReturnData = {
     }
 }
 
-const older_date = '31.12.2019'
-const recent_date = '01.01.2020'
-const one_day_into_the_tax_year = '02.01.2020'
+const older_date_day = '31'
+const older_date_month = '12'
+const older_date_year = '2019'
+const recent_date_day = '01'
+const recent_date_month = '01'
+const recent_date_year = '2020'
+const one_day_into_the_tax_year_day = '02'
+const one_day_into_the_tax_year_month = '01'
+const one_day_into_the_tax_year_year = '2020'
 
 const submitBtnSelector = '[name="next_button"]'
 const overviewBtnSelector = '[name="overview_button"]'
@@ -139,21 +153,29 @@ context('Acceptance tests', () => {
 
             // Married
             cy.get('#familienstand-1').check()
-            cy.get('#familienstand_date').clear().type(older_date)
+            cy.get('#familienstand_date_1').clear().type(older_date_day)
+            cy.get('#familienstand_date_2').clear().type(older_date_month)
+            cy.get('#familienstand_date_3').clear().type(older_date_year)
             cy.get('label[for=familienstand_married_lived_separated-no]').click()
             cy.get('label[for=familienstand_confirm_zusammenveranlagung]').should('be.visible')
 
             cy.get('label[for=familienstand_married_lived_separated-yes]').click()
-            cy.get('#familienstand_married_lived_separated_since').clear().type(older_date)
+            cy.get('#familienstand_married_lived_separated_since_1').clear().type(older_date_day)
+            cy.get('#familienstand_married_lived_separated_since_2').clear().type(older_date_month)
+            cy.get('#familienstand_married_lived_separated_since_3').clear().type(older_date_year)
             cy.get('div[id=familienstand_zusammenveranlagung_field]').should('not.be.visible')
 
             cy.get('label[for=familienstand_married_lived_separated-yes]').click()
-            cy.get('#familienstand_married_lived_separated_since').clear().type(one_day_into_the_tax_year)
+            cy.get('#familienstand_married_lived_separated_since_1').clear().type(one_day_into_the_tax_year_day)
+            cy.get('#familienstand_married_lived_separated_since_2').clear().type(one_day_into_the_tax_year_month)
+            cy.get('#familienstand_married_lived_separated_since_3').clear().type(one_day_into_the_tax_year_year)
             cy.get('div[id=familienstand_zusammenveranlagung_field]').should('be.visible')
 
             // Married -> different -> married
             cy.get('#familienstand-1').check()
-            cy.get('#familienstand_date').clear().type(older_date)
+            cy.get('#familienstand_date_1').clear().type(older_date_day)
+            cy.get('#familienstand_date_2').clear().type(older_date_month)
+            cy.get('#familienstand_date_3').clear().type(older_date_year)
             cy.get('label[for=familienstand_married_lived_separated-no]').click()
             cy.get('div[id=familienstand_confirm_zusammenveranlagung_field]').should('be.visible')
             cy.get('label[for=familienstand_confirm_zusammenveranlagung]').first().click()
@@ -167,24 +189,34 @@ context('Acceptance tests', () => {
 
             // Widowed
             cy.get('#familienstand-2').check()
-            cy.get('#familienstand_date').clear().type(older_date)
+            cy.get('#familienstand_date_1').clear().type(older_date_day)
+            cy.get('#familienstand_date_2').clear().type(older_date_month)
+            cy.get('#familienstand_date_3').clear().type(older_date_year)
             cy.get('#familienstand_widowed_lived_separated').should('not.be.visible')
 
-            cy.get('#familienstand_date').clear().type(recent_date)
+            cy.get('#familienstand_date_1').clear().type(recent_date_day)
+            cy.get('#familienstand_date_2').clear().type(recent_date_month)
+            cy.get('#familienstand_date_3').clear().type(recent_date_year)
             cy.get('label[for=familienstand_widowed_lived_separated-no]').click()
             cy.get('label[for=familienstand_confirm_zusammenveranlagung]').first().click()
 
             cy.get('label[for=familienstand_widowed_lived_separated-yes]').click()
-            cy.get('#familienstand_widowed_lived_separated_since').clear().type(older_date)
+            cy.get('#familienstand_widowed_lived_separated_since_1').clear().type(older_date_day)
+            cy.get('#familienstand_widowed_lived_separated_since_2').clear().type(older_date_month)
+            cy.get('#familienstand_widowed_lived_separated_since_3').clear().type(older_date_year)
             cy.get('div[id=familienstand_zusammenveranlagung_field]').should('not.be.visible')
 
             cy.get('label[for=familienstand_widowed_lived_separated-yes]').click()
-            cy.get('#familienstand_widowed_lived_separated_since').clear().type(one_day_into_the_tax_year)
+            cy.get('#familienstand_widowed_lived_separated_since_1').clear().type(one_day_into_the_tax_year_day)
+            cy.get('#familienstand_widowed_lived_separated_since_2').clear().type(one_day_into_the_tax_year_month)
+            cy.get('#familienstand_widowed_lived_separated_since_3').clear().type(one_day_into_the_tax_year_year)
             cy.get('div[id=familienstand_zusammenveranlagung_field]').should('be.visible')
 
             // Divorced
             cy.get('#familienstand-3').check()
-            cy.get('#familienstand_date').clear().type(older_date)
+            cy.get('#familienstand_date_1').clear().type(older_date_day)
+            cy.get('#familienstand_date_2').clear().type(older_date_month)
+            cy.get('#familienstand_date_3').clear().type(older_date_year)
             cy.get('div[id=familienstand_zusammenveranlagung_field]').should('not.be.visible')
         })
 
@@ -206,7 +238,9 @@ context('Acceptance tests', () => {
                 cy.get('#steuernummer').type(taxReturnData.taxNr)
                 cy.get(submitBtnSelector).click()
                 cy.get('#person_a_idnr').type(taxReturnData.personA.idnr)
-                cy.get('#person_a_dob').type(taxReturnData.personA.dob)
+                cy.get('#person_a_dob_1').clear().type(taxReturnData.personA.dobDay)
+                cy.get('#person_a_dob_2').clear().type(taxReturnData.personA.dobMonth)
+                cy.get('#person_a_dob_3').type(taxReturnData.personA.dobYear)
                 cy.get('#person_a_first_name').type(taxReturnData.personA.firstName)
                 cy.get('#person_a_last_name').type(taxReturnData.personA.lastName)
                 cy.get('#person_a_street').type(taxReturnData.personA.street)
@@ -241,7 +275,9 @@ context('Acceptance tests', () => {
             it('for a married couple with deductions', () => {
                 // Step 2
                 cy.get('#familienstand-1').check()
-                cy.get('#familienstand_date').type(taxReturnData.marriedDate)
+                cy.get('#familienstand_date_1').type(taxReturnData.marriedDateDay)
+                cy.get('#familienstand_date_2').type(taxReturnData.marriedDateMonth)
+                cy.get('#familienstand_date_3').type(taxReturnData.marriedDateYear)
                 cy.get('label[for=familienstand_married_lived_separated-no]').click()
                 cy.get('label[for=familienstand_confirm_zusammenveranlagung]').first().click()
                 cy.get(submitBtnSelector).click()
@@ -249,7 +285,9 @@ context('Acceptance tests', () => {
                 cy.get('#steuernummer').type(taxReturnData.taxNr)
                 cy.get(submitBtnSelector).click()
                 cy.get('#person_a_idnr').type(taxReturnData.personA.idnr)
-                cy.get('#person_a_dob').type(taxReturnData.personA.dob)
+                cy.get('#person_a_dob_1').type(taxReturnData.personA.dobDay)
+                cy.get('#person_a_dob_2').type(taxReturnData.personA.dobMonth)
+                cy.get('#person_a_dob_3').type(taxReturnData.personA.dobYear)
                 cy.get('#person_a_first_name').type(taxReturnData.personA.firstName)
                 cy.get('#person_a_last_name').type(taxReturnData.personA.lastName)
                 cy.get('#person_a_street').type(taxReturnData.personA.street)
@@ -263,7 +301,9 @@ context('Acceptance tests', () => {
                 cy.get('label[for=person_a_gehbeh]').first().click()
                 cy.get(submitBtnSelector).click()
                 cy.get('#person_b_idnr').type(taxReturnData.personB.idnr)
-                cy.get('#person_b_dob').type(taxReturnData.personB.dob)
+                cy.get('#person_b_dob_1').type(taxReturnData.personB.dobDay)
+                cy.get('#person_b_dob_2').type(taxReturnData.personB.dobMonth)
+                cy.get('#person_b_dob_3').type(taxReturnData.personB.dobYear)
                 cy.get('#person_b_first_name').type(taxReturnData.personB.firstName)
                 cy.get('#person_b_last_name').type(taxReturnData.personB.lastName)
                 cy.get('#person_b_same_address-1').click()
@@ -372,7 +412,9 @@ context('Acceptance tests', () => {
             // Set relationship widowed older -> Redirect person_b
             cy.visit('/lotse/step/familienstand')
             cy.get('#familienstand-2').check()
-            cy.get('#familienstand_date').clear().type(older_date)
+            cy.get('#familienstand_date_1').clear().type(older_date_day)
+            cy.get('#familienstand_date_2').clear().type(older_date_month)
+            cy.get('#familienstand_date_3').clear().type(older_date_year)
             cy.get(submitBtnSelector).click()
             cy.visit('/lotse/step/person_b?link_overview=True')
             cy.location().should((loc) => {
@@ -382,7 +424,9 @@ context('Acceptance tests', () => {
             // Set relationship widowed recent + zusammenveranlagung yes -> No redirect person_b
             cy.visit('/lotse/step/familienstand')
             cy.get('#familienstand-2').check()
-            cy.get('#familienstand_date').clear().type(recent_date)
+            cy.get('#familienstand_date_1').clear().type(recent_date_day)
+            cy.get('#familienstand_date_2').clear().type(recent_date_month)
+            cy.get('#familienstand_date_3').clear().type(recent_date_year)
             cy.get('label[for=familienstand_widowed_lived_separated-no]').click()
             cy.get('label[for=familienstand_confirm_zusammenveranlagung]').first().click()
             cy.get(submitBtnSelector).click()
@@ -394,7 +438,9 @@ context('Acceptance tests', () => {
             // Set relationship divorced -> Redirect person_b
             cy.visit('/lotse/step/familienstand')
             cy.get('#familienstand-3').check()
-            cy.get('#familienstand_date').clear().type(recent_date)
+            cy.get('#familienstand_date_1').clear().type(recent_date_day)
+            cy.get('#familienstand_date_2').clear().type(recent_date_month)
+            cy.get('#familienstand_date_3').clear().type(recent_date_year)
             cy.get(submitBtnSelector).click()
             cy.visit('/lotse/step/person_b?link_overview=True')
             cy.location().should((loc) => {
@@ -402,7 +448,9 @@ context('Acceptance tests', () => {
             });
             cy.visit('/lotse/step/familienstand')
             cy.get('#familienstand-3').check()
-            cy.get('#familienstand_date').clear().type(older_date)
+            cy.get('#familienstand_date_1').clear().type(older_date_day)
+            cy.get('#familienstand_date_2').clear().type(older_date_month)
+            cy.get('#familienstand_date_3').clear().type(older_date_year)
             cy.get(submitBtnSelector).click()
             cy.visit('/lotse/step/person_b?link_overview=True')
             cy.location().should((loc) => {
@@ -412,9 +460,13 @@ context('Acceptance tests', () => {
             // Set relationship married + separated + zusammenveranlagung-> No redirect person_b
             cy.visit('/lotse/step/familienstand')
             cy.get('#familienstand-1').check()
-            cy.get('#familienstand_date').type(taxReturnData.marriedDate)
+            cy.get('#familienstand_date_1').clear().type(taxReturnData.marriedDateDay)
+            cy.get('#familienstand_date_2').clear().type(taxReturnData.marriedDateMonth)
+            cy.get('#familienstand_date_3').clear().type(taxReturnData.marriedDateYear)
             cy.get('label[for=familienstand_married_lived_separated-yes]').click()
-            cy.get('#familienstand_married_lived_separated_since').clear().type(one_day_into_the_tax_year)
+            cy.get('#familienstand_married_lived_separated_since_1').clear().type(one_day_into_the_tax_year_day)
+            cy.get('#familienstand_married_lived_separated_since_2').clear().type(one_day_into_the_tax_year_month)
+            cy.get('#familienstand_married_lived_separated_since_3').clear().type(one_day_into_the_tax_year_year)
             cy.get('label[for=familienstand_zusammenveranlagung-yes]').click()
             cy.get(submitBtnSelector).click()
             cy.visit('/lotse/step/person_b?link_overview=True')
@@ -425,9 +477,13 @@ context('Acceptance tests', () => {
             // Set relationship married + separated + no zusammenveranlagung-> Redirect person_b
             cy.visit('/lotse/step/familienstand')
             cy.get('#familienstand-1').check()
-            cy.get('#familienstand_date').type(taxReturnData.marriedDate)
+            cy.get('#familienstand_date_1').clear().type(taxReturnData.marriedDateDay)
+            cy.get('#familienstand_date_2').clear().type(taxReturnData.marriedDateMonth)
+            cy.get('#familienstand_date_3').clear().type(taxReturnData.marriedDateYear)
             cy.get('label[for=familienstand_married_lived_separated-yes]').click()
-            cy.get('#familienstand_married_lived_separated_since').clear().type(one_day_into_the_tax_year)
+            cy.get('#familienstand_married_lived_separated_since_1').clear().type(one_day_into_the_tax_year_day)
+            cy.get('#familienstand_married_lived_separated_since_2').clear().type(one_day_into_the_tax_year_month)
+            cy.get('#familienstand_married_lived_separated_since_3').clear().type(one_day_into_the_tax_year_year)
             cy.get('label[for=familienstand_zusammenveranlagung-no]').click()
             cy.get(submitBtnSelector).click()
             cy.visit('/lotse/step/person_b?link_overview=True')
@@ -505,7 +561,9 @@ context('Acceptance tests', () => {
             // Set familienstand divorced
             cy.visit('/lotse/step/familienstand')
             cy.get('#familienstand-3').check()
-            cy.get('#familienstand_date').clear().type(taxReturnData.marriedDate)
+            cy.get('#familienstand_date_1').clear().type(taxReturnData.marriedDateDay)
+            cy.get('#familienstand_date_2').clear().type(taxReturnData.marriedDateMonth)
+            cy.get('#familienstand_date_3').clear().type(taxReturnData.marriedDateYear)
             cy.get(submitBtnSelector).click()
 
             // Redirect gem_haushalt

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -84,12 +84,9 @@ class SteuerlotseDateField(DateField):
         kwargs.setdefault('format', "%d %m %Y")
 
         if kwargs.get('render_kw'):
-            if kwargs['render_kw'].get('class'):
-                kwargs['render_kw']['class'] = kwargs['render_kw']['class'] + " date_input form-control"
-            else:
-                kwargs['render_kw']['class'] = "date_input form-control"
-            if 'example_input' not in kwargs['render_kw']:
-                kwargs['render_kw']['example_input'] = _('fields.date_field.example_input.text')
+            kwargs['render_kw']['class'] = kwargs['render_kw'].get('class', '') + " date_input form-control"
+            kwargs['render_kw']['example_input'] = kwargs['render_kw'].get('example_input',
+                                                                           _('fields.date_field.example_input.text'))
         else:
             kwargs['render_kw'] = {'class': "date_input form-control",
                                    'example_input': _('fields.date_field.example_input.text')}

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -100,7 +100,7 @@ class SteuerlotseDateField(DateField):
         if self.data:
             return [self.data.day, self.data.month, self.data.year]
         else:
-            return self.raw_data if self.raw_data else ''
+            return self.raw_data if self.raw_data else []
 
 
 class EuroFieldWidget(TextInput):

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -63,6 +63,36 @@ class UnlockCodeField(SteuerlotseStringField):
         return self.data.split('-') if self.data else ''
 
 
+class SteuerlotseDateWidget(MultipleInputFieldWidget):
+    separator = ''
+    input_field_lengths = [2, 2, 4]
+
+
+class SteuerlotseDateField(DateField):
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault('format', "%d %m %Y")
+
+        if kwargs.get('render_kw'):
+            if kwargs['render_kw'].get('class'):
+                kwargs['render_kw']['class'] = kwargs['render_kw']['class'] + " date_input form-control"
+            else:
+                kwargs['render_kw']['class'] = "date_input form-control"
+            if 'example_input' not in kwargs['render_kw']:
+                kwargs['render_kw']['example_input'] = _('fields.date_field.example_input.text')
+        else:
+            kwargs['render_kw'] = {'class': "date_input form-control",
+                                   'example_input': _('fields.date_field.example_input.text')}
+        super(SteuerlotseDateField, self).__init__(**kwargs)
+        self.widget = SteuerlotseDateWidget()
+
+    def _value(self):
+        if self.data:
+            return [self.data.day, self.data.month, self.data.year]
+        else:
+            return self.raw_data if self.raw_data else ''
+
+
 class EuroFieldWidget(TextInput):
     """A simple Euro widget that uses Bootstrap features for nice looks."""
 
@@ -119,26 +149,6 @@ class SteuerlotseSelectField(SelectField):
         else:
             kwargs['render_kw'] = {'class': "custom-select steuerlotse-select"}
         super(SteuerlotseSelectField, self).__init__(**kwargs)
-
-
-class SteuerlotseDateField(DateField):
-
-    def __init__(self, **kwargs):
-        if not kwargs.get('format'):
-            kwargs['format'] = "%d.%m.%Y"
-
-        if kwargs.get('render_kw'):
-            if kwargs['render_kw'].get('class'):
-                kwargs['render_kw']['class'] = kwargs['render_kw']['class'] + " date_input form-control"
-            else:
-                kwargs['render_kw']['class'] = "date_input form-control"
-            if 'example_input' not in kwargs['render_kw']:
-                kwargs['render_kw']['example_input'] = _('fields.date_field.example_input.text')
-        else:
-            kwargs['render_kw'] = {'class': "date_input form-control",
-                                   'example_input': _('fields.date_field.example_input.text')}
-        super(SteuerlotseDateField, self).__init__(**kwargs)
-
 
 class ConfirmationField(BooleanField):
     """A CheckBox that will not validate unless checked."""

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -9,6 +9,7 @@ from wtforms.validators import InputRequired
 from wtforms.widgets.core import TextInput, Markup, html_params
 
 from flask_babel import _
+from flask_babel import lazy_gettext as _l
 from babel.numbers import format_decimal, parse_decimal
 
 from app.forms.validators import ValidElsterCharacterSet
@@ -75,7 +76,7 @@ class UnlockCodeField(SteuerlotseStringField):
 class SteuerlotseDateWidget(MultipleInputFieldWidget):
     separator = ''
     input_field_lengths = [2, 2, 4]
-    input_field_labels = [_('date-field.day'), _('date-field-month'), _('date-field-year')]
+    input_field_labels = [_l('date-field.day'), _l('date-field.month'), _l('date-field.year')]
 
 
 class SteuerlotseDateField(DateField):

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -23,6 +23,7 @@ class MultipleInputFieldWidget(TextInput):
     """A divided input field."""
     separator = ''
     input_field_lengths = []
+    input_field_labels = []
 
     def __call__(self, field, **kwargs):
         if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
@@ -33,9 +34,17 @@ class MultipleInputFieldWidget(TextInput):
         for idx, input_field_length in enumerate(self.input_field_lengths):
             kwargs['maxlength'] = input_field_length
 
+            sub_field_id = f'{field.id}_{idx + 1}'
             kwargs['value'] = field._value()[idx] if len(field._value()) >= idx + 1 else ''
-            kwargs['id'] = f'{field.id}_{idx + 1}'
-            joined_input_fields += (super(MultipleInputFieldWidget, self).__call__(field, **kwargs))
+            kwargs['id'] = sub_field_id
+            if len(self.input_field_labels) > idx:
+                joined_input_fields += Markup(
+                    f'<div>'
+                    f'<label for="{sub_field_id}" class="sub-field-label">{self.input_field_labels[idx]}</label>')
+                joined_input_fields += (super(MultipleInputFieldWidget, self).__call__(field, **kwargs))
+                joined_input_fields += Markup('</div>')
+            else:
+                joined_input_fields += (super(MultipleInputFieldWidget, self).__call__(field, **kwargs))
             if self.separator and idx < len(self.input_field_lengths) - 1:
                 joined_input_fields += Markup(self.separator)
 
@@ -66,6 +75,7 @@ class UnlockCodeField(SteuerlotseStringField):
 class SteuerlotseDateWidget(MultipleInputFieldWidget):
     separator = ''
     input_field_lengths = [2, 2, 4]
+    input_field_labels = [_('date-field.day'), _('date-field-month'), _('date-field-year')]
 
 
 class SteuerlotseDateField(DateField):

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -526,6 +526,12 @@ input[type="radio"]:checked:focus + label::before{
     font-size: var(--text-l);
 }
 
+.sub-field-label {
+    margin-bottom: 0 !important;
+    font-size: var(--text-sm);
+    font-weight: var(--font-bold);
+}
+
 /* ALERTS */
 .alert-success{
     color: var(--inverse-text-color);

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -79,7 +79,7 @@
     {%- set help = field.render_kw['help'] -%}
     {%- set detail = field.render_kw['detail'] -%}
 
-    {% if field.type == 'RadioField' or field.type == 'UnlockCodeField' %}
+    {% if field.type == 'RadioField' or field.type == 'UnlockCodeField' or field.type == 'SteuerlotseDateField'%}
         {% if label.text %} {# Only show legend if there is a legend text to show #}
             <legend class="field-label {{ class }}">{{ label.text }}
                 {% if help %}{{ help_button(label.field_id) }}{% endif %}

--- a/webapp/app/templates/lotse/form_familienstand.html
+++ b/webapp/app/templates/lotse/form_familienstand.html
@@ -38,16 +38,18 @@
     <script>
         const FIRST_DAY_OF_TAX_PERIOD = new Date(2020, 0, 1)
 
-        function convertStringToDate(date) {
-            const parts = date.split('.');
-            return new Date(parts[2], parts[1] - 1, parts[0]);
+        function convertStringToDate(day, month, year) {
+            return new Date(year, month - 1, day);
         }
 
         function has_relationship_changed_last_year(selector, including_first_day=true) {
+            const inputted_date = convertStringToDate(document.querySelector(selector + '_1').value,
+                document.querySelector(selector + '_2').value,
+                document.querySelector(selector + '_3').value)
             if (including_first_day) {
-                return convertStringToDate(document.querySelector(selector).value) >= FIRST_DAY_OF_TAX_PERIOD
+                return inputted_date >= FIRST_DAY_OF_TAX_PERIOD
             } else {
-                return convertStringToDate(document.querySelector(selector).value) > FIRST_DAY_OF_TAX_PERIOD
+                return inputted_date > FIRST_DAY_OF_TAX_PERIOD
             }
         }
 

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -54,7 +54,7 @@
         {{ _render_field(field, 12, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors) }}
     {% elif field.type == 'BooleanField' %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors) }}
-    {% elif field.type == 'RadioField' or field.type == 'UnlockCodeField' %}
+    {% elif field.type == 'RadioField' or field.type == 'UnlockCodeField' or field.type == 'SteuerlotseDateField' %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=True) }}
     {% else %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=hide_label, hide_errors=hide_errors) }}
@@ -84,7 +84,7 @@
                 {{ components.checkbox(field, classes=classes) }}
             {% elif field.type == 'RadioField' %}
                 {{ components.radio_field(field) }}
-            {% elif field.type == 'UnlockCodeField' %}
+            {% elif field.type == 'UnlockCodeField' or field.type == 'SteuerlotseDateField' %}
                 {{ components.separated_field(field) }}
             {% else %}
                 {% if field.errors %}

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-07-22 17:46+0200\n"
+"POT-Creation-Date: 2021-07-27 14:09+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -139,34 +139,34 @@ msgid "date-field.day"
 msgstr "Tag"
 
 #: app/forms/fields.py:78
-msgid "date-field-month"
+msgid "date-field.month"
 msgstr "Monat"
 
 #: app/forms/fields.py:78
-msgid "date-field-year"
+msgid "date-field.year"
 msgstr "Jahr"
 
-#: app/forms/fields.py:92 app/forms/fields.py:95
+#: app/forms/fields.py:89 app/forms/fields.py:92
 msgid "fields.date_field.example_input.text"
 msgstr "z.B. 31.06.1951"
 
-#: app/forms/fields.py:136
+#: app/forms/fields.py:133
 msgid "fields.euro_field.example_input.text"
 msgstr "z.B. 343,20"
 
-#: app/forms/fields.py:167
+#: app/forms/fields.py:164
 msgid "confirmation_field_must_be_set"
 msgstr "Sie müssen dieses Feld auswählen, um weiter zu machen."
 
-#: app/forms/fields.py:186
+#: app/forms/fields.py:183
 msgid "jquery_entries.add"
 msgstr "Weiteren Eintrag hinzufügen"
 
-#: app/forms/fields.py:249
+#: app/forms/fields.py:246
 msgid "switch.yes"
 msgstr "Ja"
 
-#: app/forms/fields.py:249
+#: app/forms/fields.py:246
 msgid "switch.no"
 msgstr "Nein"
 

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-07-19 18:16+0200\n"
+"POT-Creation-Date: 2021-07-21 11:38+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -134,27 +134,39 @@ msgstr ""
 "Bitte prüfen Sie Ihre Angaben. Es sind nicht alle notwendigen "
 "Formularfelder ausgefüllt."
 
-#: app/forms/fields.py:90
-msgid "fields.euro_field.example_input.text"
-msgstr "z.B. 343,20"
+#: app/forms/fields.py:78
+msgid "date-field.day"
+msgstr "Tag"
 
-#: app/forms/fields.py:130 app/forms/fields.py:133
+#: app/forms/fields.py:78
+msgid "date-field-month"
+msgstr "Monat"
+
+#: app/forms/fields.py:78
+msgid "date-field-year"
+msgstr "Jahr"
+
+#: app/forms/fields.py:92 app/forms/fields.py:95
 msgid "fields.date_field.example_input.text"
 msgstr "z.B. 31.06.1951"
 
-#: app/forms/fields.py:141
+#: app/forms/fields.py:136
+msgid "fields.euro_field.example_input.text"
+msgstr "z.B. 343,20"
+
+#: app/forms/fields.py:167
 msgid "confirmation_field_must_be_set"
 msgstr "Sie müssen dieses Feld auswählen, um weiter zu machen."
 
-#: app/forms/fields.py:160
+#: app/forms/fields.py:186
 msgid "jquery_entries.add"
 msgstr "Weiteren Eintrag hinzufügen"
 
-#: app/forms/fields.py:223
+#: app/forms/fields.py:249
 msgid "switch.yes"
 msgstr "Ja"
 
-#: app/forms/fields.py:223
+#: app/forms/fields.py:249
 msgid "switch.no"
 msgstr "Nein"
 
@@ -2306,15 +2318,15 @@ msgstr ""
 msgid "form.lotse.summary-button-edit"
 msgstr "Ändern"
 
-#: app/templates/components.html:97
+#: app/templates/components.html:107
 msgid "errors.warning-image.aria-label"
 msgstr "Fehlermeldung"
 
-#: app/templates/components.html:208
+#: app/templates/components.html:217
 msgid "button.help"
 msgstr "Weitere Informationen"
 
-#: app/templates/components.html:217
+#: app/templates/components.html:226
 msgid "button.close.aria-label"
 msgstr "Schließen"
 
@@ -2322,11 +2334,11 @@ msgstr "Schließen"
 msgid "form.back"
 msgstr "Zurück"
 
-#: app/templates/macros.html:106 app/templates/macros.html:124
+#: app/templates/macros.html:108 app/templates/macros.html:126
 msgid "form.back_to_overview"
 msgstr "Zurück zur Übersicht"
 
-#: app/templates/macros.html:112 app/templates/macros.html:131
+#: app/templates/macros.html:114 app/templates/macros.html:133
 msgid "form.next"
 msgstr "Weiter"
 
@@ -4364,42 +4376,42 @@ msgstr ""
 msgid "landing.interviews-link"
 msgstr "Mehr erfahren"
 
-#: app/templates/eligibility/display_failure.html:8
+#: app/templates/eligibility/display_failure.html:7
 msgid "form.eligibility.intro-errors"
 msgstr "Folgende Ihrer Lebensumstände deckt der Steuerlotse nicht ab:"
 
-#: app/templates/eligibility/display_failure.html:31
+#: app/templates/eligibility/display_failure.html:27
 msgid "form.eligibility.use-elster"
 msgstr "Wie geht es weiter?"
 
-#: app/templates/eligibility/display_failure.html:32
+#: app/templates/eligibility/display_failure.html:28
 msgid "form.eligibility.use-elster-text"
 msgstr ""
 "Es gibt zwei Möglichkeiten, Ihre Steuererklärung ohne den Steuerlotsen zu"
 " machen:"
 
-#: app/templates/eligibility/display_failure.html:34
+#: app/templates/eligibility/display_failure.html:30
 msgid "form.eligibility.use-elster.list-item-1"
 msgstr ""
 "Sie können für Ihre Steuererklärung die vollumfänglichen "
 "Steuererklärungsvordrucke nutzen. Die notwendigen Formulare dazu erhalten"
 " Sie zum Beispiel in Ihrem Finanzamt."
 
-#: app/templates/eligibility/display_failure.html:35
+#: app/templates/eligibility/display_failure.html:31
 msgid "form.eligibility.use-elster.list-item-2"
 msgstr ""
 "Sie können Ihre Steuererklärung online über das Steuerportal Mein ELSTER "
 "erledigen."
 
-#: app/templates/eligibility/display_failure.html:42
+#: app/templates/eligibility/display_failure.html:37
 msgid "form.eligibility.use-elster-button"
 msgstr "Zu Mein ELSTER"
 
-#: app/templates/eligibility/display_failure.html:50
+#: app/templates/eligibility/display_failure.html:45
 msgid "form.eligibility.impact-development"
 msgstr "Nehmen Sie Einfluss auf die Weiterentwicklung des Steuerlotsen"
 
-#: app/templates/eligibility/display_failure.html:51
+#: app/templates/eligibility/display_failure.html:46
 msgid "form.eligibility.impact-development-text"
 msgstr ""
 "Sie hätten den Steuerlotsen gern genutzt, aber befinden sich "

--- a/webapp/tests/forms/flows/test_lotse_flow.py
+++ b/webapp/tests/forms/flows/test_lotse_flow.py
@@ -1127,7 +1127,7 @@ class TestLotseHandleSpecificsForStep(unittest.TestCase):
     def test_if_familienstand_step_then_delete_familienstand_date_correctly(self):
         with app.app_context() and app.test_request_context(method='POST',
                                                             data={'familienstand': 'married',
-                                                                  'familienstand_date': '01.01.1985',
+                                                                  'familienstand_date': ['1', '1', '1985'],
                                                                   'familienstand_married_lived_separated': 'no',
                                                                   'familienstand_confirm_zusammenveranlagung': True}):
             _, returned_data = self.flow._handle_specifics_for_step(
@@ -1136,7 +1136,7 @@ class TestLotseHandleSpecificsForStep(unittest.TestCase):
 
         with app.app_context() and app.test_request_context(method='POST',
                                                             data={'familienstand': 'single',
-                                                                  'familienstand_date': '01.01.1985'}):
+                                                                  'familienstand_date': ['1', '1', '1985']}):
             _, returned_data = self.flow._handle_specifics_for_step(
                 self.familienstand_step, self.render_info_familienstand_step, {})
             self.assertNotIn('familienstand_date', returned_data)
@@ -1144,7 +1144,7 @@ class TestLotseHandleSpecificsForStep(unittest.TestCase):
     def test_if_familienstand_step_then_delete_gem_haushalt_correctly(self):
         with app.app_context() and app.test_request_context(method='POST',
                                                             data={'familienstand': 'married',
-                                                                  'familienstand_date': '01.01.1985',
+                                                                  'familienstand_date': ['1', '1', '1985'],
                                                                   'familienstand_married_lived_separated': 'no',
                                                                   'familienstand_confirm_zusammenveranlagung': True}):
             _, returned_data = self.flow._handle_specifics_for_step(
@@ -1172,7 +1172,7 @@ class TestLotseHandleSpecificsForStep(unittest.TestCase):
             self.assertEqual(self.IBAN_url, render_info.next_url)
 
     def test_if_person_b_step_then_delete_person_b_address_correctly(self):
-        correct_person_b_data = {'person_b_idnr': '02293417683', 'person_b_dob': '25.02.1951',
+        correct_person_b_data = {'person_b_idnr': '02293417683', 'person_b_dob': ['25', '2', '1951'],
                                  'person_b_first_name': 'Gerta', 'person_b_last_name': 'Mustername',
                                  'person_b_religion': 'rk',
                                  'person_b_street': 'Steuerweg', 'person_b_street_number': 42, 'person_b_plz': '20354',

--- a/webapp/tests/forms/flows/test_multistep_flow.py
+++ b/webapp/tests/forms/flows/test_multistep_flow.py
@@ -113,7 +113,7 @@ class TestMultiStepFlowHandle(unittest.TestCase):
     def test_if_form_step_after_render_step_then_keep_data_from_older_form_step(self):
         testing_steps = [MockStartStep, MockFormWithInputStep, MockRenderStep, MockFormStep, MockFinalStep]
         endpoint_correct = "lotse"
-        original_data = {'pet': 'Yoshi', 'date': '09.07.1981', 'decimal': '60.000'}
+        original_data = {'pet': 'Yoshi', 'date': ['9', '7', '1981'], 'decimal': '60.000'}
 
         with app.app_context() and app.test_request_context():
             flow = MultiStepFlow(title="Testing MultiStepFlow", steps=testing_steps, endpoint=endpoint_correct)
@@ -416,7 +416,7 @@ class TestMultiStepFlowHandleSpecificsForStep(unittest.TestCase):
     def test_if_step_is_form_step_and_form_data_then_return_updated_stored_data(self):
         original_data = {"name": "Peach"}
         with app.app_context() and app.test_request_context(method='POST') as req:
-            req.request.form = ImmutableMultiDict({'pet': 'Yoshi', 'date': '09.07.1981', 'decimal': '60.000'})
+            req.request.form = ImmutableMultiDict({'pet': 'Yoshi', 'date': ['9', '7', '1981'], 'decimal': '60.000'})
             returned_data, updated_data = self.flow._handle_specifics_for_step(
                 self.form_step_input, self.render_info_form_step_with_input, original_data)
 

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -95,7 +95,7 @@ class TestInteractionBetweenSteps(unittest.TestCase):
     def test_if_form_step_after_render_step_then_keep_data_from_older_form_step(self):
         testing_steps = [MockStartStep, MockFormWithInputStep, MockRenderStep, MockFormStep, MockFinalStep]
         endpoint_correct = "lotse"
-        original_data = {'pet': 'Yoshi', 'date': '09.07.1981', 'decimal': '60.000'}
+        original_data = {'pet': 'Yoshi', 'date': ['9', '7', '1981'], 'decimal': '60.000'}
 
         with app.app_context() and app.test_request_context():
             step_chooser = StepChooser(title="Testing StepChooser", steps=testing_steps, endpoint=endpoint_correct)
@@ -109,8 +109,8 @@ class TestInteractionBetweenSteps(unittest.TestCase):
     def test_if_form_step_after_form_step_then_keep_data_from_newer_form_step(self):
         testing_steps = [MockStartStep, MockFormWithInputStep, MockFormWithInputStep, MockRenderStep, MockFormStep, MockFinalStep]
         endpoint_correct = "lotse"
-        original_data = {'pet': 'Yoshi', 'date': '09.07.1981', 'decimal': '60.000'}
-        adapted_data = {'pet': 'Goomba', 'date': '09.07.1981', 'decimal': '60.000'}
+        original_data = {'pet': 'Yoshi', 'date': ['9', '7', '1981'], 'decimal': '60.000'}
+        adapted_data = {'pet': 'Goomba', 'date': ['9', '7', '1981'], 'decimal': '60.000'}
 
         with app.app_context() and app.test_request_context():
             step_chooser = StepChooser(title="Testing StepChooser", steps=testing_steps, endpoint=endpoint_correct)

--- a/webapp/tests/forms/flows/test_unlock_code_request_flow.py
+++ b/webapp/tests/forms/flows/test_unlock_code_request_flow.py
@@ -149,7 +149,7 @@ class TestUnlockCodeRequestHandleSpecificsForStep(unittest.TestCase):
             # Set sessions up
             self.valid_idnr = '04452397687'
             self.session_data = {'idnr': self.valid_idnr, 'dob': dt.date(1985, 1, 1)}
-            self.valid_input_data = {'idnr': self.valid_idnr, 'dob': '01.01.1980',
+            self.valid_input_data = {'idnr': self.valid_idnr, 'dob': ['1', '1', '1980'],
                                      'registration_confirm_data_privacy': True,
                                      'registration_confirm_terms_of_service': True,
                                      'registration_confirm_incomes': True,

--- a/webapp/tests/forms/flows/test_unlock_code_revocation_flow.py
+++ b/webapp/tests/forms/flows/test_unlock_code_revocation_flow.py
@@ -231,26 +231,6 @@ class TestUnlockCodeRevocationHandleSpecificsForStep(unittest.TestCase):
                     self.input_step, self.render_info_input_step, self.session_data)
                 self.assertRaises(UserNotExistingError, find_user, existing_idnr)
 
-    def test_if_user_exists_but_elster_returns_already_revoked_then_user_is_deleted(self):
-        existing_idnr = '04452397687'
-        date_of_birth = '01.01.1985'
-        create_user(existing_idnr, date_of_birth, '0000')
-
-        with open('tests/samples/sample_vast_revocation_response_failure.xml') as failue_sample:
-            failure_server_response = failue_sample.read()
-        with app.app_context() and app.test_request_context(method='POST',
-                                                            data={'idnr': existing_idnr, 'dob': date_of_birth}):
-            with patch("app.forms.flows.unlock_code_revocation_flow.elster_client.send_unlock_code_revocation_with_elster") \
-                    as fun_unlock_code_revocation:
-                expected_error = ElsterRequestAlreadyRevoked()
-                expected_error.eric_response = b''
-                expected_error.server_response = failure_server_response
-                fun_unlock_code_revocation.side_effect = expected_error
-
-                render_info, _ = self.flow._handle_specifics_for_step(
-                    self.input_step, self.render_info_input_step, self.session_data)
-                self.assertRaises(UserNotExistingError, find_user, existing_idnr)
-
     def test_if_unlock_code_revocation_did_not_get_through_then_next_url_is_failure_step(self):
         existing_idnr = '04452397687'
         correct_dob = ['1', '1', '1985']

--- a/webapp/tests/forms/flows/test_unlock_code_revocation_flow.py
+++ b/webapp/tests/forms/flows/test_unlock_code_revocation_flow.py
@@ -163,8 +163,8 @@ class TestUnlockCodeRevocationHandleSpecificsForStep(unittest.TestCase):
 
     def test_if_user_exists_and_dob_correct_and_unlock_code_revocation_got_through_then_next_url_is_success_step(self):
         existing_idnr = '04452397687'
-        correct_dob = '01.01.1985'
-        create_user(existing_idnr, correct_dob, '0000')
+        correct_dob = ['1', '1', '1985']
+        create_user(existing_idnr, '01.01.1985', '0000')
         with app.app_context() and app.test_request_context(method='POST',
                                                             data={'idnr': existing_idnr,
                                                                   'dob': correct_dob}):
@@ -178,8 +178,8 @@ class TestUnlockCodeRevocationHandleSpecificsForStep(unittest.TestCase):
 
     def test_if_user_exists_and_dob_correct_and_unlock_code_revocation_got_through_then_user_is_deleted(self):
         existing_idnr = '04452397687'
-        correct_dob = '01.01.1985'
-        create_user(existing_idnr, correct_dob, '0000')
+        correct_dob = ['1', '1', '1985']
+        create_user(existing_idnr, '01.01.1985', '0000')
         with app.app_context() and app.test_request_context(method='POST',
                                                             data={'idnr': existing_idnr,
                                                                   'dob': correct_dob}):
@@ -191,8 +191,8 @@ class TestUnlockCodeRevocationHandleSpecificsForStep(unittest.TestCase):
 
     def test_if_user_exists_but_elster_returns_no_antrag_found_then_next_url_is_success_step(self):
         existing_idnr = '04452397687'
-        date_of_birth = '01.01.1985'
-        create_user(existing_idnr, date_of_birth, '0000')
+        date_of_birth = ['1', '1', '1985']
+        create_user(existing_idnr, '01.01.1985', '0000')
 
         with open('tests/samples/sample_vast_revocation_response_failure.xml') as failue_sample:
             failure_server_response = failue_sample.read()
@@ -212,8 +212,8 @@ class TestUnlockCodeRevocationHandleSpecificsForStep(unittest.TestCase):
 
     def test_if_user_exists_but_elster_returns_no_antrag_found_then_user_is_deleted(self):
         existing_idnr = '04452397687'
-        date_of_birth = '01.01.1985'
-        create_user(existing_idnr, date_of_birth, '0000')
+        date_of_birth = ['1', '1', '1985']
+        create_user(existing_idnr, '01.01.1985', '0000')
 
         with open('tests/samples/sample_vast_revocation_response_failure.xml') as failue_sample:
             failure_server_response = failue_sample.read()
@@ -232,8 +232,8 @@ class TestUnlockCodeRevocationHandleSpecificsForStep(unittest.TestCase):
 
     def test_if_unlock_code_revocation_did_not_get_through_then_next_url_is_failure_step(self):
         existing_idnr = '04452397687'
-        correct_dob = '01.01.1985'
-        create_user(existing_idnr, correct_dob, '0000')
+        correct_dob = ['1', '1', '1985']
+        create_user(existing_idnr, '01.01.1985', '0000')
         with app.app_context() and app.test_request_context(method='POST',
                                                             data={'idnr': existing_idnr,
                                                                   'dob': correct_dob}):
@@ -248,8 +248,8 @@ class TestUnlockCodeRevocationHandleSpecificsForStep(unittest.TestCase):
 
     def test_if_unlock_code_revocation_did_not_get_through_then_user_is_not_deleted(self):
         existing_idnr = '04452397687'
-        correct_dob = '01.01.1985'
-        create_user(existing_idnr, correct_dob, '0000')
+        correct_dob = ['1', '1', '1985']
+        create_user(existing_idnr, '01.01.1985', '0000')
         with app.app_context() and app.test_request_context(method='POST',
                                                             data={'idnr': existing_idnr,
                                                                   'dob': correct_dob}):

--- a/webapp/tests/forms/flows/test_unlock_code_revocation_flow.py
+++ b/webapp/tests/forms/flows/test_unlock_code_revocation_flow.py
@@ -231,6 +231,26 @@ class TestUnlockCodeRevocationHandleSpecificsForStep(unittest.TestCase):
                     self.input_step, self.render_info_input_step, self.session_data)
                 self.assertRaises(UserNotExistingError, find_user, existing_idnr)
 
+    def test_if_user_exists_but_elster_returns_already_revoked_then_user_is_deleted(self):
+        existing_idnr = '04452397687'
+        date_of_birth = ['01', '01', '1985']
+        create_user(existing_idnr, '01.01.1985', '0000')
+
+        with open('tests/samples/sample_vast_revocation_response_failure.xml') as failure_sample:
+            failure_server_response = failure_sample.read()
+        with app.app_context() and app.test_request_context(method='POST',
+                                                            data={'idnr': existing_idnr, 'dob': date_of_birth}):
+            with patch("app.forms.flows.unlock_code_revocation_flow.elster_client.send_unlock_code_revocation_with_elster") \
+                    as fun_unlock_code_revocation:
+                expected_error = ElsterRequestAlreadyRevoked()
+                expected_error.eric_response = b''
+                expected_error.server_response = failure_server_response
+                fun_unlock_code_revocation.side_effect = expected_error
+
+                render_info, _ = self.flow._handle_specifics_for_step(
+                    self.input_step, self.render_info_input_step, self.session_data)
+                self.assertRaises(UserNotExistingError, find_user, existing_idnr)
+
     def test_if_unlock_code_revocation_did_not_get_through_then_next_url_is_failure_step(self):
         existing_idnr = '04452397687'
         correct_dob = ['1', '1', '1985']

--- a/webapp/tests/forms/steps/test_personal_data_steps.py
+++ b/webapp/tests/forms/steps/test_personal_data_steps.py
@@ -36,7 +36,7 @@ class TestPersonAStep(unittest.TestCase):
         self.form.person_a_gehbeh.data = False
 
         self.valid_formdata = MultiDict({'person_a_idnr': self.idnr, 'person_a_first_name': 'Hermine',
-                                         'person_a_last_name': 'Granger', 'person_a_dob': '01.01.1985',
+                                         'person_a_last_name': 'Granger', 'person_a_dob': ['01', '01', '1985'],
                                          'person_a_street': 'Hogwartsstraße', 'person_a_street_number': '7',
                                          'person_a_plz': '12345', 'person_a_town': 'Hogsmeade',
                                          'person_a_religion': 'none'})
@@ -151,7 +151,7 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_invalid_familienstand_date_given_then_fail_validation(self):
         data = MultiDict({'familienstand': 'married',
-                          'familienstand_date': '99.99.9999',
+                          'familienstand_date': ['99', '99', '9999'],
                           'familienstand_married_lived_separated': 'no',
                           'familienstand_confirm_zusammenveranlagung': 'y'})
         form = self.step.Form(formdata=data)
@@ -168,7 +168,7 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_married_and_no_lived_separated_given_then_fail_validation(self):
         data = MultiDict({'familienstand': 'married',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_confirm_zusammenveranlagung': 'y'})
         form = self.step.Form(formdata=data)
         self.assertFalse(form.validate())
@@ -176,7 +176,7 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_married_and_not_lived_separated_but_no_zusammenveranlagung_confirmed_then_fail_validation(self):
         data = MultiDict({'familienstand': 'married',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_married_lived_separated': 'no'})
         form = self.step.Form(formdata=data)
         self.assertFalse(form.validate())
@@ -184,7 +184,7 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_married_and_not_lived_separated_and_zusammenveranlagung_confirmed_then_succ_validation(self):
         data = MultiDict({'familienstand': 'married',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_married_lived_separated': 'no',
                           'familienstand_confirm_zusammenveranlagung': 'y'})
         form = self.step.Form(formdata=data)
@@ -192,7 +192,7 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_married_and_lived_separated_and_no_separated_since_given_then_fail_validation(self):
         data = MultiDict({'familienstand': 'married',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_married_lived_separated': 'yes',
                           'familienstand_confirm_zusammenveranlagung': 'y'})
         form = self.step.Form(formdata=data)
@@ -201,7 +201,7 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_married_and_lived_separated_and_separated_since_is_invalid_date_then_fail_validation(self):
         data = MultiDict({'familienstand': 'married',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_married_lived_separated': 'yes',
                           'familienstand_married_lived_separated_since': '99.99.9999',
                           'familienstand_confirm_zusammenveranlagung': 'y'})
@@ -211,9 +211,9 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_married_and_lived_separated_and_separated_since_before_married_date_then_fail_validation(self):
         data = MultiDict({'familienstand': 'married',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_married_lived_separated': 'yes',
-                          'familienstand_married_lived_separated_since': '01.01.2007',
+                          'familienstand_married_lived_separated_since': ['01', '01', '2007'],
                           'familienstand_confirm_zusammenveranlagung': 'y'})
         form = self.step.Form(formdata=data)
         self.assertFalse(form.validate())
@@ -221,34 +221,34 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_married_and_lived_separated_and_separated_since_not_last_tax_year_then_succ_validation(self):
         data = MultiDict({'familienstand': 'married',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_married_lived_separated': 'yes',
-                          'familienstand_married_lived_separated_since': '01.01.2020'})
+                          'familienstand_married_lived_separated_since': ['01', '01', '2020']})
         form = self.step.Form(formdata=data)
         self.assertTrue(form.validate())
 
     def test_if_married_and_lived_separated_and_separated_since_last_tax_year_but_no_zusammenveranlagung_given_then_fail_validation(self):
         data = MultiDict({'familienstand': 'married',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_married_lived_separated': 'yes',
-                          'familienstand_married_lived_separated_since': '02.01.2020'})
+                          'familienstand_married_lived_separated_since': ['02', '01', '2020']})
         form = self.step.Form(formdata=data)
         self.assertFalse(form.validate())
         self.assertIn('familienstand_zusammenveranlagung', form.errors)
 
     def test_if_married_and_lived_separated_and_separated_since_last_tax_year_and_zusammenveranlagung_given_then_succ_validation(self):
         data = MultiDict({'familienstand': 'married',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_married_lived_separated': 'yes',
-                          'familienstand_married_lived_separated_since': '02.01.2020',
+                          'familienstand_married_lived_separated_since': ['02', '01', '2020'],
                           'familienstand_zusammenveranlagung': 'yes'})
         form = self.step.Form(formdata=data)
         self.assertTrue(form.validate())
 
         data = MultiDict({'familienstand': 'married',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_married_lived_separated': 'yes',
-                          'familienstand_married_lived_separated_since': '02.01.2020',
+                          'familienstand_married_lived_separated_since': ['02', '01', '2020'],
                           'familienstand_zusammenveranlagung': 'no'})
         form = self.step.Form(formdata=data)
         self.assertTrue(form.validate())
@@ -267,13 +267,13 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_widowed_not_in_last_tax_year_then_succ_validation(self):
         data = MultiDict({'familienstand': 'widowed',
-                          'familienstand_date': '31.12.2019'})
+                          'familienstand_date': ['31', '12', '2019']})
         form = self.step.Form(formdata=data)
         self.assertTrue(form.validate())
 
     def test_if_widowed_last_tax_year_and_no_lived_separated_given_then_fail_validation(self):
         data = MultiDict({'familienstand': 'widowed',
-                          'familienstand_date': '01.01.2020',
+                          'familienstand_date': ['01', '01', '2020'],
                           'familienstand_confirm_zusammenveranlagung': 'y'})
         form = self.step.Form(formdata=data)
         self.assertFalse(form.validate())
@@ -281,7 +281,7 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_widowed_last_tax_year_and_not_lived_separated_but_no_zusammenveranlagung_confirmed_then_fail_validation(self):
         data = MultiDict({'familienstand': 'widowed',
-                          'familienstand_date': '01.01.2020',
+                          'familienstand_date': ['01', '01', '2020'],
                           'familienstand_widowed_lived_separated': 'no'})
         form = self.step.Form(formdata=data)
         self.assertFalse(form.validate())
@@ -289,7 +289,7 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_widowed_last_tax_year_and_not_lived_separated_and_zusammenveranlagung_confirmed_then_succ_validation(self):
         data = MultiDict({'familienstand': 'widowed',
-                          'familienstand_date': '01.01.2020',
+                          'familienstand_date': ['01', '01', '2020'],
                           'familienstand_widowed_lived_separated': 'no',
                           'familienstand_confirm_zusammenveranlagung': 'y'})
         form = self.step.Form(formdata=data)
@@ -297,7 +297,7 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_widowed_last_tax_year_and_lived_separated_and_no_separated_since_given_then_fail_validation(self):
         data = MultiDict({'familienstand': 'widowed',
-                          'familienstand_date': '01.01.2020',
+                          'familienstand_date': ['01', '01', '2020'],
                           'familienstand_widowed_lived_separated': 'yes',
                           'familienstand_confirm_zusammenveranlagung': 'y'})
         form = self.step.Form(formdata=data)
@@ -306,9 +306,9 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_widowed_and_lived_separated_and_separated_since_after_widowed_date_then_fail_validation(self):
         data = MultiDict({'familienstand': 'widowed',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_widowed_lived_separated': 'yes',
-                          'familienstand_widowed_lived_separated_since': '01.01.2010',
+                          'familienstand_widowed_lived_separated_since': ['01', '01', '2010'],
                           'familienstand_confirm_zusammenveranlagung': 'y'})
         form = self.step.Form(formdata=data)
         self.assertFalse(form.validate())
@@ -316,7 +316,7 @@ class TestFamilienstand(unittest.TestCase):
     
     def test_if_widowed_and_lived_separated_and_separated_since_is_invalid_date_then_fail_validation(self):
         data = MultiDict({'familienstand': 'widowed',
-                          'familienstand_date': '03.04.2008',
+                          'familienstand_date': ['03', '04', '2008'],
                           'familienstand_widowed_lived_separated': 'yes',
                           'familienstand_widowed_lived_separated_since': '99.99.9999',
                           'familienstand_confirm_zusammenveranlagung': 'y'})
@@ -326,34 +326,34 @@ class TestFamilienstand(unittest.TestCase):
 
     def test_if_widowed_last_tax_year_and_lived_separated_and_separated_since_not_last_tax_year_then_succ_validation(self):
         data = MultiDict({'familienstand': 'widowed',
-                          'familienstand_date': '01.06.2020',
+                          'familienstand_date': ['01', '06', '2020'],
                           'familienstand_widowed_lived_separated': 'yes',
-                          'familienstand_widowed_lived_separated_since': '01.01.2020'})
+                          'familienstand_widowed_lived_separated_since': ['01', '01', '2020']})
         form = self.step.Form(formdata=data)
         self.assertTrue(form.validate())
 
     def test_if_widowed_last_tax_year_and_lived_separated_and_separated_since_last_tax_year_but_no_zusammenveranlagung_given_then_fail_validation(self):
         data = MultiDict({'familienstand': 'widowed',
-                          'familienstand_date': '01.01.2020',
+                          'familienstand_date': ['01', '01', '2020'],
                           'familienstand_widowed_lived_separated': 'yes',
-                          'familienstand_widowed_lived_separated_since': '02.01.2020'})
+                          'familienstand_widowed_lived_separated_since': ['02', '01', '2020']})
         form = self.step.Form(formdata=data)
         self.assertFalse(form.validate())
         self.assertIn('familienstand_zusammenveranlagung', form.errors)
 
     def test_if_widowed_last_tax_year_and_lived_separated_and_separated_since_last_tax_year_and_zusammenveranlagung_given_then_succ_validation(self):
         data = MultiDict({'familienstand': 'widowed',
-                          'familienstand_date': '01.06.2020',
+                          'familienstand_date': ['01', '06', '2020'],
                           'familienstand_widowed_lived_separated': 'yes',
-                          'familienstand_widowed_lived_separated_since': '02.01.2020',
+                          'familienstand_widowed_lived_separated_since': ['02', '01', '2020'],
                           'familienstand_zusammenveranlagung': 'yes'})
         form = self.step.Form(formdata=data)
         self.assertTrue(form.validate())
 
         data = MultiDict({'familienstand': 'widowed',
-                          'familienstand_date': '01.06.2020',
+                          'familienstand_date': ['01', '06', '2020'],
                           'familienstand_widowed_lived_separated': 'yes',
-                          'familienstand_widowed_lived_separated_since': '02.01.2020',
+                          'familienstand_widowed_lived_separated_since': ['02', '01', '2020'],
                           'familienstand_zusammenveranlagung': 'no'})
         form = self.step.Form(formdata=data)
         self.assertTrue(form.validate())

--- a/webapp/tests/forms/test_fields.py
+++ b/webapp/tests/forms/test_fields.py
@@ -1,0 +1,103 @@
+import datetime as dt
+import unittest
+
+from werkzeug.datastructures import MultiDict
+
+from app.forms import SteuerlotseBaseForm
+from app.forms.fields import SteuerlotseDateField
+
+
+class DateForm(SteuerlotseBaseForm):
+    date_field = SteuerlotseDateField()
+
+
+class TestSteuerlotseDateFieldData(unittest.TestCase):
+    def setUp(self):
+        self.form = DateForm()
+
+    def test_if_no_data_and_no_formdata_given_then_return_none(self):
+        """ Simulates a GET request without prefilled data."""
+        self.form.process()
+        self.assertEqual(None, self.form.date_field.data)
+
+    def test_if_data_given_and_no_formdata_then_store_data_as_is(self):
+        """ Simulates a GET request with prefilled data."""
+        prefilled_date = dt.date(1980, 7, 31)
+        self.form.process(data={'date_field': prefilled_date})
+        self.assertEqual(prefilled_date, self.form.date_field.data)
+
+    def test_if_no_data_given_and_invalid_formdata_then_return_none(self):
+        """ Simulates a POST request with invalid formdata and no prefilled data."""
+        wrong_date_input = ['77', '07', '1980']
+        self.form.process(formdata=MultiDict({'date_field': wrong_date_input}))
+        self.form.validate()
+        self.assertEqual(None, self.form.date_field.data)
+
+    def test_if_no_data_given_and_valid_formdata_then_store_form_data_as_string(self):
+        """ Simulates a POST request with valid formdata and no prefilled data."""
+        correct_date_input = ['31', '07', '1980']
+        self.form.process(formdata=MultiDict({'date_field': correct_date_input}))
+        self.form.validate()
+        self.assertEqual(dt.date(1980, 7, 31), self.form.date_field.data)
+
+    def test_if_data_given_and_invalid_formdata_then_return_none(self):
+        """ Simulates a POST request with invalid formdata and prefilled data."""
+        wrong_date_input = ['77', '07', '1980']
+        self.form.process(formdata=MultiDict({'date_field': wrong_date_input}),
+                          data={'date_field': dt.date(1979, 9, 19)})
+        self.form.validate()
+        self.assertEqual(None, self.form.date_field.data)
+
+    def test_if_data_given_and_valid_formdata_then_store_form_data_as_string(self):
+        """ Simulates a POST request with valid formdata and prefilled data."""
+        correct_date_input = ['31', '07', '1980']
+        self.form.process(formdata=MultiDict({'date_field': correct_date_input}),
+                          data={'date_field': dt.date(1979, 9, 19)})
+        self.form.validate()
+        self.assertEqual(dt.date(1980, 7, 31), self.form.date_field.data)
+
+
+class TestSteuerlotseDateFieldValue(unittest.TestCase):
+    def setUp(self):
+        self.form = DateForm()
+
+    def test_if_no_data_and_no_formdata_given_then_value_equals_empty_list(self):
+        """ Simulates a GET request without prefilled data."""
+        self.form.process()
+        self.assertEqual([], self.form.date_field._value())
+
+    def test_if_data_given_and_no_formdata_then_value_equals_list_of_data(self):
+        """ Simulates a GET request with prefilled data."""
+        prefilled_date = dt.date(1979, 9, 19)
+        self.form.process(data={'date_field': prefilled_date})
+        self.assertEqual([19, 9, 1979], self.form.date_field._value())
+
+    def test_if_no_data_given_and_invalid_formdata_then_value_equals_formdata_as_is(self):
+        """ Simulates a POST request with invalid formdata and no prefilled data."""
+        wrong_date_input = ['77', '07', '1980']
+        self.form.process(formdata=MultiDict({'date_field': wrong_date_input}))
+        self.form.validate()
+        self.assertEqual(wrong_date_input, self.form.date_field._value())
+
+    def test_if_no_data_given_and_valid_formdata_then_value_equals_formdata_as_is(self):
+        """ Simulates a POST request with valid formdata and no prefilled data."""
+        correct_date_input = ['31', '07', '1980']
+        self.form.process(formdata=MultiDict({'date_field': correct_date_input}))
+        self.form.validate()
+        self.assertEqual([31, 7, 1980], self.form.date_field._value())
+
+    def test_if_data_given_and_invalid_formdata_then_value_equals_formdata_as_is(self):
+        """ Simulates a POST request with invalid formdata and prefilled data."""
+        wrong_date_input = ['77', '07', '1980']
+        self.form.process(formdata=MultiDict({'date_field': wrong_date_input}),
+                          data={'date_field': dt.date(1979, 9, 19)})
+        self.form.validate()
+        self.assertEqual(wrong_date_input, self.form.date_field._value())
+
+    def test_if_data_given_and_valid_formdata_then_value_equals_form_data_as_is(self):
+        """ Simulates a POST request with valid formdata and prefilled data."""
+        correct_date_input = ['31', '07', '1980']
+        self.form.process(formdata=MultiDict({'date_field': correct_date_input}),
+                          data={'date_field': dt.date(1979, 9, 19)})
+        self.form.validate()
+        self.assertEqual([31, 7, 1980], self.form.date_field._value())


### PR DESCRIPTION
# Short Description
- We separate the date field into day, month and year input fields.

# Changes
- Add another MultipleInputFieldWidget class
- Add the possibility to set field_labels to MultipleInputFieldWidget itself
- Adapt tests (dates are now sent as array, not as string)

# Feedback
- What do you think of the way I added the sub_field_labels?
- Do you see how we could get rid of the adaption of `render_kw` in `SteuerlotseDateField.__init()__`?
