### PR TITLE
Log every request from Flask

### DIFF
--- a/webapp/app/__init__.py
+++ b/webapp/app/__init__.py
@@ -1,7 +1,7 @@
 from decimal import Decimal, ROUND_UP
 
 # This needs to be run before any extensions and libraries configure their logging.
-from .logging import configure_logging
+from .logging import configure_logging, log_flask_request
 configure_logging()
 
 from flask import Flask
@@ -55,6 +55,9 @@ app.json_decoder = SteuerlotseJSONDecoder
 if app.config['PROMETHEUS_EXPORTER_ENABLED']:
     metrics = GunicornInternalPrometheusMetrics(app)
     metrics.info('up', 'WebApp is up')
+
+
+app.before_request(log_flask_request)
 
 
 @babel.localeselector

--- a/webapp/app/logging.py
+++ b/webapp/app/logging.py
@@ -3,7 +3,7 @@ from logging.config import dictConfig
 import json
 import os
 
-from flask import has_request_context, request
+from flask import current_app, has_request_context, request
 
 
 def configure_logging():
@@ -19,3 +19,7 @@ class AddRequestIdFilter(logging.Filter):
             record.request_id = request.headers['X-Request-ID']
 
         return True
+
+
+def log_flask_request():
+    current_app.logger.info(f'Received request: {request.method} {request.path}')


### PR DESCRIPTION
# Short Description
- This is to be able to trace requests using their X-Request-ID from the very start in the webapp.
- The previous PR got us _most_ of the way, see: https://grafana.stl.ds4g.dev/goto/ZOfaAJn7k
- However, gunicorn.access only logs when a request is completed, not when it starts

# Changes
- I've added a new `before_request` hook that logs the request.

# Feedback
- Nothing specific. I placed the `before_request` hook in a pretty random place, but this will be cleaned up when we move to an app factory.