### PR TITLE
Delete familienstand dates

### DIFF
--- a/webapp/app/templates/lotse/form_familienstand.html
+++ b/webapp/app/templates/lotse/form_familienstand.html
@@ -53,12 +53,17 @@
             }
         }
 
+
+        function delete_date_field_value(input_name){
+            $('#' + input_name + ' :input').val('');
+        }
+
         function show_hide_date_field(show_condition, input_name) {
             if (show_condition) {
                 $('#' + input_name + '_field').show();
             } else {
                 $('#' + input_name + '_field').hide();
-                $('#' + input_name).attr('value', '');
+                delete_date_field_value(input_name);
             }
         }
 
@@ -153,6 +158,7 @@
         }
 
         function show_hide_all_fields() {
+            remove_familienstand_date_input();
             show_hide_familienstand_date_field()
             show_hide_familienstand_married_lived_separated_field()
             show_hide_familienstand_married_lived_separated_since_field()

--- a/webapp/app/templates/lotse/form_familienstand.html
+++ b/webapp/app/templates/lotse/form_familienstand.html
@@ -162,7 +162,6 @@
         }
 
         function show_hide_all_fields() {
-            remove_familienstand_date_input();
             show_hide_familienstand_date_field()
             show_hide_familienstand_married_lived_separated_field()
             show_hide_familienstand_married_lived_separated_since_field()
@@ -176,6 +175,7 @@
         $(document).ready(function () {
             show_hide_all_fields()
 
+            $(`input[type="radio"]`).change(remove_familienstand_date_input);
             $(`input[type="radio"]`).change(show_hide_all_fields);
             $(`#familienstand_married_lived_separated`).change(show_hide_familienstand_married_lived_separated_since_field);
             $(`#familienstand_married_lived_separated`).change(show_hide_familienstand_confirm_zusammenveranlagung_field);

--- a/webapp/app/templates/lotse/form_familienstand.html
+++ b/webapp/app/templates/lotse/form_familienstand.html
@@ -88,6 +88,10 @@
             }
         }
 
+        function remove_familienstand_date_input(){
+            delete_date_field_value('familienstand_date');
+        }
+
         function show_hide_familienstand_date_field() {
             show_hide_date_field($('input[value="married"]').is(':checked') ||
                 $('input[value="widowed"]').is(':checked') ||


### PR DESCRIPTION
# Short Description
Changing the marital status on Familienstand did not delete the data of the date fields. This was because the date field is now a split into three inputs and the value has to be reset on all of them. Furthermore, it only happened for the fields that are not shown.

Relevant ticket can be found [here](https://steuerlotse.atlassian.net/browse/STL-1283?atlOrigin=eyJpIjoiYWM5NzJmYWQ3ZmRlNGRlYWI5ZjJkMDdiZGE3YTc3ZmUiLCJwIjoiaiJ9).

# Changes
- This sets the values of all the child inputs of the corresponding fields to "" (delete the date for the split fields)
- This deletes the input on the date field on every change of the marital status

# Feedback
- Do you see any problems with this?
