### PR TITLE
Set data-mask for numeric inputs

### DIFF
--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -285,7 +285,7 @@ class ConfirmationField(BooleanField):
     """A CheckBox that will not validate unless checked."""
 
     def __init__(self, label=None, false_values=None, input_required=True, **kwargs):
-        validators = [InputRequired(message=_('confirmation_field_must_be_set'))] if input_required else []
+        validators = [InputRequired(message=_l('confirmation_field_must_be_set'))] if input_required else []
         super(BooleanField, self).__init__(
             label,
             validators=validators,

--- a/webapp/app/forms/fields.py
+++ b/webapp/app/forms/fields.py
@@ -20,7 +20,7 @@ class NumericInputMixin:
     @staticmethod
     def set_inputmode(kwargs):
         kwargs.setdefault('inputmode', 'numeric')
-        kwargs.setdefault('pattern', '[0-9]*')
+        kwargs.setdefault('data-mask', '0#')
         return kwargs
 
 

--- a/webapp/app/forms/steps/lotse/personal_data_steps.py
+++ b/webapp/app/forms/steps/lotse/personal_data_steps.py
@@ -169,7 +169,7 @@ class StepSteuernummer(FormStep):
                 ('SH', _l('form.lotse.field_bundesland_sh')),
                 ('TH', _l('form.lotse.field_bundesland_th'))
             ],
-            validators=[InputRequired(message=_('form.lotse.field_bundesland_required'))],
+            validators=[InputRequired(message=_l('form.lotse.field_bundesland_required'))],
             render_kw={'data_label': _l('form.lotse.field_bundesland.data_label'),
                        'input_req_err_msg': _l('form.lotse.field_bundesland_required')}
         )

--- a/webapp/app/templates/basis/base_step_form.html
+++ b/webapp/app/templates/basis/base_step_form.html
@@ -6,7 +6,7 @@
     {% block step_intro %}
         {{ macros.form_header(render_info) }}
     {% endblock %}
-    <form class="container px-0 form-container" method="POST" action="{{ render_info.submit_url }}">
+    <form novalidate class="container px-0 form-container" method="POST" action="{{ render_info.submit_url }}">
         {% block form_content %}
         {% endblock %}
 


### PR DESCRIPTION
# Short Description
We want to allow only numeric input for the following fields using masking:
- birth date
- Tax identification number
- tax number
- Postcode
- Degree of disability
- Number of other people in the household
See the ticket [here](https://steuerlotse.atlassian.net/browse/STL-1322?atlOrigin=eyJpIjoiZjc5MWQ5OWVlMTZjNGUyMWExYTI1NjFkMjcyNzIzOGEiLCJwIjoiaiJ9). With our masking plugin we can set a mask `0#` to only allow numeric input (see [recursive digits](http://igorescobar.github.io/jQuery-Mask-Plugin/docs.html#translation)). We can [set the mask using the `data-mask` attribute](http://igorescobar.github.io/jQuery-Mask-Plugin/docs.html#using-html-notation-examples). 

We also do not want to use the browser validation through the pattern attribute. For that, we could either:
- Get rid of the pattern attribute because we do need it.
- Set `invalidate`on all forms. This would also get rid of all browser validation for required fields and it would leave us with the possibility to reuse the pattern.

# Changes
- Swap the `pattern` attribute with the `data-mask` attribute in the NumericInputMixin

# Feedback
- What do you think about the pattern attribute? The more I think about it, the more I think that we should set `novalidate` even if we do not keep the `pattern` attributes.
