### PR TITLE
Add placeholder to avoid empty input fields from jumping

### DIFF
--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -30,6 +30,8 @@ class MultipleInputFieldWidget(TextInput):
         if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
             kwargs['required'] = True
         kwargs['class'] = 'form-control'
+        # Safari has a bug where empty input fields do not align correctly with baseline alignment.
+        # Thus, we add a placeholder.
         kwargs['placeholder'] = ' '
 
         joined_input_fields = Markup()

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -30,6 +30,7 @@ class MultipleInputFieldWidget(TextInput):
         if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
             kwargs['required'] = True
         kwargs['class'] = 'form-control'
+        kwargs['placeholder'] = ' '
 
         joined_input_fields = Markup()
         for idx, input_field_length in enumerate(self.input_field_lengths):


### PR DESCRIPTION
# Short Description
- When you inputted a value into the first field of the unlock_code (and IdNr) field, the field was not aligned with the others anymore.
- This is due to the fact that Safari has a bug that makes the baseline alignment not work as intended on empty input fields in a flexbox with baseline alignment: https://github.com/philipwalton/flexbugs/issues/270

# Changes
- Added an empty placeholder, because then the field is not technically empty and the fields are correctly aligned (solution from the above post)

# Feedback
- Do you see any problems with this?
