### PR TITLE
Correct autofocus for entry and radio button fields

### DIFF
--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -56,7 +56,7 @@
         {{ field_label(field) }}
         {% for subfield in field %}
             <div>
-                {% if (first_field or field.errors) and loop.index0==0 %}
+                {% if field.errors and loop.index0==0 %}
                     {{ subfield(class="", autofocus=True) }}
                 {% else %}
                     {{ subfield(class="") }}

--- a/webapp/app/templates/fields/jquery_entries.html
+++ b/webapp/app/templates/fields/jquery_entries.html
@@ -6,7 +6,7 @@
 <div id="{{id}}-div">
     {%- for item in kwargs['data'] %}
     <div class="{{dynamic_div_classes}}">
-        <input class="dynamic-entry {{dynamic_input_classes}}" type="text" value="{{item}}">{{remove_button()}}
+        <input {% if 'autofocus' in kwargs %}autofocus {% endif %}class="dynamic-entry {{dynamic_input_classes}}" type="text" value="{{item}}">{{remove_button()}}
     </div>
     {%- endfor -%}
 </div>

--- a/webapp/app/templates/lotse/form_familienstand.html
+++ b/webapp/app/templates/lotse/form_familienstand.html
@@ -7,7 +7,7 @@
         {{ macros.render_field(form.familienstand, 10) }}
     </div>
     <div id="familienstand_date_field" class="form-row-center hidden">
-        {{ macros.render_field(form.familienstand_date, first_field=True if not render_info.form.errors) }}
+        {{ macros.render_field(form.familienstand_date) }}
     </div>
     <div id="familienstand_married_lived_separated_field" class="hidden">
         {{ macros.render_field(form.familienstand_married_lived_separated) }}

--- a/webapp/app/templates/lotse/form_familienstand.html
+++ b/webapp/app/templates/lotse/form_familienstand.html
@@ -4,10 +4,10 @@
 {% block form_content %}
 
     <div id="familienstand_field" class="mb-3">
-        {{ macros.render_field(form.familienstand, 10, first_field=True if not render_info.form.errors) }}
+        {{ macros.render_field(form.familienstand, 10) }}
     </div>
     <div id="familienstand_date_field" class="form-row-center hidden">
-        {{ macros.render_field(form.familienstand_date) }}
+        {{ macros.render_field(form.familienstand_date, first_field=True if not render_info.form.errors) }}
     </div>
     <div id="familienstand_married_lived_separated_field" class="hidden">
         {{ macros.render_field(form.familienstand_married_lived_separated) }}


### PR DESCRIPTION
# Short Description
- The autofocus on the first field did not work for entry fields
- Autofocus was not intended on the radio button fields -> removed

# Changes
- Add autofocus to entry field if autofocus is present
- disallow focus on radio buttons, even if first_field is set to True
- set the familienstand date as first field for familienstand form to focus this instead of the radio field.

# Feedback
- I don't see anything problematic with this. Do you?
