### PR TITLE
Set spellcheck false for name fields

### DIFF
--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -59,6 +59,14 @@ class SteuerlotseNumericStringField(NumericInputMixin, StringField):
         return super().__call__(**kwargs)
 
 
+class SteuerlotseNameStringField(StringField):
+
+    def __call__(self, *args, **kwargs):
+        kwargs.setdefault('spellcheck', 'false')
+
+        return super().__call__(**kwargs)
+
+
 class MultipleInputFieldWidget(TextInput, BaselineBugFixMixin):
     """A divided input field."""
     sub_field_separator = ''

--- a/webapp/app/forms/flows/lotse_flow.py
+++ b/webapp/app/forms/flows/lotse_flow.py
@@ -7,7 +7,7 @@ from app import app
 from app.data_access.audit_log_controller import create_audit_log_confirmation_entry
 from app.forms.fields import SteuerlotseSelectField, YesNoField, SteuerlotseDateField, SteuerlotseStringField, \
     ConfirmationField, EntriesField, EuroField, IdNrField, IntegerField, SteuerlotseIntegerField, \
-    SteuerlotseNumericStringField
+    SteuerlotseNumericStringField, SteuerlotseNameStringField
 from app.model.form_data import MandatoryFormData, FamilienstandModel, MandatoryConfirmations, \
     ConfirmationMissingInputValidationError, MandatoryFieldMissingValidationError, InputDataInvalidError, \
     IdNrMismatchInputValidationError
@@ -389,7 +389,7 @@ class LotseMultiStepFlow(MultiStepFlow):
         elif field.field_class == EuroField:
             value_representation = str(value) + " €"
         elif field.field_class == SteuerlotseStringField or field.field_class == IdNrField \
-                or field.field_class == SteuerlotseNumericStringField:
+                or field.field_class == SteuerlotseNumericStringField or field.field_class == SteuerlotseNameStringField:
             value_representation = value
         elif field.field_class == IntegerField or field.field_class == SteuerlotseIntegerField:
             value_representation = value

--- a/webapp/app/forms/steps/lotse/personal_data_steps.py
+++ b/webapp/app/forms/steps/lotse/personal_data_steps.py
@@ -3,7 +3,8 @@ from pydantic import ValidationError
 from app.forms import SteuerlotseBaseForm
 from app.forms.steps.step import FormStep, SectionLink
 from app.forms.fields import YesNoField, SteuerlotseDateField, SteuerlotseSelectField, ConfirmationField, \
-    SteuerlotseStringField, IdNrField, SteuerlotseIntegerField, SteuerlotseNumericStringField
+    SteuerlotseStringField, IdNrField, SteuerlotseIntegerField, SteuerlotseNumericStringField, \
+    SteuerlotseNameStringField
 
 from flask_babel import _, ngettext
 from flask_babel import lazy_gettext as _l
@@ -236,12 +237,12 @@ class StepPersonA(FormStep):
         person_a_dob = SteuerlotseDateField(
             label=_l('form.lotse.field_person_dob'),
             render_kw={'data_label': _l('form.lotse.field_person_dob.data_label')}, validators=[InputRequired()])
-        person_a_first_name = SteuerlotseStringField(
+        person_a_first_name = SteuerlotseNameStringField(
             label=_l('form.lotse.field_person_first_name'),
             render_kw={'data_label': _l('form.lotse.field_person_first_name.data_label'),
                        'max_characters': 25},
             validators=[InputRequired(), validators.length(max=25)])
-        person_a_last_name = SteuerlotseStringField(
+        person_a_last_name = SteuerlotseNameStringField(
             label=_l('form.lotse.field_person_last_name'),
             render_kw={'data_label': _l('form.lotse.field_person_last_name.data_label'),
                        'max_characters': 25},
@@ -362,12 +363,12 @@ class StepPersonB(FormStep):
             label=_l('form.lotse.field_person_dob'),
             render_kw={'data_label': _l('form.lotse.field_person_dob.data_label')},
             validators=[InputRequired()])
-        person_b_first_name = SteuerlotseStringField(
+        person_b_first_name = SteuerlotseNameStringField(
             label=_l('form.lotse.field_person_first_name'),
             render_kw={'data_label': _l('form.lotse.field_person_first_name.data_label'),
                        'max_characters': 25},
             validators=[InputRequired(), validators.length(max=25)])
-        person_b_last_name = SteuerlotseStringField(
+        person_b_last_name = SteuerlotseNameStringField(
             label=_l('form.lotse.field_person_last_name'),
             render_kw={'data_label': _l('form.lotse.field_person_last_name.data_label'),
                        'max_characters': 25},


### PR DESCRIPTION
# Short Description
We want to disable the spellcheck for name fields by setting the attribute `spellcheck="false"`. See [this ticket](https://steuerlotse.atlassian.net/browse/STL-1265?atlOrigin=eyJpIjoiNDIxYjk0YzFmNzZmNDg0OGE1MTQ5MmQyY2M0YzA0ZWYiLCJwIjoiaiJ9) for reference.

# Changes
- Introduced the SteuerlotseNameStringField that sets the correct kwargs to set the attribute spellcheck to false
- Added the SteuerlotseNameStringField to the name fields (person_a and person_b first and last name)

# Feedback
- Is this what you would have expected?
