### PR TITLE
Limit input field width

### DIFF
--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -15,20 +15,7 @@ from babel.numbers import format_decimal, parse_decimal
 from app.forms.validators import ValidElsterCharacterSet
 
 
-class SteuerlotseIntegerField(IntegerField):
-    def __init__(self, label='', validators=None, **kwargs):
-        if kwargs.get('render_kw') and kwargs['render_kw'].get('max_characters'):
-            kwargs['render_kw']['class'] = kwargs['render_kw'].get('class', '') + \
-                                           f' input-width-{kwargs["render_kw"].get("max_characters")}'
-        super().__init__(label, validators, **kwargs)
-
-
 class SteuerlotseStringField(StringField):
-    def __init__(self, label='', validators=None, **kwargs):
-        if kwargs.get('render_kw') and kwargs['render_kw'].get('max_characters'):
-            kwargs['render_kw']['class'] = kwargs['render_kw'].get('class', '') + \
-                                           f' input-width-{kwargs["render_kw"].get("max_characters")}'
-        super().__init__(label, validators, **kwargs)
 
     def pre_validate(self, form):
         ValidElsterCharacterSet().__call__(form, self)

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -232,6 +232,7 @@ class SteuerlotseSelectField(SelectField):
             kwargs['render_kw'] = {'class': "custom-select steuerlotse-select"}
         super(SteuerlotseSelectField, self).__init__(**kwargs)
 
+
 class ConfirmationField(BooleanField):
     """A CheckBox that will not validate unless checked."""
 
@@ -260,6 +261,8 @@ class JqueryEntriesWidget(object):
             kwargs['value'] = field._value()
         if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
             kwargs['required'] = True
+        if 'max_characters' not in kwargs:
+            kwargs['max_characters'] = 25
         return Markup(render_template('fields/jquery_entries.html', kwargs=kwargs))
 
 

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from flask import request
 from flask.templating import render_template
 from wtforms import RadioField, Field, StringField
-from wtforms.fields.core import BooleanField, DateField, SelectField
+from wtforms.fields.core import BooleanField, DateField, SelectField, IntegerField
 from wtforms.utils import unset_value
 from wtforms.validators import InputRequired
 from wtforms.widgets.core import TextInput, Markup, html_params
@@ -15,7 +15,21 @@ from babel.numbers import format_decimal, parse_decimal
 from app.forms.validators import ValidElsterCharacterSet
 
 
+class SteuerlotseIntegerField(IntegerField):
+    def __init__(self, label='', validators=None, **kwargs):
+        if kwargs.get('render_kw') and kwargs['render_kw'].get('max_characters'):
+            kwargs['render_kw']['class'] = kwargs['render_kw'].get('class', '') + \
+                                           f' input-width-{kwargs["render_kw"].get("max_characters")}'
+        super().__init__(label, validators, **kwargs)
+
+
 class SteuerlotseStringField(StringField):
+    def __init__(self, label='', validators=None, **kwargs):
+        if kwargs.get('render_kw') and kwargs['render_kw'].get('max_characters'):
+            kwargs['render_kw']['class'] = kwargs['render_kw'].get('class', '') + \
+                                           f' input-width-{kwargs["render_kw"].get("max_characters")}'
+        super().__init__(label, validators, **kwargs)
+
     def pre_validate(self, form):
         ValidElsterCharacterSet().__call__(form, self)
 

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -41,6 +41,7 @@ class MultipleInputFieldWidget(TextInput):
             sub_field_id = f'{field.id}_{idx + 1}'
             kwargs['id'] = sub_field_id
             kwargs['value'] = field._value()[idx] if len(field._value()) >= idx + 1 else ''
+            kwargs['class'] = kwargs.get('class', '') + f' input-width-{input_field_length}'
 
             if len(self.input_field_labels) > idx:
                 joined_input_fields += Markup(

--- a/webapp/app/forms/flows/lotse_flow.py
+++ b/webapp/app/forms/flows/lotse_flow.py
@@ -1,12 +1,12 @@
 from flask import request, flash, url_for
 from flask_login import current_user
 from pydantic import ValidationError, MissingError
-from wtforms.fields.core import UnboundField, SelectField, BooleanField, RadioField, IntegerField
+from wtforms.fields.core import UnboundField, SelectField, BooleanField, RadioField
 
 from app import app
 from app.data_access.audit_log_controller import create_audit_log_confirmation_entry
 from app.forms.fields import SteuerlotseSelectField, YesNoField, SteuerlotseDateField, SteuerlotseStringField, \
-    ConfirmationField, EntriesField, EuroField, IdNrField, SteuerlotseIntegerField
+    ConfirmationField, EntriesField, EuroField, IdNrField, IntegerField
 from app.model.form_data import MandatoryFormData, FamilienstandModel, MandatoryConfirmations, \
     ConfirmationMissingInputValidationError, MandatoryFieldMissingValidationError, InputDataInvalidError, \
     IdNrMismatchInputValidationError
@@ -389,7 +389,7 @@ class LotseMultiStepFlow(MultiStepFlow):
             value_representation = str(value) + " €"
         elif field.field_class == SteuerlotseStringField or field.field_class == IdNrField:
             value_representation = value
-        elif field.field_class == IntegerField or field.field_class == SteuerlotseIntegerField:
+        elif field.field_class == IntegerField or field.field_class == IntegerField:
             value_representation = value
         elif field.field_class == ConfirmationField:
             value_representation = "Ja" if value else "Nein"

--- a/webapp/app/forms/flows/lotse_flow.py
+++ b/webapp/app/forms/flows/lotse_flow.py
@@ -6,7 +6,7 @@ from wtforms.fields.core import UnboundField, SelectField, BooleanField, RadioFi
 from app import app
 from app.data_access.audit_log_controller import create_audit_log_confirmation_entry
 from app.forms.fields import SteuerlotseSelectField, YesNoField, SteuerlotseDateField, SteuerlotseStringField, \
-    ConfirmationField, EntriesField, EuroField, IdNrField
+    ConfirmationField, EntriesField, EuroField, IdNrField, SteuerlotseIntegerField
 from app.model.form_data import MandatoryFormData, FamilienstandModel, MandatoryConfirmations, \
     ConfirmationMissingInputValidationError, MandatoryFieldMissingValidationError, InputDataInvalidError, \
     IdNrMismatchInputValidationError
@@ -389,7 +389,7 @@ class LotseMultiStepFlow(MultiStepFlow):
             value_representation = str(value) + " €"
         elif field.field_class == SteuerlotseStringField or field.field_class == IdNrField:
             value_representation = value
-        elif field.field_class == IntegerField:
+        elif field.field_class == IntegerField or field.field_class == SteuerlotseIntegerField:
             value_representation = value
         elif field.field_class == ConfirmationField:
             value_representation = "Ja" if value else "Nein"

--- a/webapp/app/forms/steps/lotse/personal_data_steps.py
+++ b/webapp/app/forms/steps/lotse/personal_data_steps.py
@@ -3,11 +3,11 @@ from pydantic import ValidationError
 from app.forms import SteuerlotseBaseForm
 from app.forms.steps.step import FormStep, SectionLink
 from app.forms.fields import YesNoField, SteuerlotseDateField, SteuerlotseSelectField, ConfirmationField, \
-    SteuerlotseStringField, IdNrField, SteuerlotseIntegerField
+    SteuerlotseStringField, IdNrField
 
 from flask_babel import _, ngettext
 from flask_babel import lazy_gettext as _l
-from wtforms import RadioField, validators, BooleanField
+from wtforms import RadioField, validators, BooleanField, IntegerField
 from wtforms.validators import InputRequired
 
 from app.forms.validators import IntegerLength, ValidIban, ValidIdNr, DecimalOnly
@@ -251,7 +251,7 @@ class StepPersonA(FormStep):
             render_kw={'data_label': _l('form.lotse.field_person_street.data_label'),
                        'max_characters': 25},
             validators=[InputRequired(), validators.length(max=25)])
-        person_a_street_number = SteuerlotseIntegerField(
+        person_a_street_number = IntegerField(
             label=_l('form.lotse.field_person_street_number'),
             render_kw={'data_label': _l('form.lotse.field_person_street_number.data_label'),
                        'max_characters': 4},
@@ -278,7 +278,7 @@ class StepPersonA(FormStep):
             validators=[InputRequired(), validators.length(max=20)])
         person_a_religion = get_religion_field()
 
-        person_a_beh_grad = SteuerlotseIntegerField(
+        person_a_beh_grad = IntegerField(
             label=_l('form.lotse.field_person_beh_grad'),
             validators=[
                 validators.any_of([25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100])],
@@ -386,7 +386,7 @@ class StepPersonB(FormStep):
                        'max_characters': 25,
                        'required_if_shown': True},
             validators=[input_required_if_not_same_address, validators.length(max=25)])
-        person_b_street_number = SteuerlotseIntegerField(
+        person_b_street_number = IntegerField(
             label=_l('form.lotse.field_person_street_number'),
             render_kw={'data_label': _l('form.lotse.field_person_street_number'
                                         '.data_label'),
@@ -417,7 +417,7 @@ class StepPersonB(FormStep):
             validators=[input_required_if_not_same_address, validators.length(max=20)])
         person_b_religion = get_religion_field()
 
-        person_b_beh_grad = SteuerlotseIntegerField(
+        person_b_beh_grad = IntegerField(
             label=_l('form.lotse.field_person_beh_grad'),
             validators=[validators.any_of([25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100])],
             render_kw={'help': _l('form.lotse.field_person_beh_grad-help'),

--- a/webapp/app/forms/steps/lotse/personal_data_steps.py
+++ b/webapp/app/forms/steps/lotse/personal_data_steps.py
@@ -3,11 +3,11 @@ from pydantic import ValidationError
 from app.forms import SteuerlotseBaseForm
 from app.forms.steps.step import FormStep, SectionLink
 from app.forms.fields import YesNoField, SteuerlotseDateField, SteuerlotseSelectField, ConfirmationField, \
-    SteuerlotseStringField, IdNrField
+    SteuerlotseStringField, IdNrField, SteuerlotseIntegerField
 
 from flask_babel import _, ngettext
 from flask_babel import lazy_gettext as _l
-from wtforms import IntegerField, RadioField, validators, BooleanField
+from wtforms import RadioField, validators, BooleanField
 from wtforms.validators import InputRequired
 
 from app.forms.validators import IntegerLength, ValidIban, ValidIdNr, DecimalOnly
@@ -238,45 +238,54 @@ class StepPersonA(FormStep):
             render_kw={'data_label': _l('form.lotse.field_person_dob.data_label')}, validators=[InputRequired()])
         person_a_first_name = SteuerlotseStringField(
             label=_l('form.lotse.field_person_first_name'),
-            render_kw={'data_label': _l('form.lotse.field_person_first_name.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_first_name.data_label'),
+                       'max_characters': 25},
             validators=[InputRequired(), validators.length(max=25)])
         person_a_last_name = SteuerlotseStringField(
             label=_l('form.lotse.field_person_last_name'),
-            render_kw={'data_label': _l('form.lotse.field_person_last_name.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_last_name.data_label'),
+                       'max_characters': 25},
             validators=[InputRequired(), validators.length(max=25)])
         person_a_street = SteuerlotseStringField(
             label=_l('form.lotse.field_person_street'),
-            render_kw={'data_label': _l('form.lotse.field_person_street.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_street.data_label'),
+                       'max_characters': 25},
             validators=[InputRequired(), validators.length(max=25)])
-        person_a_street_number = IntegerField(
+        person_a_street_number = SteuerlotseIntegerField(
             label=_l('form.lotse.field_person_street_number'),
-            render_kw={'data_label': _l('form.lotse.field_person_street_number.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_street_number.data_label'),
+                       'max_characters': 4},
             validators=[InputRequired(), IntegerLength(max=4)])
         person_a_street_number_ext = SteuerlotseStringField(
             label=_l('form.lotse.field_person_street_number_ext'),
-            render_kw={'data_label': _l('form.lotse.field_person_street_number_ext.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_street_number_ext.data_label'),
+                       'max_characters': 6},
             validators=[validators.length(max=6)])
         person_a_address_ext = SteuerlotseStringField(
             label=_l('form.lotse.field_person_address_ext'),
-            render_kw={'data_label': _l('form.lotse.field_person_address_ext.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_address_ext.data_label'),
+                       'max_characters': 25},
             validators=[validators.length(max=25)])
         person_a_plz = SteuerlotseStringField(
             label=_l('form.lotse.field_person_plz'),
-            render_kw={'data_label': _l('form.lotse.field_person_plz.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_plz.data_label'),
+                       'max_characters': 5},
             validators=[InputRequired(), DecimalOnly(), validators.length(max=5)])
         person_a_town = SteuerlotseStringField(
             label=_l('form.lotse.field_person_town'),
-            render_kw={'data_label': _l('form.lotse.field_person_town.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_town.data_label'),
+                       'max_characters': 25},
             validators=[InputRequired(), validators.length(max=20)])
         person_a_religion = get_religion_field()
 
-        person_a_beh_grad = IntegerField(
+        person_a_beh_grad = SteuerlotseIntegerField(
             label=_l('form.lotse.field_person_beh_grad'),
             validators=[
                 validators.any_of([25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100])],
             render_kw={'help': _l('form.lotse.field_person_beh_grad-help'),
                        'data_label': _l('form.lotse.field_person_beh_grad.data_label'),
-                       'example_input': _l('form.lotse.field_person_beh_grad.example_input')})
+                       'example_input': _l('form.lotse.field_person_beh_grad.example_input'),
+                       'max_characters': 3})
         person_a_blind = BooleanField(
             label=_l('form.lotse.field_person_blind'),
             render_kw={'data_label': _l('form.lotse.field_person_blind.data_label')})
@@ -355,11 +364,13 @@ class StepPersonB(FormStep):
             validators=[InputRequired()])
         person_b_first_name = SteuerlotseStringField(
             label=_l('form.lotse.field_person_first_name'),
-            render_kw={'data_label': _l('form.lotse.field_person_first_name.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_first_name.data_label'),
+                       'max_characters': 25},
             validators=[InputRequired(), validators.length(max=25)])
         person_b_last_name = SteuerlotseStringField(
             label=_l('form.lotse.field_person_last_name'),
-            render_kw={'data_label': _l('form.lotse.field_person_last_name.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_last_name.data_label'),
+                       'max_characters': 25},
             validators=[InputRequired(), validators.length(max=25)])
 
         person_b_same_address = RadioField(
@@ -372,41 +383,47 @@ class StepPersonB(FormStep):
         person_b_street = SteuerlotseStringField(
             label=_l('form.lotse.field_person_street'),
             render_kw={'data_label': _l('form.lotse.field_person_street.data_label'),
+                       'max_characters': 25,
                        'required_if_shown': True},
             validators=[input_required_if_not_same_address, validators.length(max=25)])
-        person_b_street_number = IntegerField(
+        person_b_street_number = SteuerlotseIntegerField(
             label=_l('form.lotse.field_person_street_number'),
             render_kw={'data_label': _l('form.lotse.field_person_street_number'
                                         '.data_label'),
+                       'max_characters': 4,
                        'required_if_shown': True},
             validators=[input_required_if_not_same_address, IntegerLength(max=4)])
         person_b_street_number_ext = SteuerlotseStringField(
             label=_l('form.lotse.field_person_street_number_ext'),
-            render_kw={'data_label': _l('form.lotse.field_person_street_number_ext.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_street_number_ext.data_label'),
+                       'max_characters': 6},
             validators=[validators.length(max=6)])
         person_b_address_ext = SteuerlotseStringField(
             label=_l('form.lotse.field_person_address_ext'),
-            render_kw={
-                'data_label': _l('form.lotse.field_person_address_ext.data_label')},
+            render_kw={'data_label': _l('form.lotse.field_person_address_ext.data_label'),
+                       'max_characters': 25},
             validators=[validators.length(max=25)])
         person_b_plz = SteuerlotseStringField(
             label=_l('form.lotse.field_person_plz'),
             render_kw={'data_label': _l('form.lotse.field_person_plz.data_label'),
+                       'max_characters': 5,
                        'required_if_shown': True},
             validators=[input_required_if_not_same_address, DecimalOnly(), validators.length(max=5)])
         person_b_town = SteuerlotseStringField(
             label=_l('form.lotse.field_person_town'),
             render_kw={'data_label': _l('form.lotse.field_person_town.data_label'),
+                       'max_characters': 25,
                        'required_if_shown': True},
             validators=[input_required_if_not_same_address, validators.length(max=20)])
         person_b_religion = get_religion_field()
 
-        person_b_beh_grad = IntegerField(
+        person_b_beh_grad = SteuerlotseIntegerField(
             label=_l('form.lotse.field_person_beh_grad'),
             validators=[validators.any_of([25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100])],
             render_kw={'help': _l('form.lotse.field_person_beh_grad-help'),
                        'data_label': _l('form.lotse.field_person_beh_grad.data_label'),
-                       'example_input': _l('form.lotse.field_person_beh_grad.example_input')})
+                       'example_input': _l('form.lotse.field_person_beh_grad.example_input'),
+                       'max_characters': 3})
         person_b_blind = BooleanField(
             label=_l('form.lotse.field_person_blind'),
             render_kw={'data_label': _l('form.lotse.field_person_blind.data_label')})
@@ -451,7 +468,8 @@ class StepIban(FormStep):
         iban = SteuerlotseStringField(
             label=_l('form.lotse.field_iban'),
             render_kw={'data_label': _l('form.lotse.field_iban.data_label'),
-                       'example_input': _l('form.loste.field_iban.example_input')},
+                       'example_input': _l('form.loste.field_iban.example_input'),
+                       'max_characters': 25},
             validators=[InputRequired(), ValidIban()],
             filters=[lambda value: value.replace(' ', '') if value else value])
 
@@ -462,7 +480,8 @@ class StepIban(FormStep):
         iban = SteuerlotseStringField(
             label=_l('form.lotse.field_iban'),
             render_kw={'data_label': _l('form.lotse.field_iban.data_label'),
-                       'example_input': _l('form.loste.field_iban.example_input')},
+                       'example_input': _l('form.loste.field_iban.example_input'),
+                       'max_characters': 25},
             validators=[InputRequired(), ValidIban()],
             filters=[lambda value: value.replace(' ', '') if value else value])
 

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -66,6 +66,34 @@ a:visited{
 
 /* INPUTS */
 
+.input-width-2 {
+    width: var(--input-width-2);
+}
+
+.input-width-3 {
+    width: var(--input-width-3);
+}
+
+.input-width-4 {
+    width: var(--input-width-4);
+}
+
+.input-width-5 {
+    width: var(--input-width-5);
+}
+
+.input-width-6 {
+    width: var(--input-width-6);
+}
+
+.input-width-10 {
+    width: var(--input-width-10);
+}
+
+.input-width-25 {
+    max-width: var(--input-width-25);
+}
+
 input.form-control{
     border: 2px solid var(--border-color);
     border-radius: 0;

--- a/webapp/app/static/css/variables.css
+++ b/webapp/app/static/css/variables.css
@@ -72,6 +72,15 @@
   --spacing-10: 5.625rem;
   --spacing-11: 7.5rem;
 
+  /* Input Field Widths */
+  --input-width-2: 60px;
+  --input-width-3: 65px;
+  --input-width-4: 85px;
+  --input-width-5: 100px;
+  --input-width-6: 120px;
+  --input-width-10: 280px;
+  --input-width-25: 400px;
+
   /* Specifics */
   
   --sidebar-width: 220px;

--- a/webapp/app/static/css/variables.css
+++ b/webapp/app/static/css/variables.css
@@ -73,13 +73,13 @@
   --spacing-11: 7.5rem;
 
   /* Input Field Widths */
-  --input-width-2: 60px;
-  --input-width-3: 65px;
-  --input-width-4: 85px;
-  --input-width-5: 100px;
-  --input-width-6: 120px;
-  --input-width-10: 280px;
-  --input-width-25: 400px;
+  --input-width-2: 3.5rem;
+  --input-width-3: 3.8rem;
+  --input-width-4: 5rem;
+  --input-width-5: 5.8rem;
+  --input-width-6: 7rem;
+  --input-width-10: 16.5rem;
+  --input-width-25: 23.5rem;
 
   /* Specifics */
   

--- a/webapp/app/templates/fields/jquery_entries.html
+++ b/webapp/app/templates/fields/jquery_entries.html
@@ -1,5 +1,7 @@
 {% set id = kwargs['id'] -%}
 {% set dynamic_div_classes = "my-2 form-row-center entries-field" %}
+{# max_characters is set in the instantiation of the field in the WTForm.
+We set a corresponding class determining the width depending on max_characters. #}
 {% if kwargs['max_characters'] %}
     {% set dynamic_input_classes = "form-control input-width-" + kwargs['max_characters'] | string %}
 {% else %}

--- a/webapp/app/templates/fields/jquery_entries.html
+++ b/webapp/app/templates/fields/jquery_entries.html
@@ -1,6 +1,10 @@
 {% set id = kwargs['id'] -%}
 {% set dynamic_div_classes = "my-2 form-row-center entries-field" %}
-{% set dynamic_input_classes = "form-control" %}
+{% if kwargs['max_characters'] %}
+    {% set dynamic_input_classes = "form-control input-width-" + kwargs['max_characters'] | string %}
+{% else %}
+    {% set dynamic_input_classes = "form-control" %}
+{% endif %}
 {% macro remove_button() %}<button type="button" id="{{id}}-remove" class="remove-button" aria-label="{{ _('jquery_entries.remove.aria-label') }}">×</button>{% endmacro -%}
 
 <div id="{{id}}-div">

--- a/webapp/app/templates/lotse/form_person_a.html
+++ b/webapp/app/templates/lotse/form_person_a.html
@@ -37,7 +37,7 @@
             {{ macros.render_field(form.person_a_address_ext, optional=True) }}
         </div>
         <div class="form-row-center">
-            {{ macros.render_field(form.person_a_plz, 3) }}
+            {{ macros.render_field(form.person_a_plz, 2) }}
             {{ macros.render_field(form.person_a_town) }}
         </div>
     </fieldset>

--- a/webapp/app/templates/lotse/form_person_b.html
+++ b/webapp/app/templates/lotse/form_person_b.html
@@ -37,7 +37,7 @@
                 {{ macros.render_field(form.person_b_address_ext, optional=True) }}
             </div>
             <div class="form-row-center">
-                {{ macros.render_field(form.person_b_plz, 3) }}
+                {{ macros.render_field(form.person_b_plz, 2) }}
                 {{ macros.render_field(form.person_b_town) }}
             </div>
         </div>

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -78,7 +78,11 @@
         {% set classes = "form-control " + class %}
         {% if field.render_kw and 'class' in field.render_kw %}
             {% set classes = classes + field.render_kw['class'] %}
-        {% elif field.errors %}
+        {% endif %}
+        {% if field.render_kw and 'max_characters' in field.render_kw %}
+            {% set classes = classes + ' input-width-' + field.render_kw['max_characters'] | string %}
+        {% endif %}
+        {% if field.errors %}
             {% set classes = classes + " field-error-found" %}
         {% endif %}
 

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -79,6 +79,8 @@
         {% if field.render_kw and 'class' in field.render_kw %}
             {% set classes = classes + field.render_kw['class'] %}
         {% endif %}
+        {# max_characters is set in the instantiation of the field in the WTForm.
+        We set a corresponding class determining the width depending on max_characters. #}
         {% if field.render_kw and 'max_characters' in field.render_kw %}
             {% set classes = classes + ' input-width-' + field.render_kw['max_characters'] | string %}
         {% endif %}


### PR DESCRIPTION
# Short Description
- For the user to better differenciate between different fields and their required input, most of the text input fields do now have a dedicated (max-) width.

# Changes
- Added variables and classes to define the different widths for different number of characters within a field
- Added a kwarg to all fields requiring a dedicated width (`max_characters`)
- Use this kwarg to add the specific class to a field
- Introduce `SteuerlotseIntegerFeield` to also be able to set the length there

# Feedback
- Do you see a better way to achieve this? I thought about: instead of setting the class directly in the field, we could set it in the `render_field` macro. However, I thought this attribute should really belong to the field. The more I think about it, the better I think the macro  solution is. Let me know what you think.
