### PR TITLE
Remove background-clip from buttons

### DIFF
--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -9,7 +9,6 @@
     text-decoration: none;
     color: var(--inverse-text-color);
     background: var(--link-color);
-    background-clip: padding-box;
     display: inline-block;
     position: relative;
     border: none;


### PR DESCRIPTION
# Short Description
On Safari buttons had a fine line near the bottom. Background: Our buttons have the background-clipping property set to padding-box. This means that the background does not stretch into the border which will result in this fine line between the border and the inner content of the box.
If we do not clip the background at the padding-box, we do not have this problem. I went through the places where the buttons are set and I could not find any special place where we want to clip the background. I guess that this was useful in one of the earlier designs.

# Changes
- Remove the mentioned css property

# Feedback
- Do you see any part in the design the change could break?
