### PR TITLE
Bolden input labels

### DIFF
--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -691,6 +691,7 @@ footer a{
 .text-input-field-label {
     padding-top: var(--spacing-08);
     font-size: var(--text-lg);
+    font-weight: var(--font-bold);
 }
 
 .nav-button-row {

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -37,11 +37,6 @@ body {
     font-size: var(--text-medium);
 }
 
-/* SPACING */
-.spacing-t-07 {
-    padding-top: var(--spacing-07);
-}
-
 /* LINKS */
 a{
     text-decoration: underline;

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -37,6 +37,11 @@ body {
     font-size: var(--text-medium);
 }
 
+/* SPACING */
+.spacing-t-07 {
+    padding-top: var(--spacing-07);
+}
+
 /* LINKS */
 a{
     text-decoration: underline;

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -446,7 +446,11 @@ a.back-link:focus a.back-link:active{
     border: 2px solid var(--text-color);
 }
 
-/* SECONDARY */
+/* YES NO FIELDS */
+.yes-no-field-label {
+    padding-top: var(--spacing-07);
+}
+
 .switch-yes, .switch-no {
     padding: 1rem 1.45rem;
     color: var(--text-color) !important;

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -69,7 +69,7 @@
 {%- endmacro %}
 
 {% macro yes_no_field(field, first_field=False) %}
-    {{ field_label(field, class='spacing-t-07') }}
+    {{ field_label(field, class='yes-no-field-label') }}
     {{ _field(field, first_field=first_field) }}
 {% endmacro %}
 

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -68,6 +68,11 @@
     </fieldset>
 {%- endmacro %}
 
+{% macro yes_no_field(field, first_field=False) %}
+    {{ field_label(field, class='spacing-t-07') }}
+    {{ _field(field, first_field=first_field) }}
+{% endmacro %}
+
 {% macro separated_field(field,first_field=False) -%}
     <fieldset id="{{ field.id }}">
         {{ field_label(field, class="text-input-field-label") }}

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -52,7 +52,7 @@
 {% macro render_field(field, cols=6, class="", field_div_classes="", d_block=False, as_card=False, hide_label=False, hide_errors=False, first_field=False) %}
     {% if field.type == 'ConfirmationField' %}
         {{ _render_field(field, 12, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors, first_field=first_field) }}
-    {% elif field.type == 'BooleanField' %}
+    {% elif field.type in ('BooleanField', 'YesNoField') %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors, first_field=first_field) }}
     {% elif field.type == 'RadioField' or field.type == 'UnlockCodeField' or field.type == 'IdNrField' or field.type == 'SteuerlotseDateField' %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=True, first_field=first_field) }}
@@ -87,6 +87,8 @@
                 {{ components.checkbox(field, classes=classes, first_field=first_field) }}
             {% elif field.type == 'RadioField' %}
                 {{ components.radio_field(field, first_field=first_field) }}
+            {% elif field.type == 'YesNoField' %}
+                {{ components.yes_no_field(field, first_field=first_field) }}
             {% elif field.type == 'UnlockCodeField' or field.type == 'IdNrField' or field.type == 'SteuerlotseDateField' %}
                 {{ components.separated_field(field, first_field=first_field) }}
             {% else %}


### PR DESCRIPTION
# Short Description
- The labels of text inputs are now bold

# Changes
- Set font weight to bold for `.text-input-label`
- Introduce a special case in the macros for yes_no_fields. Those previously were the only special ones without a dedicated macro to construct them.

# Feedback
- Does the solution make sense to you?