### PR TITLE
Logging to debug worker timeouts

### DIFF
--- a/webapp/app/__init__.py
+++ b/webapp/app/__init__.py
@@ -42,8 +42,12 @@ login_manager = LoginManager()
 login_manager.init_app(app)
 login_manager.session_protection = 'strong'
 
-# Set pool_pre_ping to fix problems with stale connection we've been seeing.
-db = SQLAlchemy(app, engine_options={'pool_pre_ping': True})
+# SQLAlchemy options
+# - pool_pre_ping: fix problems with stale connection we've been seeing (see also:
+#   https://docs.syseleven.de/syseleven-stack/de/reference/network/known-issues#idle-tcp-sessions-being-closed).
+# - hide_parameters: don't log any parameters with errors or when logging SQL statements (
+#   https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.hide_parameters)
+db = SQLAlchemy(app, engine_options={'pool_pre_ping': True, 'hide_parameters': True})
 migrate = Migrate(app, db)
 
 register_commands(app)

--- a/webapp/app/__init__.py
+++ b/webapp/app/__init__.py
@@ -1,10 +1,8 @@
 from decimal import Decimal, ROUND_UP
-from logging.config import dictConfig
-import json
-import os
 
-with open(os.path.join(os.path.dirname(__file__), '..', 'logging.json')) as f:
-    dictConfig(json.load(f))
+# This needs to be run before any extensions and libraries configure their logging.
+from .logging import configure_logging
+configure_logging()
 
 from flask import Flask
 from flask_babel import Babel

--- a/webapp/app/elster_client/elster_client.py
+++ b/webapp/app/elster_client/elster_client.py
@@ -32,12 +32,15 @@ _DATE_KEYS = ['familienstand_date', 'familienstand_married_lived_separated_since
 
 
 def send_to_erica(*args, **kwargs):
+    app.logger.info(f'Making Erica request with args {args!r}')
     if app.config['USE_MOCK_API']:
         from tests.elster_client.mock_erica import MockErica
-        return MockErica.mocked_elster_requests(*args, **kwargs)
+        response = MockErica.mocked_elster_requests(*args, **kwargs)
     else:
         headers = {'Content-type': 'application/json'}
-        return requests.post(*args, headers=headers, **kwargs)
+        response = requests.post(*args, headers=headers, **kwargs)
+    app.logger.info(f'Completed Erica request with args {args!r}, got code {response.status_code}')
+    return response
 
 
 def send_est_with_elster(form_data, ip_address, year=2020, include_elster_responses=True):

--- a/webapp/app/logging.py
+++ b/webapp/app/logging.py
@@ -1,0 +1,21 @@
+import logging
+from logging.config import dictConfig
+import json
+import os
+
+from flask import has_request_context, request
+
+
+def configure_logging():
+    with open(os.path.join(os.path.dirname(__file__), '..', 'logging.json')) as f:
+        dictConfig(json.load(f))
+
+
+class AddRequestIdFilter(logging.Filter):
+    """Add the request ID to the log (if present)."""
+
+    def filter(self, record):
+        if has_request_context() and 'X-Request-ID' in request.headers:
+            record.request_id = request.headers['X-Request-ID']
+
+        return True

--- a/webapp/gunicorn_config.py
+++ b/webapp/gunicorn_config.py
@@ -15,3 +15,4 @@ with open('logging.json') as f:
 workers = 4
 bind = '0.0.0.0:5000'
 worker_tmp_dir = '/tmp'
+access_log_format = '%({x-request-id}i)s %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'

--- a/webapp/gunicorn_config.py
+++ b/webapp/gunicorn_config.py
@@ -15,4 +15,5 @@ with open('logging.json') as f:
 workers = 4
 bind = '0.0.0.0:5000'
 worker_tmp_dir = '/tmp'
+# See https://docs.gunicorn.org/en/stable/settings.html#access-log-format
 access_log_format = '%({x-request-id}i)s %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'

--- a/webapp/logging.json
+++ b/webapp/logging.json
@@ -20,6 +20,9 @@
     "loggers": {
         "gunicorn": {
             "level": "DEBUG"
+        },
+        "sqlalchemy.engine": {
+            "level": "INFO"
         }
     },
     "disable_existing_loggers": false

--- a/webapp/logging.json
+++ b/webapp/logging.json
@@ -6,10 +6,16 @@
             "class": "pythonjsonlogger.jsonlogger.JsonFormatter"
         }
     },
+    "filters": {
+        "default": {
+            "()": "app.logging.AddRequestIdFilter"
+        }
+    },
     "handlers": {
         "wsgi": {
             "class": "logging.StreamHandler",
             "stream": "ext://flask.logging.wsgi_errors_stream",
+            "filters": ["default"],
             "formatter": "default"
         }
     },


### PR DESCRIPTION
# Short Description
- This adds logging to help us understand what the webapp is doing when we get WORKER TIMEOUTS.

# Changes
I've added:
- Logging before / after erica requests (to get timestamps).
- SQLAlchemy echo logging, without values for privacy reasons (gives us timestamps on transactions).
- Log the request-id generated by nginx in gunicorn access and any other python logs.

# Feedback
- Nothing specific.

# Reference:
- https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.hide_parameters
- https://docs.python.org/3/howto/logging-cookbook.html#using-filters-to-impart-contextual-information
- https://docs.gunicorn.org/en/stable/settings.html#access-log-format