### PR TITLE
Set pool_pre_ping on SQLAlchemy

### DIFF
--- a/webapp/app/__init__.py
+++ b/webapp/app/__init__.py
@@ -42,7 +42,8 @@ login_manager = LoginManager()
 login_manager.init_app(app)
 login_manager.session_protection = 'strong'
 
-db = SQLAlchemy(app)
+# Set pool_pre_ping to fix problems with stale connection we've been seeing.
+db = SQLAlchemy(app, engine_options={'pool_pre_ping': True})
 migrate = Migrate(app, db)
 
 register_commands(app)


### PR DESCRIPTION
# Short Description
- We have been experiencing intermittent DB connection issues, manifested as `SSL SYSCALL error: EOF` errors in the application.
- Possible causes for this include network instability or timeout configuration inconsistencies between the Postgres server and our clients.
- SQLAlchemy has a mechanism to always validate connections before using them, which should solve many of these issues: https://docs.sqlalchemy.org/en/14/core/pooling.html#disconnect-handling-pessimistic

# Changes
- Sets `pool_pre_ping` flag of `create_engine()` to `True`

# Feedback
- Nothing specific.