### PR TITLE
Add mask for iban field

### DIFF
--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -67,6 +67,21 @@ class SteuerlotseNameStringField(StringField):
         return super().__call__(**kwargs)
 
 
+class SteuerlotseIbanField(SteuerlotseStringField):
+
+    def __call__(self, *args, **kwargs):
+        if 'class' in kwargs:
+            kwargs['class'] = kwargs['class'] + ' iban-input'
+        else:
+            kwargs.setdefault('class', 'iban-input')
+
+        return super().__call__(**kwargs)
+
+    def process_formdata(self, valuelist):
+        valuelist = [value.upper() for value in valuelist]
+        super().process_formdata(valuelist)
+
+
 class MultipleInputFieldWidget(TextInput, BaselineBugFixMixin):
     """A divided input field."""
     sub_field_separator = ''

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -73,7 +73,9 @@ class SteuerlotseIbanField(SteuerlotseStringField):
         if 'class' in kwargs:
             kwargs['class'] = kwargs['class'] + ' iban-input'
         else:
-            kwargs.setdefault('class', 'iban-input')
+            kwargs['class'] = 'iban-input'
+
+        kwargs.setdefault('data-mask', 'AA00 0000 0000 0000 0000 00## ##')
 
         return super().__call__(**kwargs)
 

--- a/webapp/app/forms/flows/lotse_flow.py
+++ b/webapp/app/forms/flows/lotse_flow.py
@@ -7,7 +7,7 @@ from app import app
 from app.data_access.audit_log_controller import create_audit_log_confirmation_entry
 from app.forms.fields import SteuerlotseSelectField, YesNoField, SteuerlotseDateField, SteuerlotseStringField, \
     ConfirmationField, EntriesField, EuroField, IdNrField, IntegerField, SteuerlotseIntegerField, \
-    SteuerlotseNumericStringField, SteuerlotseNameStringField
+    SteuerlotseNumericStringField, SteuerlotseNameStringField, SteuerlotseIbanField
 from app.model.form_data import MandatoryFormData, FamilienstandModel, MandatoryConfirmations, \
     ConfirmationMissingInputValidationError, MandatoryFieldMissingValidationError, InputDataInvalidError, \
     IdNrMismatchInputValidationError
@@ -389,7 +389,8 @@ class LotseMultiStepFlow(MultiStepFlow):
         elif field.field_class == EuroField:
             value_representation = str(value) + " €"
         elif field.field_class == SteuerlotseStringField or field.field_class == IdNrField \
-                or field.field_class == SteuerlotseNumericStringField or field.field_class == SteuerlotseNameStringField:
+                or field.field_class == SteuerlotseNumericStringField or field.field_class == SteuerlotseNameStringField \
+                or field.field_class == SteuerlotseIbanField:
             value_representation = value
         elif field.field_class == IntegerField or field.field_class == SteuerlotseIntegerField:
             value_representation = value

--- a/webapp/app/forms/steps/lotse/personal_data_steps.py
+++ b/webapp/app/forms/steps/lotse/personal_data_steps.py
@@ -4,7 +4,7 @@ from app.forms import SteuerlotseBaseForm
 from app.forms.steps.step import FormStep, SectionLink
 from app.forms.fields import YesNoField, SteuerlotseDateField, SteuerlotseSelectField, ConfirmationField, \
     SteuerlotseStringField, IdNrField, SteuerlotseIntegerField, SteuerlotseNumericStringField, \
-    SteuerlotseNameStringField
+    SteuerlotseNameStringField, SteuerlotseIbanField
 
 from flask_babel import _, ngettext
 from flask_babel import lazy_gettext as _l
@@ -466,7 +466,7 @@ class StepIban(FormStep):
             choices=[('yes', _l('form.lotse.field_is_person_a_account_holder-person-a')),
                      ('no', _l('form.lotse.field_is_person_a_account_holder-person-b')),
                      ])
-        iban = SteuerlotseStringField(
+        iban = SteuerlotseIbanField(
             label=_l('form.lotse.field_iban'),
             render_kw={'data_label': _l('form.lotse.field_iban.data_label'),
                        'example_input': _l('form.loste.field_iban.example_input'),
@@ -478,7 +478,7 @@ class StepIban(FormStep):
         is_person_a_account_holder = ConfirmationField(
             label=_l('form.lotse.field_is_person_a_account_holder_single'),
             render_kw={'data_label': _l('form.lotse.field_is_person_a_account_holder_single.data_label')})
-        iban = SteuerlotseStringField(
+        iban = SteuerlotseIbanField(
             label=_l('form.lotse.field_iban'),
             render_kw={'data_label': _l('form.lotse.field_iban.data_label'),
                        'example_input': _l('form.loste.field_iban.example_input'),

--- a/webapp/app/static/css/components.css
+++ b/webapp/app/static/css/components.css
@@ -544,3 +544,8 @@ input[type="radio"]:checked:focus + label::before{
         border: 0;
     border-radius: 0;
 }
+
+/* INPUT FIELDS */
+.iban-input{
+    text-transform: uppercase;
+}

--- a/webapp/app/templates/basis/base_step_form.html
+++ b/webapp/app/templates/basis/base_step_form.html
@@ -42,6 +42,7 @@
     <script>
         $(document).ready(function(){
           $('.date_input').mask('00.00.0000');
+          $('input[id=iban]').mask('SS00 0000 0000 0000 0000 00', { reverse: true });
         });
     </script>
 {% endblock %}

--- a/webapp/app/templates/basis/base_step_form.html
+++ b/webapp/app/templates/basis/base_step_form.html
@@ -42,7 +42,7 @@
     <script>
         $(document).ready(function(){
           $('.date_input').mask('00.00.0000');
-          $('input[id=iban]').mask('SS00 0000 0000 0000 0000 00', { reverse: true });
+          $('input[id=iban]').mask('AA00 0000 0000 0000 0000 00', { reverse: true });
         });
     </script>
 {% endblock %}

--- a/webapp/app/templates/basis/base_step_form.html
+++ b/webapp/app/templates/basis/base_step_form.html
@@ -39,10 +39,4 @@
         $('input[type="date"]').attr('max', '9999-12-31');
     </script>
     <script src="{{ url_for('static', filename='js/jquery.mask.min.js') }}" type=text/javascript></script>
-    <script>
-        $(document).ready(function(){
-          $('.date_input').mask('00.00.0000');
-          $('input[id=iban]').mask('AA00 0000 0000 0000 0000 00## ##');
-        });
-    </script>
 {% endblock %}

--- a/webapp/app/templates/basis/base_step_form.html
+++ b/webapp/app/templates/basis/base_step_form.html
@@ -42,7 +42,7 @@
     <script>
         $(document).ready(function(){
           $('.date_input').mask('00.00.0000');
-          $('input[id=iban]').mask('AA00 0000 0000 0000 0000 00', { reverse: true });
+          $('input[id=iban]').mask('AA00 0000 0000 0000 0000 00## ##');
         });
     </script>
 {% endblock %}

--- a/webapp/tests/forms/steps/test_personal_data_steps.py
+++ b/webapp/tests/forms/steps/test_personal_data_steps.py
@@ -361,10 +361,18 @@ class TestFamilienstand(unittest.TestCase):
 
 class TestStepIban(unittest.TestCase):
 
+    def test_if_lowercase_input_then_uppercase_input(self):
+        step = StepIban(prev_step='', next_step='')
+        data = {'iban': "thisIsLowerCase"}
+        expected_output = "THISISLOWERCASE"
+        with app.test_request_context(method='POST', data=data):
+            form = step.create_form(request, prefilled_data={})
+            self.assertEqual(expected_output, form.data['iban'])
+
     def test_if_whitespace_input_then_strip_whitespace(self):
         step = StepIban(prev_step='', next_step='')
-        data = {'iban': "Here is whitespace "}
-        expected_output = "Hereiswhitespace"
+        data = {'iban': "HERE IS WHITESPACE "}
+        expected_output = "HEREISWHITESPACE"
         with app.test_request_context(method='POST', data=data):
             form = step.create_form(request, prefilled_data={})
             self.assertEqual(expected_output, form.data['iban'])


### PR DESCRIPTION
# Short Description
This will mask the input for the Iban in the following way:
- allow 2 letters followed by 20 digits
- make the two letters uppercase
- put spaces between each set of for chars: `DE12 1234 1234 1234 1234 12 

Corresponding ticket can be found [here](https://steuerlotse.atlassian.net/browse/STL-1269?atlOrigin=eyJpIjoiNzY2NmEyYWI0YTdmNGY4OWJkNzk1MzI1Yzc0YjM5ZDUiLCJwIjoiaiJ9)

# Changes
- Add the mask

# Feedback
- Do you see any problem with that?
