### PR TITLE
Familienstand yesno bug

### DIFF
--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -293,7 +293,7 @@ class JqueryEntriesWidget(BaselineBugFixMixin, object):
         self.input_type = None
 
     def __call__(self, field, **kwargs):
-        kwargs = super().__call__(field, **kwargs)
+        kwargs = super().set_placeholder(kwargs)
         kwargs.setdefault('id', field.id)
         kwargs.setdefault('data', field.data)
         kwargs.setdefault('split_chars', field.split_chars)

--- a/webapp/app/templates/lotse/form_familienstand.html
+++ b/webapp/app/templates/lotse/form_familienstand.html
@@ -175,7 +175,7 @@
         $(document).ready(function () {
             show_hide_all_fields()
 
-            $(`input[type="radio"]`).change(remove_familienstand_date_input);
+            $(`input[type="radio"][name="familienstand"]`).change(remove_familienstand_date_input);
             $(`input[type="radio"]`).change(show_hide_all_fields);
             $(`#familienstand_married_lived_separated`).change(show_hide_familienstand_married_lived_separated_since_field);
             $(`#familienstand_married_lived_separated`).change(show_hide_familienstand_confirm_zusammenveranlagung_field);


### PR DESCRIPTION
# Short Description
We had a problem with the FamilienstandStep because we are now deleting the date for every change of the marital status. However, we did just look for any radio button to change. As the YesNo-Button is also a RadioField this would lead to a problem where the date got deleted whenever the user was changing the YesNo-Button. 
I've also cleaned up an outdated method call for the BugFixMixin, that lead to a problem

# Changes
- Select the correct radio button by using `[name="familienstand"]`
- Call `set_placeholder` for BugFixMixin instead of the outdated `__call__`

# Feedback
- Do you have any problem the the BugFixMixin fix is part of this PR?
