### PR TITLE
Group address fields

### DIFF
--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -693,6 +693,11 @@ footer a{
     font-size: var(--text-lg);
 }
 
+.optional-hint {
+    font-size: var(--text-medium);
+    font-weight: var(--font-normal);
+}
+
 .nav-button-row {
     margin-top: var(--spacing-08);
 }

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -689,7 +689,7 @@ footer a{
 }
 
 .text-input-field-label {
-    padding-top: var(--spacing-08);
+    margin-top: var(--spacing-06);
     font-size: var(--text-lg);
 }
 
@@ -698,21 +698,51 @@ footer a{
     font-weight: var(--font-normal);
 }
 
+/* Place legend inside the fieldset, not at its border */
+legend {
+    float: left;
+}
+
 .nav-button-row {
-    margin-top: var(--spacing-08);
+    margin-top: var(--spacing-09);
 }
 
 .form-row-center {
     display: flex;
+    flex-wrap: wrap;
     align-items: baseline;
+    margin-top: var(--spacing-06);
     /* This moved the border further outside to allow for the children to fill that space with margin,
     allowing the children to have space between them. See the bootstrap row/column technique. */
     margin-left: calc(-1 * var(--spacing-02));
     margin-right: calc(-1 * var(--spacing-02));
 }
 
+.separated-field {
+    flex-wrap: nowrap;
+    margin-top: 0;
+}
+
+.entries-field {
+    flex-wrap: nowrap;
+}
+
 .form-row-center > * {
     margin: 0 var(--spacing-02);
+}
+
+.grouped-input-fields > .form-row-center {
+    margin-top: 0;
+}
+
+.grouped-input-fields .text-input-field-label {
+    margin-top: var(--spacing-06);
+}
+
+@media (max-width: 360px) {
+    .grouped-input-fields .text-input-field-label {
+        margin-top: var(--spacing-04);
+    }
 }
 
 .section-intro p {

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -703,6 +703,10 @@ legend {
     float: left;
 }
 
+fieldset {
+    width: 100%;
+}
+
 .nav-button-row {
     margin-top: var(--spacing-09);
 }

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -198,6 +198,7 @@
     width: 100%;
     overflow: auto;
 }
+
 .details-card .card {
     border: 0;
     border-radius: 0;

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -193,6 +193,11 @@
 }
 
 /* DETAILS */
+.details-card {
+    display: block;
+    width: 100%;
+    overflow: auto;
+}
 .details-card .card {
     border: 0;
     border-radius: 0;

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -71,7 +71,7 @@
 {% macro separated_field(field,first_field=False) -%}
     <fieldset id="{{ field.id }}">
         {{ field_label(field, class="text-input-field-label") }}
-        <div class="form-row-center">
+        <div class="form-row-center separated-field">
             {{ _field(field, first_field=first_field) }}
         </div>
         {{ field_errors(field) }}

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -78,7 +78,7 @@
     </fieldset>
 {%- endmacro %}
 
-{% macro field_label(field, class="") %}
+{% macro field_label(field, class="", optional=False) %}
     {%- set label = field.label -%}
     {%- set help = field.render_kw['help'] -%}
     {%- set detail = field.render_kw['detail'] -%}
@@ -86,12 +86,14 @@
     {% if field.type == 'RadioField' or field.type == 'UnlockCodeField' or field.type == 'IdNrField' or field.type == 'SteuerlotseDateField' %}
         {% if label.text %} {# Only show legend if there is a legend text to show #}
             <legend class="field-label {{ class }}">{{ label.text }}
+                {% if optional %}<span class="optional-hint">{{ _('form.optional') }}</span>{% endif %}
                 {% if help %}{{ help_button(label.field_id) }}{% endif %}
             </legend>
         {% endif %}
     {% else %}
         <label for="{{ label.field_id }}"
                class="field-label {{ class }}">{{ label.text }}
+            {% if optional %}<span class="optional-hint">{{ _('form.optional') }}</span>{% endif %}
             {% if help %}{{ help_button(label.field_id) }}{% endif %}
         </label>
     {% endif %}

--- a/webapp/app/templates/fields/jquery_entries.html
+++ b/webapp/app/templates/fields/jquery_entries.html
@@ -1,5 +1,5 @@
 {% set id = kwargs['id'] -%}
-{% set dynamic_div_classes = "my-2 form-row-center" %}
+{% set dynamic_div_classes = "my-2 form-row-center entries-field" %}
 {% set dynamic_input_classes = "form-control" %}
 {% macro remove_button() %}<button type="button" id="{{id}}-remove" class="remove-button" aria-label="{{ _('jquery_entries.remove.aria-label') }}">×</button>{% endmacro -%}
 

--- a/webapp/app/templates/lotse/form_person_a.html
+++ b/webapp/app/templates/lotse/form_person_a.html
@@ -3,9 +3,10 @@
 {% import "components.html" as components %}
 
 {% block form_content %}
-
-    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-allgemein') }}</h2>
-    <div class="grouped-input-fields">
+    <fieldset class="grouped-input-fields">
+        <legend class="mb-0">
+            <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-allgemein') }}</h2>
+        </legend>
         <div class="form-row-center">
             {{ macros.render_field(form.person_a_first_name, first_field=True if not render_info.form.errors) }}
         </div>
@@ -21,10 +22,12 @@
         <div class="form-row-center">
             {{ macros.render_field(form.person_a_idnr) }}
         </div>
-    </div>
+    </fieldset>
 
-    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-addresse') }}</h2>
-    <div class="grouped-input-fields">
+    <fieldset class="grouped-input-fields">
+        <legend class="mb-0">
+            <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-addresse') }}</h2>
+        </legend>
         <div class="form-row-center">
             {{ macros.render_field(form.person_a_street) }}
             {{ macros.render_field(form.person_a_street_number, 2) }}
@@ -37,18 +40,22 @@
             {{ macros.render_field(form.person_a_plz, 3) }}
             {{ macros.render_field(form.person_a_town) }}
         </div>
-    </div>
+    </fieldset>
 
-    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-religion') }}</h2>
-    <div class="grouped-input-fields">
+    <fieldset class="grouped-input-fields">
+        <legend class="mb-0">
+            <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-religion') }}</h2>
+        </legend>
         <div class="form-row-center">
             {{ macros.render_field(form.person_a_religion) }}
         </div>
-    </div>
+    </fieldset>
 
-    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-beh') }}</h2>
-    <p>{{ _('form.lotse.person-header-beh-intro') }}</p>
-    <div class="grouped-input-fields">
+    <fieldset class="grouped-input-fields">
+        <legend class="mb-0">
+            <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-beh') }}</h2>
+        </legend>
+        <p>{{ _('form.lotse.person-header-beh-intro') }}</p>
         <div class="form-row-center">
             {{ macros.render_field(form.person_a_beh_grad, 4) }}
         </div>
@@ -57,6 +64,6 @@
             {{ macros.render_field(form.person_a_blind, 12, d_block=True, hide_label=True) }}
             {{ macros.render_field(form.person_a_gehbeh, 12, d_block=True, hide_label=True) }}
         </div>
-    </div>
+    </fieldset>
 
 {% endblock %}

--- a/webapp/app/templates/lotse/form_person_a.html
+++ b/webapp/app/templates/lotse/form_person_a.html
@@ -4,53 +4,59 @@
 
 {% block form_content %}
 
-    <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-allgemein') }}</h2>
-    <div class="form-row-center">
-        {{ macros.render_field(form.person_a_first_name, first_field=True if not render_info.form.errors) }}
+    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-allgemein') }}</h2>
+    <div class="grouped-input-fields">
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_a_first_name, first_field=True if not render_info.form.errors) }}
+        </div>
+
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_a_last_name) }}
+        </div>
+
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_a_dob) }}
+        </div>
+
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_a_idnr) }}
+        </div>
     </div>
 
-    <div class="form-row-center">
-        {{ macros.render_field(form.person_a_last_name) }}
-    </div>
-
-    <div class="form-row-center">
-        {{ macros.render_field(form.person_a_dob) }}
-    </div>
-
-    <div class="form-row-center">
-        {{ macros.render_field(form.person_a_idnr) }}
-    </div>
-
-    <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-addresse') }}</h2>
-    <div class="form-row-center">
-        {{ macros.render_field(form.person_a_street) }}
-        {{ macros.render_field(form.person_a_street_number, 2) }}
+    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-addresse') }}</h2>
+    <div class="grouped-input-fields">
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_a_street) }}
+            {{ macros.render_field(form.person_a_street_number, 2) }}
             {{ macros.render_field(form.person_a_street_number_ext, 2, field_div_classes='text-nowrap', optional=True) }}
-    </div>
-    <div class="form-row-center">
+        </div>
+        <div class="form-row-center">
             {{ macros.render_field(form.person_a_address_ext, optional=True) }}
-        {{ macros.render_field(form.person_a_address_ext) }}
-    </div>
-    <div class="form-row-center">
-        {{ macros.render_field(form.person_a_plz) }}
-        {{ macros.render_field(form.person_a_town, 6) }}
-    </div>
-
-    <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-religion') }}</h2>
-    <div class="form-row-center">
-        {{ macros.render_field(form.person_a_religion) }}
+        </div>
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_a_plz, 3) }}
+            {{ macros.render_field(form.person_a_town) }}
+        </div>
     </div>
 
-    <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-beh') }}</h2>
-    <p class="mb-4">{{ _('form.lotse.person-header-beh-intro') }}</p>
-    <div class="form-row-center">
-        {{ macros.render_field(form.person_a_beh_grad, 4) }}
+    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-religion') }}</h2>
+    <div class="grouped-input-fields">
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_a_religion) }}
+        </div>
     </div>
-    <div class="form-row-center">
-        {{ macros.render_field(form.person_a_blind, 4, d_block=True, hide_label=True) }}
-    </div>
-    <div class="form-row-center">
-        {{ macros.render_field(form.person_a_gehbeh, 4, d_block=True, hide_label=True) }}
+
+    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-beh') }}</h2>
+    <p>{{ _('form.lotse.person-header-beh-intro') }}</p>
+    <div class="grouped-input-fields">
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_a_beh_grad, 4) }}
+        </div>
+        <div class="form-row-center w-100">
+            <span class="text-input-field-label">{{ _('form.lotse.person-merkzeichen.title') }}</span>
+            {{ macros.render_field(form.person_a_blind, 12, d_block=True, hide_label=True) }}
+            {{ macros.render_field(form.person_a_gehbeh, 12, d_block=True, hide_label=True) }}
+        </div>
     </div>
 
 {% endblock %}

--- a/webapp/app/templates/lotse/form_person_a.html
+++ b/webapp/app/templates/lotse/form_person_a.html
@@ -25,9 +25,10 @@
     <div class="form-row-center">
         {{ macros.render_field(form.person_a_street) }}
         {{ macros.render_field(form.person_a_street_number, 2) }}
+            {{ macros.render_field(form.person_a_street_number_ext, 2, field_div_classes='text-nowrap', optional=True) }}
     </div>
     <div class="form-row-center">
-        {{ macros.render_field(form.person_a_street_number_ext) }}
+            {{ macros.render_field(form.person_a_address_ext, optional=True) }}
         {{ macros.render_field(form.person_a_address_ext) }}
     </div>
     <div class="form-row-center">

--- a/webapp/app/templates/lotse/form_person_b.html
+++ b/webapp/app/templates/lotse/form_person_b.html
@@ -25,13 +25,13 @@
     <div class="form-row-center">
       {{ macros.render_field(form.person_b_street) }}
       {{ macros.render_field(form.person_b_street_number, 2) }}
+      {{ macros.render_field(form.person_b_street_number_ext, 2, field_div_classes='text-nowrap', optional=True) }}
     </div>
     <div class="form-row-center">
-      {{ macros.render_field(form.person_b_street_number_ext) }}
-      {{ macros.render_field(form.person_b_address_ext) }}
+      {{ macros.render_field(form.person_b_address_ext, optional=True) }}
     </div>
     <div class="form-row-center">
-      {{ macros.render_field(form.person_b_plz) }}
+      {{ macros.render_field(form.person_b_plz, 3) }}
       {{ macros.render_field(form.person_b_town) }}
     </div>
   </div>

--- a/webapp/app/templates/lotse/form_person_b.html
+++ b/webapp/app/templates/lotse/form_person_b.html
@@ -3,9 +3,10 @@
 {% import "components.html" as components %}
 
 {% block form_content %}
-
-    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-allgemein') }}</h2>
-    <div class="grouped-input-fields">
+    <fieldset class="grouped-input-fields">
+        <legend class="mb-0">
+            <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-allgemein') }}</h2>
+        </legend>
         <div class="form-row-center">
             {{ macros.render_field(form.person_b_first_name, first_field=True if not render_info.form.errors) }}
         </div>
@@ -18,13 +19,15 @@
         <div class="form-row-center">
             {{ macros.render_field(form.person_b_idnr) }}
         </div>
-    </div>
+    </fieldset>
 
-    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-addresse') }}</h2>
-    {{ macros.render_field(form.person_b_same_address, 10) }}
+    <fieldset class="grouped-input-fields">
+        <legend class="mb-0">
+            <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-addresse') }}</h2>
+        </legend>
+        {{ macros.render_field(form.person_b_same_address, 10, class='w-100') }}
 
-    <div id="form_address_fields" class="hidden">
-        <div class="grouped-input-fields">
+        <div id="form_address_fields" class="grouped-input-fields hidden">
             <div class="form-row-center">
                 {{ macros.render_field(form.person_b_street) }}
                 {{ macros.render_field(form.person_b_street_number, 2) }}
@@ -38,18 +41,22 @@
                 {{ macros.render_field(form.person_b_town) }}
             </div>
         </div>
-    </div>
+    </fieldset>
 
-    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-religion') }}</h2>
-    <div class="grouped-input-fields">
+    <fieldset class="grouped-input-fields">
+        <legend class="mb-0">
+            <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-religion') }}</h2>
+        </legend>
         <div class="form-row-center">
             {{ macros.render_field(form.person_b_religion, 6) }}
         </div>
-    </div>
+    </fieldset>
 
-    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-beh') }}</h2>
-    <p>{{ _('form.lotse.person-header-beh-intro') }}</p>
-    <div class="grouped-input-fields">
+    <fieldset class="grouped-input-fields">
+        <legend class="mb-0">
+            <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-beh') }}</h2>
+        </legend>
+        <p>{{ _('form.lotse.person-header-beh-intro') }}</p>
         <div class="form-row-center">
             {{ macros.render_field(form.person_b_beh_grad, 4) }}
         </div>
@@ -58,7 +65,7 @@
             {{ macros.render_field(form.person_b_blind, 12, d_block=True, hide_label=True) }}
             {{ macros.render_field(form.person_b_gehbeh, 12, d_block=True, hide_label=True) }}
         </div>
-    </div>
+    </fieldset>
 
 {% endblock %}
 

--- a/webapp/app/templates/lotse/form_person_b.html
+++ b/webapp/app/templates/lotse/form_person_b.html
@@ -4,54 +4,61 @@
 
 {% block form_content %}
 
-  <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-allgemein') }}</h2>
-   <div class="form-row-center">
-    {{ macros.render_field(form.person_b_first_name, first_field=True if not render_info.form.errors) }}
-  </div>
-  <div class="form-row-center">
-    {{ macros.render_field(form.person_b_last_name) }}
-  </div>
-  <div class="form-row-center">
-    {{ macros.render_field(form.person_b_dob) }}
-  </div>
-  <div class="form-row-center">
-    {{ macros.render_field(form.person_b_idnr) }}
-  </div>
-
-  <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-addresse') }}</h2>
-  {{ macros.render_field(form.person_b_same_address, 10) }}
-
-  <div id="form_address_fields" class="hidden">
-    <div class="form-row-center">
-      {{ macros.render_field(form.person_b_street) }}
-      {{ macros.render_field(form.person_b_street_number, 2) }}
-      {{ macros.render_field(form.person_b_street_number_ext, 2, field_div_classes='text-nowrap', optional=True) }}
+    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-allgemein') }}</h2>
+    <div class="grouped-input-fields">
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_b_first_name, first_field=True if not render_info.form.errors) }}
+        </div>
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_b_last_name) }}
+        </div>
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_b_dob) }}
+        </div>
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_b_idnr) }}
+        </div>
     </div>
-    <div class="form-row-center">
-      {{ macros.render_field(form.person_b_address_ext, optional=True) }}
-    </div>
-    <div class="form-row-center">
-      {{ macros.render_field(form.person_b_plz, 3) }}
-      {{ macros.render_field(form.person_b_town) }}
-    </div>
-  </div>
 
-  <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-religion') }}</h2>
-  <div class="form-row-center">
-    {{ macros.render_field(form.person_b_religion, 6) }}
-  </div>
+    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-addresse') }}</h2>
+    {{ macros.render_field(form.person_b_same_address, 10) }}
 
-  <h2 class="mt-5 my-3">{{ _('form.lotse.person-header-beh') }}</h2>
-  <p class="mb-4">{{ _('form.lotse.person-header-beh-intro') }}</p>
-  <div class="form-row-center">
-    {{ macros.render_field(form.person_b_beh_grad, 4) }}
-  </div>
-  <div class="form-row-center">
-    {{ macros.render_field(form.person_b_blind, 4, d_block=True, hide_label=True) }}
-  </div>
-  <div class="form-row-center">
-    {{ macros.render_field(form.person_b_gehbeh, 4, d_block=True, hide_label=True) }}
-  </div>
+    <div id="form_address_fields" class="hidden">
+        <div class="grouped-input-fields">
+            <div class="form-row-center">
+                {{ macros.render_field(form.person_b_street) }}
+                {{ macros.render_field(form.person_b_street_number, 2) }}
+                {{ macros.render_field(form.person_b_street_number_ext, 2, field_div_classes='text-nowrap', optional=True) }}
+            </div>
+            <div class="form-row-center">
+                {{ macros.render_field(form.person_b_address_ext, optional=True) }}
+            </div>
+            <div class="form-row-center">
+                {{ macros.render_field(form.person_b_plz, 3) }}
+                {{ macros.render_field(form.person_b_town) }}
+            </div>
+        </div>
+    </div>
+
+    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-religion') }}</h2>
+    <div class="grouped-input-fields">
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_b_religion, 6) }}
+        </div>
+    </div>
+
+    <h2 class="mt-5 mb-0">{{ _('form.lotse.person-header-beh') }}</h2>
+    <p>{{ _('form.lotse.person-header-beh-intro') }}</p>
+    <div class="grouped-input-fields">
+        <div class="form-row-center">
+            {{ macros.render_field(form.person_b_beh_grad, 4) }}
+        </div>
+        <div class="form-row-center w-100">
+            <span class="text-input-field-label w-100">{{ _('form.lotse.person-merkzeichen.title') }}</span>
+            {{ macros.render_field(form.person_b_blind, 12, d_block=True, hide_label=True) }}
+            {{ macros.render_field(form.person_b_gehbeh, 12, d_block=True, hide_label=True) }}
+        </div>
+    </div>
 
 {% endblock %}
 

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -41,36 +41,36 @@
 
 {# ------------------------ #}
 
-{% macro field_label(field, class="") %}
-    {{ components.field_label(field, class) }}
+{% macro field_label(field, class="", optional=False) %}
+    {{ components.field_label(field, class, optional) }}
 {%- endmacro %}
 
 {% macro field_errors(field) -%}
     {{ components.field_errors(field) }}
 {%- endmacro %}
 
-{% macro render_field(field, cols=6, class="", field_div_classes="", d_block=False, as_card=False, hide_label=False, hide_errors=False, first_field=False) %}
+{% macro render_field(field, cols=6, class="", field_div_classes="", d_block=False, as_card=False, hide_label=False, hide_errors=False, first_field=False, optional=False) %}
     {% if field.type == 'ConfirmationField' %}
-        {{ _render_field(field, 12, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors, first_field=first_field) }}
+        {{ _render_field(field, 12, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors, first_field=first_field, optional=optional) }}
     {% elif field.type == 'BooleanField' %}
-        {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors, first_field=first_field) }}
+        {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=hide_errors, first_field=first_field, optional=optional) }}
     {% elif field.type == 'RadioField' or field.type == 'UnlockCodeField' or field.type == 'IdNrField' or field.type == 'SteuerlotseDateField' %}
-        {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=True, first_field=first_field) }}
+        {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=True, hide_errors=True, first_field=first_field, optional=optional) }}
     {% else %}
-        {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=hide_label, hide_errors=hide_errors, first_field=first_field) }}
+        {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, hide_label=hide_label, hide_errors=hide_errors, first_field=first_field, optional=optional) }}
     {% endif %}
 {% endmacro %}
 
-{% macro _render_field(field, cols, class="", field_div_classes="", d_block=False, as_card=False, hide_label=False, hide_errors=False, first_field=False) %}
+{% macro _render_field(field, cols, class="", field_div_classes="", d_block=False, as_card=False, hide_label=False, hide_errors=False, first_field=False, optional=False) %}
     {% if field.errors %}
         {% set field_div_classes = field_div_classes + " error-found-line" %}
     {% endif %}
     <div class="col-md-{{ cols }} {% if as_card %} simple-card {% else %} px-0 {% endif %} {{ field_div_classes }}">
         {% if not hide_label and not (field.render_kw and 'hide_label' in field.render_kw and field.render_kw["hide_label"]) %}
             {% if as_card %}
-                {{ field_label(field) }}
+                {{ field_label(field, optional=optional) }}
             {% else %}
-                {{ field_label(field, class="text-input-field-label") }}
+                {{ field_label(field, class="text-input-field-label", optional=optional) }}
             {% endif %}
         {% endif %}
 

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-07-27 10:12+0200\n"
+"POT-Creation-Date: 2021-07-28 09:56+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -134,39 +134,39 @@ msgstr ""
 "Bitte prüfen Sie Ihre Angaben. Es sind nicht alle notwendigen "
 "Formularfelder ausgefüllt."
 
-#: app/forms/fields.py:78
+#: app/forms/fields.py:80
 msgid "date-field.day"
 msgstr "Tag"
 
-#: app/forms/fields.py:78
+#: app/forms/fields.py:80
 msgid "date-field.month"
 msgstr "Monat"
 
-#: app/forms/fields.py:78
+#: app/forms/fields.py:80
 msgid "date-field.year"
 msgstr "Jahr"
 
-#: app/forms/fields.py:89 app/forms/fields.py:92
+#: app/forms/fields.py:91 app/forms/fields.py:94
 msgid "fields.date_field.example_input.text"
 msgstr "z.B. 31.06.1951"
 
-#: app/forms/fields.py:133
+#: app/forms/fields.py:190
 msgid "fields.euro_field.example_input.text"
 msgstr "z.B. 343,20"
 
-#: app/forms/fields.py:164
+#: app/forms/fields.py:221
 msgid "confirmation_field_must_be_set"
 msgstr "Sie müssen dieses Feld auswählen, um weiter zu machen."
 
-#: app/forms/fields.py:183
+#: app/forms/fields.py:240
 msgid "jquery_entries.add"
 msgstr "Weiteren Eintrag hinzufügen"
 
-#: app/forms/fields.py:246
+#: app/forms/fields.py:303
 msgid "switch.yes"
 msgstr "Ja"
 
-#: app/forms/fields.py:246
+#: app/forms/fields.py:303
 msgid "switch.no"
 msgstr "Nein"
 
@@ -194,25 +194,25 @@ msgstr "Ungültige IBAN Nummer"
 msgid "validate.country-code-not-de"
 msgstr "Geben Sie bitte eine IBAN an, die mit DE beginnt."
 
-#: app/forms/validators.py:69 app/forms/validators.py:79
-#: app/forms/validators.py:82 app/forms/validators.py:85
-#: app/forms/validators.py:88
+#: app/forms/validators.py:71 app/forms/validators.py:81
+#: app/forms/validators.py:84 app/forms/validators.py:87
+#: app/forms/validators.py:90
 msgid "validate.invalid-idnr"
 msgstr "Geben Sie bitte eine gültige Steuer-Identifikationsnummer an."
 
-#: app/forms/validators.py:72
+#: app/forms/validators.py:74
 msgid "validate.idnr-length"
 msgstr "Eine gültige Steuer-Identifikationsnummer hat genau 11 Ziffern."
 
-#: app/forms/validators.py:96
+#: app/forms/validators.py:98
 msgid "validate.unlock-code-length"
 msgstr "Ein gültiger Freischaltcode hat genau 12 Zeichen."
 
-#: app/forms/validators.py:99
+#: app/forms/validators.py:101
 msgid "validate.invalid-unlock-code"
 msgstr "Der Freischaltcode ist nicht valide."
 
-#: app/forms/validators.py:107
+#: app/forms/validators.py:109
 msgid "validate.invalid-character"
 msgstr "Das Feld enthält ein Zeichen, das nicht unterstützt wird."
 
@@ -527,14 +527,27 @@ msgid "unlock-code-activation.idnr"
 msgstr "Steuer-Identifikationsnummer"
 
 #: app/forms/steps/unlock_code_activation_steps.py:17
+#: app/forms/steps/unlock_code_request_steps.py:17
+msgid "unlock-code-request.idnr.help-title"
+msgstr "Wo finde ich diese Nummer?"
+
+#: app/forms/steps/unlock_code_activation_steps.py:18
+#: app/forms/steps/unlock_code_request_steps.py:18
+msgid "unlock-code-request.idnr.help-text"
+msgstr ""
+"Die 11-stellige Nummer haben Sie mit einem Brief vom Bundeszentralamt für"
+" Steuern erhalten. Die Nummer steht oben rechts groß auf dem Brief. "
+"Alternativ finden Sie diese Nummer auch auf Ihrem letzten Steuerbescheid."
+
+#: app/forms/steps/unlock_code_activation_steps.py:21
 msgid "unlock-code-activation.unlock-code"
 msgstr "Freischaltcode"
 
-#: app/forms/steps/unlock_code_activation_steps.py:18
+#: app/forms/steps/unlock_code_activation_steps.py:22
 msgid "unlock-code-request.unlock-code.help-title"
 msgstr "Wo finde ich diese Nummer?"
 
-#: app/forms/steps/unlock_code_activation_steps.py:19
+#: app/forms/steps/unlock_code_activation_steps.py:23
 msgid "unlock-code-request.unlock-code.help-text"
 msgstr ""
 "Wenn Sie sich beim Steuerlotsen erfolgreich registriert haben, bekommen "
@@ -542,39 +555,28 @@ msgstr ""
 "Freischaltcode zugeschickt. Den Freischaltcode finden Sie auf der letzten"
 " Seite des Briefes."
 
-#: app/forms/steps/unlock_code_activation_steps.py:24
+#: app/forms/steps/unlock_code_activation_steps.py:28
 msgid "form.unlock-code-activation.input-title"
 msgstr "Melden Sie sich mit Ihrem Freischaltcode an"
 
-#: app/forms/steps/unlock_code_activation_steps.py:25
+#: app/forms/steps/unlock_code_activation_steps.py:29
 msgid "form.unlock-code-activation.input-intro"
 msgstr ""
 "Sie sind vorbereitet und haben den Freischaltcode per Post erhalten? Dann"
 " können Sie mit Ihrer Steuererklärung 2020 beginnen."
 
-#: app/forms/steps/unlock_code_activation_steps.py:28
-#: app/forms/steps/unlock_code_activation_steps.py:41
+#: app/forms/steps/unlock_code_activation_steps.py:32
+#: app/forms/steps/unlock_code_activation_steps.py:45
 msgid "form.unlock-code-activation.header-title"
 msgstr "Anmelden - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/unlock_code_activation_steps.py:37
+#: app/forms/steps/unlock_code_activation_steps.py:41
 msgid "form.unlock-code-activation.failure-title"
 msgstr "Anmeldung fehlgeschlagen. Bitte prüfen Sie Ihre Angaben"
 
 #: app/forms/steps/unlock_code_request_steps.py:16
 msgid "unlock-code-request.idnr"
 msgstr "Steuer-Identifikationsnummer"
-
-#: app/forms/steps/unlock_code_request_steps.py:17
-msgid "unlock-code-request.idnr.help-title"
-msgstr "Wo finde ich diese Nummer?"
-
-#: app/forms/steps/unlock_code_request_steps.py:18
-msgid "unlock-code-request.idnr.help-text"
-msgstr ""
-"Die 11-stellige Nummer haben Sie mit einem Brief vom Bundeszentralamt für"
-" Steuern erhalten. Die Nummer steht oben rechts groß auf dem Brief. "
-"Alternativ finden Sie diese Nummer auch auf Ihrem letzten Steuerbescheid."
 
 #: app/forms/steps/unlock_code_request_steps.py:19
 msgid "unlock-code-request.dob"
@@ -796,8 +798,8 @@ msgstr "Angabe zu weiteren Einkünften"
 #: app/forms/steps/lotse/personal_data_steps.py:22
 #: app/forms/steps/lotse/personal_data_steps.py:145
 #: app/forms/steps/lotse/personal_data_steps.py:227
-#: app/forms/steps/lotse/personal_data_steps.py:333
-#: app/forms/steps/lotse/personal_data_steps.py:442
+#: app/forms/steps/lotse/personal_data_steps.py:332
+#: app/forms/steps/lotse/personal_data_steps.py:440
 msgid "form.lotse.mandatory_data.label"
 msgstr "Pflichtangaben"
 
@@ -1046,9 +1048,9 @@ msgstr "Familienstand"
 
 #: app/forms/steps/lotse/personal_data_steps.py:136
 #: app/forms/steps/lotse/personal_data_steps.py:185
-#: app/forms/steps/lotse/personal_data_steps.py:300
-#: app/forms/steps/lotse/personal_data_steps.py:423
-#: app/forms/steps/lotse/personal_data_steps.py:475
+#: app/forms/steps/lotse/personal_data_steps.py:299
+#: app/forms/steps/lotse/personal_data_steps.py:421
+#: app/forms/steps/lotse/personal_data_steps.py:473
 msgid "form.lotse.mandatory_data.header-title"
 msgstr "Steuerformular - Pflichtangaben - Der Steuerlotse für Rente und Pension"
 
@@ -1265,120 +1267,112 @@ msgid "form.lotse.field_person_religion.data_label"
 msgstr "Religionszugehörigkeit"
 
 #: app/forms/steps/lotse/personal_data_steps.py:231
-#: app/forms/steps/lotse/personal_data_steps.py:349
+#: app/forms/steps/lotse/personal_data_steps.py:348
 msgid "form.lotse.field_person_idnr"
 msgstr "Steuer-Identifikationsnummer"
 
 #: app/forms/steps/lotse/personal_data_steps.py:233
-#: app/forms/steps/lotse/personal_data_steps.py:350
-msgid "form.lotse.field_person_idnr-help"
-msgstr ""
-"Die 11-stellige Nummer haben Sie mit einem Brief vom Bundeszentralamt für"
-" Steuern erhalten. Die Nummer steht oben rechts groß auf dem Brief. "
-"Alternativ finden Sie diese Nummer auch auf Ihrem letzten Steuerbescheid."
-
-#: app/forms/steps/lotse/personal_data_steps.py:234
-#: app/forms/steps/lotse/personal_data_steps.py:351
+#: app/forms/steps/lotse/personal_data_steps.py:349
 msgid "form.lotse.field_person_idnr.data_label"
 msgstr "Steuer-Identifikationsnummer"
 
-#: app/forms/steps/lotse/personal_data_steps.py:236
-#: app/forms/steps/lotse/personal_data_steps.py:353
+#: app/forms/steps/lotse/personal_data_steps.py:235
+#: app/forms/steps/lotse/personal_data_steps.py:351
 msgid "form.lotse.field_person_dob"
 msgstr "Geburtsdatum"
 
-#: app/forms/steps/lotse/personal_data_steps.py:237
-#: app/forms/steps/lotse/personal_data_steps.py:354
+#: app/forms/steps/lotse/personal_data_steps.py:236
+#: app/forms/steps/lotse/personal_data_steps.py:352
 msgid "form.lotse.field_person_dob.data_label"
 msgstr "Geburtsdatum"
 
-#: app/forms/steps/lotse/personal_data_steps.py:239
-#: app/forms/steps/lotse/personal_data_steps.py:357
+#: app/forms/steps/lotse/personal_data_steps.py:238
+#: app/forms/steps/lotse/personal_data_steps.py:355
 msgid "form.lotse.field_person_first_name"
 msgstr "Vorname"
 
-#: app/forms/steps/lotse/personal_data_steps.py:240
-#: app/forms/steps/lotse/personal_data_steps.py:358
+#: app/forms/steps/lotse/personal_data_steps.py:239
+#: app/forms/steps/lotse/personal_data_steps.py:356
 msgid "form.lotse.field_person_first_name.data_label"
 msgstr "Vorname"
 
-#: app/forms/steps/lotse/personal_data_steps.py:243
-#: app/forms/steps/lotse/personal_data_steps.py:361
+#: app/forms/steps/lotse/personal_data_steps.py:242
+#: app/forms/steps/lotse/personal_data_steps.py:359
 msgid "form.lotse.field_person_last_name"
 msgstr "Nachname"
 
-#: app/forms/steps/lotse/personal_data_steps.py:244
-#: app/forms/steps/lotse/personal_data_steps.py:362
+#: app/forms/steps/lotse/personal_data_steps.py:243
+#: app/forms/steps/lotse/personal_data_steps.py:360
 msgid "form.lotse.field_person_last_name.data_label"
 msgstr "Nachname"
 
-#: app/forms/steps/lotse/personal_data_steps.py:247
-#: app/forms/steps/lotse/personal_data_steps.py:373
+#: app/forms/steps/lotse/personal_data_steps.py:246
+#: app/forms/steps/lotse/personal_data_steps.py:371
 msgid "form.lotse.field_person_street"
 msgstr "Straße"
 
-#: app/forms/steps/lotse/personal_data_steps.py:248
-#: app/forms/steps/lotse/personal_data_steps.py:374
+#: app/forms/steps/lotse/personal_data_steps.py:247
+#: app/forms/steps/lotse/personal_data_steps.py:372
 msgid "form.lotse.field_person_street.data_label"
 msgstr "Straße"
 
-#: app/forms/steps/lotse/personal_data_steps.py:251
-#: app/forms/steps/lotse/personal_data_steps.py:378
+#: app/forms/steps/lotse/personal_data_steps.py:250
+#: app/forms/steps/lotse/personal_data_steps.py:376
 msgid "form.lotse.field_person_street_number"
 msgstr "Hausnummer"
 
-#: app/forms/steps/lotse/personal_data_steps.py:252
-#: app/forms/steps/lotse/personal_data_steps.py:379
+#: app/forms/steps/lotse/personal_data_steps.py:251
+#: app/forms/steps/lotse/personal_data_steps.py:377
 msgid "form.lotse.field_person_street_number.data_label"
 msgstr "Hausnummer"
 
-#: app/forms/steps/lotse/personal_data_steps.py:255
-#: app/forms/steps/lotse/personal_data_steps.py:384
+#: app/forms/steps/lotse/personal_data_steps.py:254
+#: app/forms/steps/lotse/personal_data_steps.py:382
 msgid "form.lotse.field_person_street_number_ext"
-msgstr "Hausnummerzusatz <i>(optional)</i>"
+msgstr "Hausnummerzusatz"
 
-#: app/forms/steps/lotse/personal_data_steps.py:256
-#: app/forms/steps/lotse/personal_data_steps.py:385
+#: app/forms/steps/lotse/personal_data_steps.py:255
+#: app/forms/steps/lotse/personal_data_steps.py:383
 msgid "form.lotse.field_person_street_number_ext.data_label"
 msgstr "Hausnummerzusatz"
 
+#: app/forms/steps/lotse/personal_data_steps.py:258
+#: app/forms/steps/lotse/personal_data_steps.py:386
+msgid "form.lotse.field_person_address_ext"
+msgstr "Adressergänzung"
+
 #: app/forms/steps/lotse/personal_data_steps.py:259
 #: app/forms/steps/lotse/personal_data_steps.py:388
-msgid "form.lotse.field_person_address_ext"
-msgstr "Adressergänzung <i>(optional)</i>"
-
-#: app/forms/steps/lotse/personal_data_steps.py:260
-#: app/forms/steps/lotse/personal_data_steps.py:390
 msgid "form.lotse.field_person_address_ext.data_label"
 msgstr "Adressergänzung"
 
-#: app/forms/steps/lotse/personal_data_steps.py:263
-#: app/forms/steps/lotse/personal_data_steps.py:393
+#: app/forms/steps/lotse/personal_data_steps.py:262
+#: app/forms/steps/lotse/personal_data_steps.py:391
 msgid "form.lotse.field_person_plz"
 msgstr "Postleitzahl"
 
-#: app/forms/steps/lotse/personal_data_steps.py:264
-#: app/forms/steps/lotse/personal_data_steps.py:394
+#: app/forms/steps/lotse/personal_data_steps.py:263
+#: app/forms/steps/lotse/personal_data_steps.py:392
 msgid "form.lotse.field_person_plz.data_label"
 msgstr "Postleitzahl"
 
-#: app/forms/steps/lotse/personal_data_steps.py:267
-#: app/forms/steps/lotse/personal_data_steps.py:398
+#: app/forms/steps/lotse/personal_data_steps.py:266
+#: app/forms/steps/lotse/personal_data_steps.py:396
 msgid "form.lotse.field_person_town"
 msgstr "Wohnort"
 
-#: app/forms/steps/lotse/personal_data_steps.py:268
-#: app/forms/steps/lotse/personal_data_steps.py:399
+#: app/forms/steps/lotse/personal_data_steps.py:267
+#: app/forms/steps/lotse/personal_data_steps.py:397
 msgid "form.lotse.field_person_town.data_label"
 msgstr "Wohnort"
 
-#: app/forms/steps/lotse/personal_data_steps.py:273
-#: app/forms/steps/lotse/personal_data_steps.py:405
+#: app/forms/steps/lotse/personal_data_steps.py:272
+#: app/forms/steps/lotse/personal_data_steps.py:403
 msgid "form.lotse.field_person_beh_grad"
-msgstr "Grad der Behinderung <i>(optional)</i>"
+msgstr "Grad der Behinderung"
 
-#: app/forms/steps/lotse/personal_data_steps.py:276
-#: app/forms/steps/lotse/personal_data_steps.py:407
+#: app/forms/steps/lotse/personal_data_steps.py:275
+#: app/forms/steps/lotse/personal_data_steps.py:405
 msgid "form.lotse.field_person_beh_grad-help"
 msgstr ""
 "Tragen Sie bitte hier den Grad der Behinderung ein. Der Grad der "
@@ -1392,148 +1386,148 @@ msgstr ""
 "Einbuße der körperlichen Beweglichkeit geführt hat oder auf einer "
 "typischen Berufskrankheit beruht.</li><ul>"
 
-#: app/forms/steps/lotse/personal_data_steps.py:277
-#: app/forms/steps/lotse/personal_data_steps.py:408
+#: app/forms/steps/lotse/personal_data_steps.py:276
+#: app/forms/steps/lotse/personal_data_steps.py:406
 msgid "form.lotse.field_person_beh_grad.data_label"
 msgstr "Grad der Behinderung"
 
-#: app/forms/steps/lotse/personal_data_steps.py:278
-#: app/forms/steps/lotse/personal_data_steps.py:409
+#: app/forms/steps/lotse/personal_data_steps.py:277
+#: app/forms/steps/lotse/personal_data_steps.py:407
 msgid "form.lotse.field_person_beh_grad.example_input"
 msgstr "z.B. 25, 30, 35 etc. "
 
-#: app/forms/steps/lotse/personal_data_steps.py:280
-#: app/forms/steps/lotse/personal_data_steps.py:411
+#: app/forms/steps/lotse/personal_data_steps.py:279
+#: app/forms/steps/lotse/personal_data_steps.py:409
 msgid "form.lotse.field_person_blind"
 msgstr "blind / ständig hilflos oder Pflegegrad 4 oder 5"
 
-#: app/forms/steps/lotse/personal_data_steps.py:281
-#: app/forms/steps/lotse/personal_data_steps.py:412
+#: app/forms/steps/lotse/personal_data_steps.py:280
+#: app/forms/steps/lotse/personal_data_steps.py:410
 msgid "form.lotse.field_person_blind.data_label"
 msgstr "blind / ständig hilflos oder Pflegegrad 4 oder 5"
 
-#: app/forms/steps/lotse/personal_data_steps.py:283
-#: app/forms/steps/lotse/personal_data_steps.py:414
+#: app/forms/steps/lotse/personal_data_steps.py:282
+#: app/forms/steps/lotse/personal_data_steps.py:412
 msgid "form.lotse.field_person_gehbeh"
 msgstr "geh- und stehbehindert"
 
-#: app/forms/steps/lotse/personal_data_steps.py:284
-#: app/forms/steps/lotse/personal_data_steps.py:415
+#: app/forms/steps/lotse/personal_data_steps.py:283
+#: app/forms/steps/lotse/personal_data_steps.py:413
 msgid "form.lotse.field_person_gehbeh.data_label"
 msgstr "geh- und stehbehindert"
 
-#: app/forms/steps/lotse/personal_data_steps.py:288
-#: app/forms/steps/lotse/personal_data_steps.py:344
+#: app/forms/steps/lotse/personal_data_steps.py:287
+#: app/forms/steps/lotse/personal_data_steps.py:343
 msgid "form.lotse.validation-person-beh-grad"
 msgstr ""
 "Sie haben eine Geh- oder Stehbehinderung angegeben. Bitte geben Sie hier "
 "den Grad der Behinderung an."
 
-#: app/forms/steps/lotse/personal_data_steps.py:307
+#: app/forms/steps/lotse/personal_data_steps.py:306
 msgid "form.lotse.step_person_a.label"
 msgid_plural "form.lotse.step_person_a.label"
 msgstr[0] "Ihre Angaben"
 msgstr[1] "Person A"
 
-#: app/forms/steps/lotse/personal_data_steps.py:311
+#: app/forms/steps/lotse/personal_data_steps.py:310
 msgid "form.lotse.person-a-title"
 msgid_plural "form.lotse.person-a-title"
 msgstr[0] "Ihre Angaben"
 msgstr[1] "Angaben für Person A"
 
-#: app/forms/steps/lotse/personal_data_steps.py:313
+#: app/forms/steps/lotse/personal_data_steps.py:312
 msgid "form.lotse.person-a-intro"
 msgstr ""
 "Geben Sie bitte zunächst die Informationen des Ehemannes an. Wenn Sie in "
 "einer gleichgeschlechtlichen Partnerschaft leben, geben Sie bitte "
 "zunächst die Person an, deren Name im Alphabet zuerst kommt."
 
-#: app/forms/steps/lotse/personal_data_steps.py:332
+#: app/forms/steps/lotse/personal_data_steps.py:331
 msgid "form.lotse.step_person_b.label"
 msgstr "Person B"
 
-#: app/forms/steps/lotse/personal_data_steps.py:366
+#: app/forms/steps/lotse/personal_data_steps.py:364
 msgid "form.lotse.field_person_b_same_address"
 msgstr "Mein Partner / Meine Partnerin und ich wohnen zusammen."
 
-#: app/forms/steps/lotse/personal_data_steps.py:367
+#: app/forms/steps/lotse/personal_data_steps.py:365
 msgid "form.lotse.field_person_b_same_address.data_label"
 msgstr "Mein Partner / Meine Partnerin und ich wohnen zusammen."
 
-#: app/forms/steps/lotse/personal_data_steps.py:369
+#: app/forms/steps/lotse/personal_data_steps.py:367
 msgid "form.lotse.field_person_b_same_address-yes"
 msgstr "Mein Partner / Meine Partnerin und ich wohnen zusammen."
 
-#: app/forms/steps/lotse/personal_data_steps.py:370
+#: app/forms/steps/lotse/personal_data_steps.py:368
 msgid "form.lotse.field_person_b_same_address-no"
 msgstr ""
 "Mein Partner / Meine Partnerin und ich wohnen nicht zusammen. Er / Sie "
 "ist wohnhaft in:"
 
-#: app/forms/steps/lotse/personal_data_steps.py:419
+#: app/forms/steps/lotse/personal_data_steps.py:417
 msgid "form.lotse.person-b-title"
 msgstr "Angaben für Person B"
 
-#: app/forms/steps/lotse/personal_data_steps.py:420
+#: app/forms/steps/lotse/personal_data_steps.py:418
 msgid "form.lotse.person-b-intro"
 msgstr ""
 "Geben Sie hier bitte die Daten der Ehefrau an. Wenn Sie in einer "
 "gleichgeschlechtlichen Partnerschaft leben, geben Sie bitte die Person "
 "an, deren Name im Alphabet zuletzt kommt."
 
+#: app/forms/steps/lotse/personal_data_steps.py:432
 #: app/forms/steps/lotse/personal_data_steps.py:434
-#: app/forms/steps/lotse/personal_data_steps.py:436
 msgid "form.lotse.skip_reason.familienstand_single"
 msgstr "Sie haben als Familienstand ledig angegeben."
 
-#: app/forms/steps/lotse/personal_data_steps.py:441
+#: app/forms/steps/lotse/personal_data_steps.py:439
 msgid "form.lotse.step_iban.label"
 msgstr "Bankverbindung"
 
-#: app/forms/steps/lotse/personal_data_steps.py:446
+#: app/forms/steps/lotse/personal_data_steps.py:444
 msgid "form.lotse.field_is_person_a_account_holder"
 msgstr "Wer ist Kontoinhaber:in?"
 
-#: app/forms/steps/lotse/personal_data_steps.py:447
+#: app/forms/steps/lotse/personal_data_steps.py:445
 msgid "form.lotse.field_is_person_a_account_holder.data_label"
 msgstr "Kontoinhaber:in"
 
-#: app/forms/steps/lotse/personal_data_steps.py:448
+#: app/forms/steps/lotse/personal_data_steps.py:446
 msgid "form.lotse.field_is_person_a_account_holder-person-a"
 msgstr "Person A"
 
-#: app/forms/steps/lotse/personal_data_steps.py:449
+#: app/forms/steps/lotse/personal_data_steps.py:447
 msgid "form.lotse.field_is_person_a_account_holder-person-b"
 msgstr "Person B"
 
-#: app/forms/steps/lotse/personal_data_steps.py:452
-#: app/forms/steps/lotse/personal_data_steps.py:463
+#: app/forms/steps/lotse/personal_data_steps.py:450
+#: app/forms/steps/lotse/personal_data_steps.py:461
 msgid "form.lotse.field_iban"
 msgstr "IBAN (inländisches Geldinstitut) "
 
-#: app/forms/steps/lotse/personal_data_steps.py:453
-#: app/forms/steps/lotse/personal_data_steps.py:464
+#: app/forms/steps/lotse/personal_data_steps.py:451
+#: app/forms/steps/lotse/personal_data_steps.py:462
 msgid "form.lotse.field_iban.data_label"
 msgstr "IBAN (inländisches Geldinstitut) "
 
-#: app/forms/steps/lotse/personal_data_steps.py:454
-#: app/forms/steps/lotse/personal_data_steps.py:465
+#: app/forms/steps/lotse/personal_data_steps.py:452
+#: app/forms/steps/lotse/personal_data_steps.py:463
 msgid "form.loste.field_iban.example_input"
 msgstr "z.B. DE35 3513 3713 3700 0000 12"
 
-#: app/forms/steps/lotse/personal_data_steps.py:460
+#: app/forms/steps/lotse/personal_data_steps.py:458
 msgid "form.lotse.field_is_person_a_account_holder_single"
 msgstr "Ja, ich bin Kontoinhaber:in."
 
-#: app/forms/steps/lotse/personal_data_steps.py:461
+#: app/forms/steps/lotse/personal_data_steps.py:459
 msgid "form.lotse.field_is_person_a_account_holder_single.data_label"
 msgstr "Das angegebene Konto gehört Ihnen"
 
-#: app/forms/steps/lotse/personal_data_steps.py:471
+#: app/forms/steps/lotse/personal_data_steps.py:469
 msgid "form.lotse.iban-title"
 msgstr "Bankverbindung"
 
-#: app/forms/steps/lotse/personal_data_steps.py:472
+#: app/forms/steps/lotse/personal_data_steps.py:470
 msgid "form.lotse.iban-intro"
 msgstr ""
 "Falls Sie Vorauszahlungen getätigt haben, werden eventuelle Erstattungen "
@@ -2319,15 +2313,19 @@ msgstr ""
 msgid "form.lotse.summary-button-edit"
 msgstr "Ändern"
 
-#: app/templates/components.html:111
+#: app/templates/components.html:89 app/templates/components.html:96
+msgid "form.optional"
+msgstr "optional"
+
+#: app/templates/components.html:113
 msgid "errors.warning-image.aria-label"
 msgstr "Fehlermeldung"
 
-#: app/templates/components.html:220
+#: app/templates/components.html:222
 msgid "button.help"
 msgstr "Weitere Informationen"
 
-#: app/templates/components.html:229
+#: app/templates/components.html:231
 msgid "button.close.aria-label"
 msgstr "Schließen"
 
@@ -2335,11 +2333,11 @@ msgstr "Schließen"
 msgid "form.back"
 msgstr "Zurück"
 
-#: app/templates/macros.html:107 app/templates/macros.html:125
+#: app/templates/macros.html:111 app/templates/macros.html:129
 msgid "form.back_to_overview"
 msgstr "Zurück zur Übersicht"
 
-#: app/templates/macros.html:113 app/templates/macros.html:132
+#: app/templates/macros.html:117 app/templates/macros.html:136
 msgid "form.next"
 msgstr "Weiter"
 
@@ -4644,19 +4642,19 @@ msgstr "Allgemeine Informationen"
 #: app/templates/lotse/form_person_a.html:24
 #: app/templates/lotse/form_person_b.html:21
 msgid "form.lotse.person-header-addresse"
-msgstr "Adresse"
+msgstr "Aktuelle Adresse"
 
-#: app/templates/lotse/form_person_a.html:38
+#: app/templates/lotse/form_person_a.html:40
 #: app/templates/lotse/form_person_b.html:39
 msgid "form.lotse.person-header-religion"
 msgstr "Religion"
 
-#: app/templates/lotse/form_person_a.html:43
+#: app/templates/lotse/form_person_a.html:45
 #: app/templates/lotse/form_person_b.html:44
 msgid "form.lotse.person-header-beh"
 msgstr "Pauschbetrag für Menschen mit Behinderung"
 
-#: app/templates/lotse/form_person_a.html:44
+#: app/templates/lotse/form_person_a.html:46
 #: app/templates/lotse/form_person_b.html:45
 msgid "form.lotse.person-header-beh-intro"
 msgstr ""

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-07-28 09:56+0200\n"
+"POT-Creation-Date: 2021-07-28 11:04+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -4639,22 +4639,22 @@ msgstr ""
 msgid "form.lotse.person-header-allgemein"
 msgstr "Allgemeine Informationen"
 
-#: app/templates/lotse/form_person_a.html:24
+#: app/templates/lotse/form_person_a.html:26
 #: app/templates/lotse/form_person_b.html:21
 msgid "form.lotse.person-header-addresse"
 msgstr "Aktuelle Adresse"
 
-#: app/templates/lotse/form_person_a.html:40
+#: app/templates/lotse/form_person_a.html:42
 #: app/templates/lotse/form_person_b.html:39
 msgid "form.lotse.person-header-religion"
 msgstr "Religion"
 
-#: app/templates/lotse/form_person_a.html:45
+#: app/templates/lotse/form_person_a.html:49
 #: app/templates/lotse/form_person_b.html:44
 msgid "form.lotse.person-header-beh"
 msgstr "Pauschbetrag für Menschen mit Behinderung"
 
-#: app/templates/lotse/form_person_a.html:46
+#: app/templates/lotse/form_person_a.html:50
 #: app/templates/lotse/form_person_b.html:45
 msgid "form.lotse.person-header-beh-intro"
 msgstr ""
@@ -4665,6 +4665,10 @@ msgstr ""
 "vorgewiesen werden. Der Pauschbetrag kann auch bei Vorlage des Bescheids "
 "über die Einstufung als Schwerstpflegebedürftiger (Pflegegrad 4 oder 5) "
 "gewährt werden."
+
+#: app/templates/lotse/form_person_a.html:57
+msgid "form.lotse.person-merkzeichen.title"
+msgstr "Angaben zum Merkzeichen"
 
 #: app/templates/unlock_code/already_logged_in.html:15
 msgid "form.unlock_code.back-to-lotse"


### PR DESCRIPTION
# Short Description
- Optically groups certain fields together (by reducing the spacing to 6 / 4 on mobile)
- I spoke to Nadine and the grouping should not only apply to the address fields but so every group of input fields that have a heading - so this now applies to all fields of person_a and person_b step.

# Changes
- Add `grouped-input-fields` class to indicate places where input fields should be grouped
- Adjust the margins of `grouped-input-fields`'s children
- To also be able to add spacing to legends, instead of just labels, move legend inside of fieldset
- Do not let "Hausnummerzusatz optional" be wrapped
- Add "optional" as a special part of the field label instead of storing it in the label's text + style it according to the design
- Let form-row-centers wrap their contents if the screen is smaller - except from separated input fields + entry fields (remove button should stay on same line)

# Feedback
- In order to achieve a spacing of spacing-09 above text-input fields and still keep some spacing when the fields are wrapped, I added a spacing-06 to all `.form-row-center`s and an additional spacing-06 to the `.text-input-field-label` (6+6 = 9, obviously). Do you think that is too hacky / do you see another way to achieve this?
- Do you see anything that you'd have solved differently?
