### PR TITLE
Correctly hide zusammenveranlagung field

### DIFF
--- a/webapp/app/templates/lotse/form_familienstand.html
+++ b/webapp/app/templates/lotse/form_familienstand.html
@@ -174,6 +174,9 @@
 
             $(`#familienstand_date`).on('input', show_hide_familienstand_married_lived_separated_field);
             $(`#familienstand_date`).on('input', show_hide_familienstand_widowed_lived_separated_field);
+            $(`#familienstand_date`).on('input', show_hide_familienstand_married_lived_separated_since_field);
+            $(`#familienstand_date`).on('input', show_hide_familienstand_widowed_lived_separated_since_field);
+            $(`#familienstand_date`).on('input', show_hide_familienstand_confirm_zusammenveranlagung_field);
 
             $(`#familienstand_married_lived_separated_since`).on('input', show_hide_familienstand_zusammenveranlagung_field);
             $(`#familienstand_widowed_lived_separated_since`).on('input', show_hide_familienstand_zusammenveranlagung_field);


### PR DESCRIPTION
# Short Description
- The confirm_zusammenveranlagung and widowed_since fields were still shown if you entered a date that actually did not need the fields (a familienstand_date that was not in 2020)

# Changes
- Add hooks to correctly change the site when a different date is inputted

# Feedback
- Just adding to the spaghetti here^^
