### PR TITLE
Fix errors with additional eligibility steps

### DIFF
--- a/webapp/app/forms/steps/eligibility_steps.py
+++ b/webapp/app/forms/steps/eligibility_steps.py
@@ -46,7 +46,8 @@ class EligibilityStepMixin:
         return False
 
     def number_of_users(self, input_data):
-        if data_fits_data_model(MarriedJointTaxesEligibilityData, input_data):
+        if data_fits_data_model(MarriedJointTaxesEligibilityData, input_data) \
+                or data_fits_data_model(SeparatedJointTaxesEligibilityData, input_data):
             return 2
         else:
             return 1

--- a/webapp/app/model/eligibility_data.py
+++ b/webapp/app/model/eligibility_data.py
@@ -223,7 +223,8 @@ class DivorcedJointTaxesEligibilityData(RecursiveDataModel):
 class AlimonyEligibilityData(RecursiveDataModel):
     is_widowed: Optional[WidowedEligibilityData]
     is_single: Optional[SingleEligibilityData]
-    no_divorced_joint_taxes: Optional[DivorcedJointTaxesEligibilityData]
+    divorced_joint_taxes: Optional[DivorcedJointTaxesEligibilityData]
+    no_separated_lived_together: Optional[SeparatedNotLivedTogetherEligibilityData]
     no_separated_joint_taxes: Optional[SeparatedNoJointTaxesEligibilityData]
     alimony_eligibility: str
 

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -4878,11 +4878,11 @@ msgid "forms.eligibility.incorrect_data.description"
 msgstr ""
 "Die gesendeten Daten konnten nicht verarbeitet werden. Bitte versuchen "
 "Sie es erneut. Benutzen Sie dafür den Zurück-Knopf in Ihrem Browser oder "
-"gehen Sie zurück zu Voraussetzungen prüfen."
+"gehen Sie zurück zu Nutzung prüfen."
 
 #: app/templates/error/incorrect_eligiblity_data.html:9
 msgid "form.eligibility.back-to-form"
-msgstr "Zurück zu Voraussetzungen prüfen"
+msgstr "Zurück zu Nutzung prüfen"
 
 #: app/templates/error/pdf_not_found.html:8
 msgid "pdf_not_found.title"

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -4815,7 +4815,7 @@ msgstr "400 - Fehlerhafte Anfrage"
 msgid "400.description"
 msgstr ""
 "In Ihrer Anfrage waren Werte (nicht) enthalten, die dazu führen, dass die"
-" Anfrage nicht verartbeitet werden kann."
+" Anfrage nicht verarbeitet werden kann."
 
 #: app/templates/error/400.html:9 app/templates/error/404.html:9
 #: app/templates/error/429.html:9 app/templates/error/500.html:9

--- a/webapp/tests/model/test_eligibility_data.py
+++ b/webapp/tests/model/test_eligibility_data.py
@@ -409,14 +409,44 @@ class TestAlimonyEligibilityData(unittest.TestCase):
                 patch('app.model.eligibility_data.DivorcedJointTaxesEligibilityData.parse_obj'):
             self.assertRaises(ValidationError, AlimonyEligibilityData.parse_obj, non_valid_data)
 
-    def test_if_widowed_and_single_status_and_divorced_joint_taxes_invalid_and_alimony_no_then_raise_validation_error(self):
+    def test_if_not_separated_living_valid_and_alimony_yes_then_raise_validation_error(self):
+        non_valid_data = {'alimony_eligibility': 'yes'}
+        with patch('app.model.eligibility_data.WidowedEligibilityData.parse_obj',
+                   MagicMock(side_effect=ValidationError([], WidowedEligibilityData))), \
+                patch('app.model.eligibility_data.SingleEligibilityData.parse_obj',
+                      MagicMock(side_effect=ValidationError([], SingleEligibilityData))), \
+                patch('app.model.eligibility_data.DivorcedJointTaxesEligibilityData.parse_obj',
+                      MagicMock(side_effect=ValidationError([], DivorcedJointTaxesEligibilityData))), \
+                patch('app.model.eligibility_data.SeparatedNotLivedTogetherEligibilityData.parse_obj'), \
+                patch('app.model.eligibility_data.SeparatedNoJointTaxesEligibilityData.parse_obj',
+                      MagicMock(side_effect=ValidationError([], SeparatedNoJointTaxesEligibilityData))):
+            self.assertRaises(ValidationError, AlimonyEligibilityData.parse_obj, non_valid_data)
+
+    def test_if_not_joint_taxes_valid_and_alimony_yes_then_raise_validation_error(self):
+        non_valid_data = {'alimony_eligibility': 'yes'}
+        with patch('app.model.eligibility_data.WidowedEligibilityData.parse_obj',
+                   MagicMock(side_effect=ValidationError([], WidowedEligibilityData))), \
+                patch('app.model.eligibility_data.SingleEligibilityData.parse_obj',
+                      MagicMock(side_effect=ValidationError([], SingleEligibilityData))), \
+                patch('app.model.eligibility_data.DivorcedJointTaxesEligibilityData.parse_obj',
+                      MagicMock(side_effect=ValidationError([], DivorcedJointTaxesEligibilityData))), \
+                patch('app.model.eligibility_data.SeparatedNotLivedTogetherEligibilityData.parse_obj',
+                      MagicMock(side_effect=ValidationError([], SeparatedNotLivedTogetherEligibilityData))), \
+                patch('app.model.eligibility_data.SeparatedNoJointTaxesEligibilityData.parse_obj'):
+            self.assertRaises(ValidationError, AlimonyEligibilityData.parse_obj, non_valid_data)
+
+    def test_if_all_previous_data_is_invalid_and_alimony_no_then_raise_validation_error(self):
         valid_data = {'alimony_eligibility': 'no'}
         with patch('app.model.eligibility_data.WidowedEligibilityData.parse_obj',
                    MagicMock(side_effect=ValidationError([], WidowedEligibilityData))), \
                 patch('app.model.eligibility_data.SingleEligibilityData.parse_obj',
                       MagicMock(side_effect=ValidationError([], SingleEligibilityData))), \
                 patch('app.model.eligibility_data.DivorcedJointTaxesEligibilityData.parse_obj',
-                      MagicMock(side_effect=ValidationError([], DivorcedJointTaxesEligibilityData))):
+                      MagicMock(side_effect=ValidationError([], DivorcedJointTaxesEligibilityData))), \
+             patch('app.model.eligibility_data.SeparatedNotLivedTogetherEligibilityData.parse_obj',
+                      MagicMock(side_effect=ValidationError([], SeparatedNotLivedTogetherEligibilityData))), \
+            patch('app.model.eligibility_data.SeparatedNoJointTaxesEligibilityData.parse_obj',
+                      MagicMock(side_effect=ValidationError([], SeparatedNoJointTaxesEligibilityData))):
             self.assertRaises(ValidationError, AlimonyEligibilityData.parse_obj, valid_data)
 
     def test_if_widowed_valid_and_alimony_no_then_raise_no_validation_error(self):
@@ -453,6 +483,38 @@ class TestAlimonyEligibilityData(unittest.TestCase):
                     patch('app.model.eligibility_data.SingleEligibilityData.parse_obj',
                           MagicMock(side_effect=ValidationError([], SingleEligibilityData))), \
                     patch('app.model.eligibility_data.DivorcedJointTaxesEligibilityData.__init__',
+                          MagicMock(return_value=None)):
+                AlimonyEligibilityData.parse_obj(valid_data)
+        except ValidationError as e:
+            self.fail("AlimonyEligibilityData.parse_obj should not raise validation error")
+
+    def test_if_not_separated_living_valid_and_alimony_no_then_raise_no_validation_error(self):
+        valid_data = {'alimony_eligibility': 'no'}
+        try:
+            with patch('app.model.eligibility_data.WidowedEligibilityData.parse_obj',
+                       MagicMock(side_effect=ValidationError([], WidowedEligibilityData))), \
+                    patch('app.model.eligibility_data.SingleEligibilityData.parse_obj',
+                          MagicMock(side_effect=ValidationError([], SingleEligibilityData))), \
+                patch('app.model.eligibility_data.DivorcedJointTaxesEligibilityData.parse_obj',
+                      MagicMock(side_effect=ValidationError([], DivorcedJointTaxesEligibilityData))), \
+                    patch('app.model.eligibility_data.SeparatedNotLivedTogetherEligibilityData.__init__',
+                          MagicMock(return_value=None)):
+                AlimonyEligibilityData.parse_obj(valid_data)
+        except ValidationError as e:
+            self.fail("AlimonyEligibilityData.parse_obj should not raise validation error")
+
+    def test_if_not_separated_joint_taxes_valid_and_alimony_no_then_raise_no_validation_error(self):
+        valid_data = {'alimony_eligibility': 'no'}
+        try:
+            with patch('app.model.eligibility_data.WidowedEligibilityData.parse_obj',
+                       MagicMock(side_effect=ValidationError([], WidowedEligibilityData))), \
+                    patch('app.model.eligibility_data.SingleEligibilityData.parse_obj',
+                          MagicMock(side_effect=ValidationError([], SingleEligibilityData))), \
+                patch('app.model.eligibility_data.DivorcedJointTaxesEligibilityData.parse_obj',
+                      MagicMock(side_effect=ValidationError([], DivorcedJointTaxesEligibilityData))), \
+                patch('app.model.eligibility_data.SeparatedNotLivedTogetherEligibilityData.parse_obj',
+                      MagicMock(side_effect=ValidationError([], SeparatedNotLivedTogetherEligibilityData))), \
+                    patch('app.model.eligibility_data.SeparatedNoJointTaxesEligibilityData.__init__',
                           MagicMock(return_value=None)):
                 AlimonyEligibilityData.parse_obj(valid_data)
         except ValidationError as e:


### PR DESCRIPTION
# Short Description
This fixes three smaller issues with the eligibility flow:
- [missing plural form if users do joint taxes](https://steuerlotse.atlassian.net/browse/STL-1306?atlOrigin=eyJpIjoiZmUxNzdkMTkyNTRkNDUwM2FkNjM4M2E4YjAzZTcyYTIiLCJwIjoiaiJ9)
- [wrong text on error page for incorrect input data](https://steuerlotse.atlassian.net/browse/STL-1308?atlOrigin=eyJpIjoiYWIwMDNhN2ExN2ZmNGI5MDk3OTY1ZGVhZDAyZTBhMDMiLCJwIjoiaiJ9)
- [incorrect data error is shown for correct path (user lives separately)](https://steuerlotse.atlassian.net/browse/STL-1307?atlOrigin=eyJpIjoiMWVmNjNlZmFmZmE3NDI4Nzk2YzJkMGU4ZWExY2RhNTUiLCJwIjoiaiJ9) 

# Changes
- Change texts
- Add SeparatedJointTaxesEligibilityData to `number_of_user` method to determine if a couple is using the Steuerlotse
- Add `SeparatedNotLivedTogetherEligibilityData` to `AlimonyEligibilityData` because this is a correct path to get to that point

# Feedback
- \
