### PR TITLE
Fix Safari baseline bug for entries fields

### DIFF
--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -15,25 +15,36 @@ from babel.numbers import format_decimal, parse_decimal
 from app.forms.validators import ValidElsterCharacterSet
 
 
+class SafariBaselineBugFixMixin:
+    """ Safari has a bug where empty input fields do not align correctly with baseline alignment. The reason is that
+    if an input field is empty its bottom border is used as the baseline instead of the baseline of the text input.
+    This can be fixed by setting a placeholder text. """
+
+    def __call__(self, field, **kwargs):
+        # Safari has a bug where empty input fields do not align correctly with baseline alignment.
+        # Thus, we add a placeholder.
+        kwargs.setdefault('placeholder', ' ')
+        return kwargs
+
+
 class SteuerlotseStringField(StringField):
 
     def pre_validate(self, form):
         ValidElsterCharacterSet().__call__(form, self)
 
 
-class MultipleInputFieldWidget(TextInput):
+class MultipleInputFieldWidget(TextInput, SafariBaselineBugFixMixin):
     """A divided input field."""
     sub_field_separator = ''
     input_field_lengths = []
     input_field_labels = []
 
     def __call__(self, field, **kwargs):
+        kwargs = SafariBaselineBugFixMixin.__call__(self, field, **kwargs)
+
         if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
             kwargs['required'] = True
         kwargs['class'] = 'form-control'
-        # Safari has a bug where empty input fields do not align correctly with baseline alignment.
-        # Thus, we add a placeholder.
-        kwargs['placeholder'] = ' '
 
         joined_input_fields = Markup()
         for idx, input_field_length in enumerate(self.input_field_lengths):
@@ -232,7 +243,7 @@ class ConfirmationField(BooleanField):
         )
 
 
-class JqueryEntriesWidget(object):
+class JqueryEntriesWidget(SafariBaselineBugFixMixin, object):
     """A custom multi-entry widget that is based on jquery."""
     html_params = staticmethod(html_params)
 
@@ -240,6 +251,7 @@ class JqueryEntriesWidget(object):
         self.input_type = None
 
     def __call__(self, field, **kwargs):
+        kwargs = super().__call__(field, **kwargs)
         kwargs.setdefault('id', field.id)
         kwargs.setdefault('data', field.data)
         kwargs.setdefault('split_chars', field.split_chars)

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -15,13 +15,13 @@ from babel.numbers import format_decimal, parse_decimal
 from app.forms.validators import ValidElsterCharacterSet
 
 
-class SafariBaselineBugFixMixin:
-    """ Safari has a bug where empty input fields do not align correctly with baseline alignment. The reason is that
+class BaselineBugFixMixin:
+    """ Safari and Firefox have a bug where empty input fields do not align correctly with baseline alignment. The reason is that
     if an input field is empty its bottom border is used as the baseline instead of the baseline of the text input.
     This can be fixed by setting a placeholder text. """
 
     def __call__(self, field, **kwargs):
-        # Safari has a bug where empty input fields do not align correctly with baseline alignment.
+        # Safari and Firefox have has a bug where empty input fields do not align correctly with baseline alignment.
         # Thus, we add a placeholder.
         kwargs.setdefault('placeholder', ' ')
         return kwargs
@@ -33,14 +33,14 @@ class SteuerlotseStringField(StringField):
         ValidElsterCharacterSet().__call__(form, self)
 
 
-class MultipleInputFieldWidget(TextInput, SafariBaselineBugFixMixin):
+class MultipleInputFieldWidget(TextInput, BaselineBugFixMixin):
     """A divided input field."""
     sub_field_separator = ''
     input_field_lengths = []
     input_field_labels = []
 
     def __call__(self, field, **kwargs):
-        kwargs = SafariBaselineBugFixMixin.__call__(self, field, **kwargs)
+        kwargs = BaselineBugFixMixin.__call__(self, field, **kwargs)
 
         if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
             kwargs['required'] = True
@@ -243,7 +243,7 @@ class ConfirmationField(BooleanField):
         )
 
 
-class JqueryEntriesWidget(SafariBaselineBugFixMixin, object):
+class JqueryEntriesWidget(BaselineBugFixMixin, object):
     """A custom multi-entry widget that is based on jquery."""
     html_params = staticmethod(html_params)
 

--- a/webapp/app/templates/fields/jquery_entries.html
+++ b/webapp/app/templates/fields/jquery_entries.html
@@ -9,11 +9,12 @@ We set a corresponding class determining the width depending on max_characters. 
 {% endif %}
 {% macro remove_button() %}<button type="button" id="{{id}}-remove" class="remove-button" aria-label="{{ _('jquery_entries.remove.aria-label') }}">×</button>{% endmacro -%}
 
+
+{% macro entry(kwargs, item=None) %}<div class="{{dynamic_div_classes}}"><input {% if 'autofocus' in kwargs %}autofocus {% endif %} {% if 'placeholder' in kwargs %}placeholder="{{kwargs['placeholder']}}" {% endif %} class="dynamic-entry {{dynamic_input_classes}}" type="text" {% if item %}value="{{item}}"{% endif %}>{{remove_button()}}</div>{% endmacro %}
+
 <div id="{{id}}-div">
     {%- for item in kwargs['data'] %}
-    <div class="{{dynamic_div_classes}}">
-        <input {% if 'autofocus' in kwargs %}autofocus {% endif %}class="dynamic-entry {{dynamic_input_classes}}" type="text" value="{{item}}">{{remove_button()}}
-    </div>
+        {{ entry(kwargs, item) }}
     {%- endfor -%}
 </div>
 <input name="{{id}}" type="hidden" value="{{kwargs['value']}}" />
@@ -30,7 +31,7 @@ We set a corresponding class determining the width depending on max_characters. 
 
         $('#{{id}}-add').on('click', function (event) {
             event.preventDefault();
-            $app.append($('<div class="{{dynamic_div_classes}}"><input class="dynamic-entry {{dynamic_input_classes}}" type="text">{{remove_button()}}</div>'))
+            $app.append($('{{entry(kwargs)}}'))
                 .find('input').focus();
         });
 


### PR DESCRIPTION
# Short Description
The delete entry button was not aligned in Safari (s. [this ticket](https://steuerlotse.atlassian.net/browse/STL-1286?atlOrigin=eyJpIjoiOWRhOTA0MjNjMzEyNDg4ZWE0YWI2MTg0NDE3MWU5Y2YiLCJwIjoiaiJ9)). In Safari [align-items uses bottom border from empty input fields](https://github.com/philipwalton/flexbugs/issues/270). Using an empty placeholder text as discussed [here](https://github.com/digitalservice4germany/steuerlotse/pull/70) fixes this issue.

# Changes
- Add a new Mixin, which can be used to set the placeholder text in widgets.
- Set the placeholder text also in the `jquery_entries.html` because the entries fields are set there

# Feedback
- Do you have any better idea how to set the placeholder for the entries field than the added macro?
