### PR TITLE
Set no previous step for eligibility start

### DIFF
--- a/webapp/app/forms/flows/eligibility_step_chooser.py
+++ b/webapp/app/forms/flows/eligibility_step_chooser.py
@@ -81,6 +81,9 @@ class EligibilityStepChooser(StepChooser):
 
     def determine_prev_step(self, step_name):
         idx = self.step_order.index(step_name)
+        if idx == 0:
+            # Start step has no previous step
+            return None
         stored_data = self._get_session_data()
         for i in range(idx - 1, 0, -1):
             current_step = self.steps[self.step_order[i]]


### PR DESCRIPTION
# Short Description
Using the new function to determine the previous step we are also setting a previous step for the start step of the eligibility flow.
This adds a guard to the `determine_prev_step` function to set the previous step to None on the start step.

# Changes
- Add guard


# Feedback
/