### PR TITLE
Set autofocus only for first input field

### DIFF
--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -44,6 +44,10 @@ class MultipleInputFieldWidget(TextInput):
             kwargs['value'] = field._value()[idx] if len(field._value()) >= idx + 1 else ''
             kwargs['class'] = kwargs.get('class', '') + f' input-width-{input_field_length}'
 
+            if idx > 0:
+                # Make sure that autofocus is only set for the first input field
+                kwargs['autofocus'] = False
+
             if len(self.input_field_labels) > idx:
                 joined_input_fields += Markup(
                     f'<div>'


### PR DESCRIPTION
# Short Description
For inputs with multiple input fields (e.g. idnr in the registration step) the autofocus is set for all of the input fields. As Safari will always focus the last set input field this will focus the last of the input fields (e.g. the year for a date field). This fixes that by setting the autofocus argument to true at the second input field.

[Corresponding ticket](https://steuerlotse.atlassian.net/browse/STL-1284?atlOrigin=eyJpIjoiMzNkYWEyMzNlNWUyNDE3Yzk5MjRkNGI0YTA4ZjIxMmUiLCJwIjoiaiJ9)

# Changes
- Set the autofocus to false for all the input fields after the first one

# Feedback
- Do you see any problem with that?
- Did you expect some other solution?
