### PR TITLE
Fix personal data page for firefox

### DIFF
--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -709,10 +709,6 @@ footer a{
     font-weight: var(--font-normal);
 }
 
-/* Place legend inside the fieldset, not at its border */
-legend {
-}
-
 .nav-button-row {
     margin-top: var(--spacing-09);
 }

--- a/webapp/app/static/css/base.css
+++ b/webapp/app/static/css/base.css
@@ -711,7 +711,6 @@ footer a{
 
 /* Place legend inside the fieldset, not at its border */
 legend {
-    float: left;
 }
 
 .nav-button-row {

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -103,10 +103,12 @@
 
     {% if field.type == 'RadioField' or field.type == 'UnlockCodeField' or field.type == 'IdNrField' or field.type == 'SteuerlotseDateField' %}
         {% if label.text %} {# Only show legend if there is a legend text to show #}
-            <legend class="field-label {{ class }}">{{ label.text }}
-                {% if optional %}<span class="optional-hint">{{ _('form.optional') }}</span>{% endif %}
-                {% if help %}{{ help_button(label.field_id) }}{% endif %}
-            </legend>
+            <span>
+                <legend class="field-label {{ class }}">{{ label.text }}
+                    {% if optional %}<span class="optional-hint">{{ _('form.optional') }}</span>{% endif %}
+                    {% if help %}{{ help_button(label.field_id) }}{% endif %}
+                </legend>
+            </span>
         {% endif %}
     {% else %}
         <label for="{{ label.field_id }}"

--- a/webapp/app/templates/lotse/form_person_a.html
+++ b/webapp/app/templates/lotse/form_person_a.html
@@ -4,9 +4,11 @@
 
 {% block form_content %}
     <fieldset class="grouped-input-fields">
-        <legend class="mb-0">
-            <h2 class="form-sub-heading">{{ _('form.lotse.person-header-allgemein') }}</h2>
-        </legend>
+        <span>
+            <legend class="mb-0">
+                <h2 class="form-sub-heading">{{ _('form.lotse.person-header-allgemein') }}</h2>
+            </legend>
+        </span>
         <div class="form-row-center">
             {{ macros.render_field(form.person_a_first_name, first_field=True if not render_info.form.errors) }}
         </div>
@@ -25,9 +27,11 @@
     </fieldset>
 
     <fieldset class="grouped-input-fields">
-        <legend class="mb-0">
-            <h2 class="form-sub-heading">{{ _('form.lotse.person-header-addresse') }}</h2>
-        </legend>
+        <span>
+            <legend class="mb-0">
+                <h2 class="form-sub-heading">{{ _('form.lotse.person-header-addresse') }}</h2>
+            </legend>
+        </span>
         <div class="form-row-center">
             {{ macros.render_field(form.person_a_street) }}
             {{ macros.render_field(form.person_a_street_number, 2) }}
@@ -43,18 +47,22 @@
     </fieldset>
 
     <fieldset class="grouped-input-fields">
-        <legend class="mb-0">
-            <h2 class="form-sub-heading">{{ _('form.lotse.person-header-religion') }}</h2>
-        </legend>
+        <span>
+            <legend class="mb-0">
+                <h2 class="form-sub-heading">{{ _('form.lotse.person-header-religion') }}</h2>
+            </legend>
+        </span>
         <div class="form-row-center">
             {{ macros.render_field(form.person_a_religion) }}
         </div>
     </fieldset>
 
     <fieldset class="grouped-input-fields">
-        <legend class="mb-0">
-            <h2 class="form-sub-heading mb-3">{{ _('form.lotse.person-header-beh') }}</h2>
-        </legend>
+        <span>
+            <legend class="mb-0">
+                <h2 class="form-sub-heading mb-3">{{ _('form.lotse.person-header-beh') }}</h2>
+            </legend>
+        </span>
         <p>{{ _('form.lotse.person-header-beh-intro') }}</p>
         <div class="form-row-center">
             {{ macros.render_field(form.person_a_beh_grad, 4) }}

--- a/webapp/app/templates/lotse/form_person_b.html
+++ b/webapp/app/templates/lotse/form_person_b.html
@@ -4,9 +4,11 @@
 
 {% block form_content %}
     <fieldset class="grouped-input-fields">
-        <legend class="mb-0">
-            <h2 class="form-sub-heading">{{ _('form.lotse.person-header-allgemein') }}</h2>
-        </legend>
+        <span>
+            <legend class="mb-0">
+                <h2 class="form-sub-heading">{{ _('form.lotse.person-header-allgemein') }}</h2>
+            </legend>
+        </span>
         <div class="form-row-center">
             {{ macros.render_field(form.person_b_first_name, first_field=True if not render_info.form.errors) }}
         </div>
@@ -22,9 +24,11 @@
     </fieldset>
 
     <fieldset class="grouped-input-fields">
-        <legend class="mb-3">
-            <h2 class="form-sub-heading">{{ _('form.lotse.person-header-addresse') }}</h2>
-        </legend>
+        <span>
+            <legend class="mb-3">
+                <h2 class="form-sub-heading">{{ _('form.lotse.person-header-addresse') }}</h2>
+            </legend>
+        </span>
         {{ macros.render_field(form.person_b_same_address, 10, class='w-100') }}
 
         <div id="form_address_fields" class="grouped-input-fields hidden">
@@ -44,18 +48,22 @@
     </fieldset>
 
     <fieldset class="grouped-input-fields">
-        <legend class="mb-0">
-            <h2 class="form-sub-heading">{{ _('form.lotse.person-header-religion') }}</h2>
-        </legend>
+        <span>
+            <legend class="mb-0">
+                <h2 class="form-sub-heading">{{ _('form.lotse.person-header-religion') }}</h2>
+            </legend>
+        </span>
         <div class="form-row-center">
             {{ macros.render_field(form.person_b_religion, 6) }}
         </div>
     </fieldset>
 
     <fieldset class="grouped-input-fields">
-        <legend class="mb-0">
-            <h2 class="form-sub-heading mb-3">{{ _('form.lotse.person-header-beh') }}</h2>
-        </legend>
+        <span>
+            <legend class="mb-0">
+                <h2 class="form-sub-heading mb-3">{{ _('form.lotse.person-header-beh') }}</h2>
+            </legend>
+        </span>
         <p>{{ _('form.lotse.person-header-beh-intro') }}</p>
         <div class="form-row-center">
             {{ macros.render_field(form.person_b_beh_grad, 4) }}


### PR DESCRIPTION
# Short Description
The personal data page looked very buggy in Firefox (s. this ticket). The reason for that is that we set the legend to float left. This affected the next container. The legend is set to float left because it otherwise will not be inside the container of the fieldset (s. [this comment](https://stackoverflow.com/a/24627851)). However, we can achieve the same by enclosing the fieldset in a span (see [here](https://stackoverflow.com/a/13844153). This does fix the issue on Firefox and looks good on Chrome and Safari.

# Changes
- Remove CSS for legend
- Enclose all legends on Person A, Person B and in the component's macro with a span element

# Feedback
- Does that make sense to you? Do you see any issues with that?
- Did I miss any important legend?
