### PR TITLE
Add inputmode numeric to relevant fields

### DIFF
--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -45,10 +45,6 @@ class MultipleInputFieldWidget(TextInput):
     input_field_lengths = []
     input_field_labels = []
 
-    @staticmethod
-    def set_inputmode(**kwargs):
-        return kwargs
-
     def __call__(self, field, **kwargs):
         if 'required' not in kwargs and 'required' in getattr(field, 'flags', []):
             kwargs['required'] = True

--- a/webapp/app/forms/flows/lotse_flow.py
+++ b/webapp/app/forms/flows/lotse_flow.py
@@ -6,7 +6,8 @@ from wtforms.fields.core import UnboundField, SelectField, BooleanField, RadioFi
 from app import app
 from app.data_access.audit_log_controller import create_audit_log_confirmation_entry
 from app.forms.fields import SteuerlotseSelectField, YesNoField, SteuerlotseDateField, SteuerlotseStringField, \
-    ConfirmationField, EntriesField, EuroField, IdNrField, IntegerField, SteuerlotseIntegerField
+    ConfirmationField, EntriesField, EuroField, IdNrField, IntegerField, SteuerlotseIntegerField, \
+    SteuerlotseNumericStringField
 from app.model.form_data import MandatoryFormData, FamilienstandModel, MandatoryConfirmations, \
     ConfirmationMissingInputValidationError, MandatoryFieldMissingValidationError, InputDataInvalidError, \
     IdNrMismatchInputValidationError
@@ -387,7 +388,7 @@ class LotseMultiStepFlow(MultiStepFlow):
             value_representation = ', '.join(value)
         elif field.field_class == EuroField:
             value_representation = str(value) + " €"
-        elif field.field_class == SteuerlotseStringField or field.field_class == IdNrField:
+        elif field.field_class == SteuerlotseStringField or field.field_class == IdNrField or SteuerlotseNumericStringField:
             value_representation = value
         elif field.field_class == IntegerField or field.field_class == SteuerlotseIntegerField:
             value_representation = value

--- a/webapp/app/forms/flows/lotse_flow.py
+++ b/webapp/app/forms/flows/lotse_flow.py
@@ -6,7 +6,7 @@ from wtforms.fields.core import UnboundField, SelectField, BooleanField, RadioFi
 from app import app
 from app.data_access.audit_log_controller import create_audit_log_confirmation_entry
 from app.forms.fields import SteuerlotseSelectField, YesNoField, SteuerlotseDateField, SteuerlotseStringField, \
-    ConfirmationField, EntriesField, EuroField, IdNrField, IntegerField
+    ConfirmationField, EntriesField, EuroField, IdNrField, IntegerField, SteuerlotseIntegerField
 from app.model.form_data import MandatoryFormData, FamilienstandModel, MandatoryConfirmations, \
     ConfirmationMissingInputValidationError, MandatoryFieldMissingValidationError, InputDataInvalidError, \
     IdNrMismatchInputValidationError
@@ -389,7 +389,7 @@ class LotseMultiStepFlow(MultiStepFlow):
             value_representation = str(value) + " €"
         elif field.field_class == SteuerlotseStringField or field.field_class == IdNrField:
             value_representation = value
-        elif field.field_class == IntegerField or field.field_class == IntegerField:
+        elif field.field_class == IntegerField or field.field_class == SteuerlotseIntegerField:
             value_representation = value
         elif field.field_class == ConfirmationField:
             value_representation = "Ja" if value else "Nein"

--- a/webapp/app/forms/steps/lotse/personal_data_steps.py
+++ b/webapp/app/forms/steps/lotse/personal_data_steps.py
@@ -3,7 +3,7 @@ from pydantic import ValidationError
 from app.forms import SteuerlotseBaseForm
 from app.forms.steps.step import FormStep, SectionLink
 from app.forms.fields import YesNoField, SteuerlotseDateField, SteuerlotseSelectField, ConfirmationField, \
-    SteuerlotseStringField, IdNrField, SteuerlotseIntegerField
+    SteuerlotseStringField, IdNrField, SteuerlotseIntegerField, SteuerlotseNumericStringField
 
 from flask_babel import _, ngettext
 from flask_babel import lazy_gettext as _l
@@ -172,13 +172,11 @@ class StepSteuernummer(FormStep):
             render_kw={'data_label': _l('form.lotse.field_bundesland.data_label'),
                        'input_req_err_msg': _l('form.lotse.field_bundesland_required')}
         )
-        steuernummer = SteuerlotseStringField(label=_l('form.lotse.steuernummer'),
+        steuernummer = SteuerlotseNumericStringField(label=_l('form.lotse.steuernummer'),
                                               validators=[InputRequired(), DecimalOnly(),
                                                           IntegerLength(min=10, max=11)],
                                               render_kw={'data_label': _l('form.lotse.steuernummer.data_label'),
-                                                         'example_input': _l('form.lotse.steuernummer.example_input'),
-                                                         'input_mode': 'numeric',
-                                                         'pattern': '[0-9]*'})
+                                                         'example_input': _l('form.lotse.steuernummer.example_input')})
 
     def __init__(self, **kwargs):
         super(StepSteuernummer, self).__init__(
@@ -268,12 +266,10 @@ class StepPersonA(FormStep):
             render_kw={'data_label': _l('form.lotse.field_person_address_ext.data_label'),
                        'max_characters': 25},
             validators=[validators.length(max=25)])
-        person_a_plz = SteuerlotseStringField(
+        person_a_plz = SteuerlotseNumericStringField(
             label=_l('form.lotse.field_person_plz'),
             render_kw={'data_label': _l('form.lotse.field_person_plz.data_label'),
-                       'max_characters': 5,
-                       'input_mode': 'numeric',
-                       'pattern': '[0-9]*'},
+                       'max_characters': 5},
             validators=[InputRequired(), DecimalOnly(), validators.length(max=5)])
         person_a_town = SteuerlotseStringField(
             label=_l('form.lotse.field_person_town'),
@@ -407,13 +403,11 @@ class StepPersonB(FormStep):
             render_kw={'data_label': _l('form.lotse.field_person_address_ext.data_label'),
                        'max_characters': 25},
             validators=[validators.length(max=25)])
-        person_b_plz = SteuerlotseStringField(
+        person_b_plz = SteuerlotseNumericStringField(
             label=_l('form.lotse.field_person_plz'),
             render_kw={'data_label': _l('form.lotse.field_person_plz.data_label'),
                        'max_characters': 5,
-                       'required_if_shown': True,
-                       'input_mode': 'numeric',
-                       'pattern': '[0-9]*'},
+                       'required_if_shown': True},
             validators=[input_required_if_not_same_address, DecimalOnly(), validators.length(max=5)])
         person_b_town = SteuerlotseStringField(
             label=_l('form.lotse.field_person_town'),

--- a/webapp/app/forms/steps/lotse/personal_data_steps.py
+++ b/webapp/app/forms/steps/lotse/personal_data_steps.py
@@ -3,7 +3,7 @@ from pydantic import ValidationError
 from app.forms import SteuerlotseBaseForm
 from app.forms.steps.step import FormStep, SectionLink
 from app.forms.fields import YesNoField, SteuerlotseDateField, SteuerlotseSelectField, ConfirmationField, \
-    SteuerlotseStringField, IdNrField
+    SteuerlotseStringField, IdNrField, SteuerlotseIntegerField
 
 from flask_babel import _, ngettext
 from flask_babel import lazy_gettext as _l
@@ -176,7 +176,9 @@ class StepSteuernummer(FormStep):
                                               validators=[InputRequired(), DecimalOnly(),
                                                           IntegerLength(min=10, max=11)],
                                               render_kw={'data_label': _l('form.lotse.steuernummer.data_label'),
-                                                         'example_input': _l('form.lotse.steuernummer.example_input')})
+                                                         'example_input': _l('form.lotse.steuernummer.example_input'),
+                                                         'input_mode': 'numeric',
+                                                         'pattern': '[0-9]*'})
 
     def __init__(self, **kwargs):
         super(StepSteuernummer, self).__init__(
@@ -251,7 +253,7 @@ class StepPersonA(FormStep):
             render_kw={'data_label': _l('form.lotse.field_person_street.data_label'),
                        'max_characters': 25},
             validators=[InputRequired(), validators.length(max=25)])
-        person_a_street_number = IntegerField(
+        person_a_street_number = SteuerlotseIntegerField(
             label=_l('form.lotse.field_person_street_number'),
             render_kw={'data_label': _l('form.lotse.field_person_street_number.data_label'),
                        'max_characters': 4},
@@ -269,7 +271,9 @@ class StepPersonA(FormStep):
         person_a_plz = SteuerlotseStringField(
             label=_l('form.lotse.field_person_plz'),
             render_kw={'data_label': _l('form.lotse.field_person_plz.data_label'),
-                       'max_characters': 5},
+                       'max_characters': 5,
+                       'input_mode': 'numeric',
+                       'pattern': '[0-9]*'},
             validators=[InputRequired(), DecimalOnly(), validators.length(max=5)])
         person_a_town = SteuerlotseStringField(
             label=_l('form.lotse.field_person_town'),
@@ -278,7 +282,7 @@ class StepPersonA(FormStep):
             validators=[InputRequired(), validators.length(max=20)])
         person_a_religion = get_religion_field()
 
-        person_a_beh_grad = IntegerField(
+        person_a_beh_grad = SteuerlotseIntegerField(
             label=_l('form.lotse.field_person_beh_grad'),
             validators=[
                 validators.any_of([25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100])],
@@ -386,7 +390,7 @@ class StepPersonB(FormStep):
                        'max_characters': 25,
                        'required_if_shown': True},
             validators=[input_required_if_not_same_address, validators.length(max=25)])
-        person_b_street_number = IntegerField(
+        person_b_street_number = SteuerlotseIntegerField(
             label=_l('form.lotse.field_person_street_number'),
             render_kw={'data_label': _l('form.lotse.field_person_street_number'
                                         '.data_label'),
@@ -407,7 +411,9 @@ class StepPersonB(FormStep):
             label=_l('form.lotse.field_person_plz'),
             render_kw={'data_label': _l('form.lotse.field_person_plz.data_label'),
                        'max_characters': 5,
-                       'required_if_shown': True},
+                       'required_if_shown': True,
+                       'input_mode': 'numeric',
+                       'pattern': '[0-9]*'},
             validators=[input_required_if_not_same_address, DecimalOnly(), validators.length(max=5)])
         person_b_town = SteuerlotseStringField(
             label=_l('form.lotse.field_person_town'),
@@ -417,7 +423,7 @@ class StepPersonB(FormStep):
             validators=[input_required_if_not_same_address, validators.length(max=20)])
         person_b_religion = get_religion_field()
 
-        person_b_beh_grad = IntegerField(
+        person_b_beh_grad = SteuerlotseIntegerField(
             label=_l('form.lotse.field_person_beh_grad'),
             validators=[validators.any_of([25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100])],
             render_kw={'help': _l('form.lotse.field_person_beh_grad-help'),


### PR DESCRIPTION
# Short Description
For touch input of integers we want to use `<input type="text" inputmode="numeric" pattern="[0-9]*">` instead of `<input type="number">` (s. [this ticket](https://steuerlotse.atlassian.net/browse/STL-1263?atlOrigin=eyJpIjoiMTY4YmI5ZmY4ZjQ3NDRhZWE5Y2M1MjcxZTE1ZDJhN2UiLCJwIjoiaiJ9)).
The fields which this would affect are:
- Date fields
- Tax ID
- Tax number
- House number
- Postal code
- Degree of disability

Relevant links:
- [Background info about input mode ](https://developer.mozilla.org/de/docs/Web/HTML/Global_attributes/inputmode)
- [Why Gov.uk changed the input type for numbers](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/)

# Changes
- Add `NumericInputMixin` with a method to add the relevant kwargs
- Add SteuerlotseIntegerField and SteuerlotseNumericStringField
- Set the correct kwargs in the custom fields  (SteuerlotseDate, IdNr, SteuerlotseIntegerField, SteuerlotseNumericStringField)
- Set the correct custom field types

# Feedback
- Does this make sense to you?
- Do you see any fields I've missed?
