### PR TITLE
Set format for euro field

### DIFF
--- a/webapp/app/templates/basis/base_step_form.html
+++ b/webapp/app/templates/basis/base_step_form.html
@@ -31,7 +31,7 @@
     </script>
     <script src="{{ url_for('static', filename='js/autonumeric.js') }}" type=text/javascript></script>
     <script>
-        new AutoNumeric.multiple('.euro_field', {decimalCharacter: ",", digitGroupSeparator: "."});
+        new AutoNumeric.multiple('.euro_field', {decimalCharacter: ",", digitGroupSeparator: ".", minimumValue: 0});
         // in order for AutoNumeric to work, autocomplete has to be turned off for the respective components
         $('.euro_field').attr('autocomplete', 'off');
     </script>


### PR DESCRIPTION
# Short Description
The only part missing for the defined format of the EuroField (s. [here](https://steuerlotse.atlassian.net/browse/STL-1320?atlOrigin=eyJpIjoiMTA2MjgwYTM1OGFiNGRiNTliYjBiODIzZmE2NmM2YWIiLCJwIjoiaiJ9)) was to disable negative values. We use AutoNumeric and I found [this solution](https://stackoverflow.com/a/54589682) to just set the minimum value to zero to disable negative values.

# Changes
- Set minimum value for EuroField

# Feedback
- We could also use the same masking tool for this as we do for all other fields. However, I expect this to be a little more tricky and I would rather standardize this, when we have a more final decision for our framework. WDYT?
