### PR TITLE
Style eligibility result pages

### DIFF
--- a/webapp/app/static/css/eligibility.css
+++ b/webapp/app/static/css/eligibility.css
@@ -18,11 +18,15 @@
     margin-bottom: var(--spacing-07);
 }
 
+.failure-success-icon {
+    min-width: 100px;
+    padding-bottom: var(--spacing-04);
+}
+
 h1.my-4{
     margin-bottom: 0 !important;
     margin-top: 0 !important;
 }
-
 
 @media (min-width: 320px) {
     h1 {

--- a/webapp/app/static/css/eligibility.css
+++ b/webapp/app/static/css/eligibility.css
@@ -1,8 +1,8 @@
-.spacing-b-07{
-    margin-bottom: var(--spacing-07);
+.spacing-b-08 {
+    margin-bottom: var(--spacing-08);
 }
 
-.spacing-b-09{
+.spacing-b-09 {
     margin-bottom: var(--spacing-09);
 }
 
@@ -14,8 +14,8 @@
     margin-bottom: var(--spacing-11);
 }
 
-.section-intro{
-    margin-bottom: var(--spacing-07);
+.section-intro {
+    margin-bottom: var(--spacing-08);
 }
 
 .failure-success-icon {
@@ -26,6 +26,14 @@
 h1.my-4{
     margin-bottom: 0 !important;
     margin-top: 0 !important;
+}
+
+.dependent-notes-heading {
+    font-size: var(--text-medium);
+}
+
+.use-elster-intro {
+    padding-bottom: var(--spacing-06);
 }
 
 @media (min-width: 320px) {

--- a/webapp/app/static/css/eligibility.css
+++ b/webapp/app/static/css/eligibility.css
@@ -54,6 +54,7 @@ h1.my-4{
 
     .result-text{
         font-size: var(--text-medium);
+        margin: 0;
     }
 }
 

--- a/webapp/app/static/css/eligibility.css
+++ b/webapp/app/static/css/eligibility.css
@@ -41,7 +41,7 @@ h1.my-4{
     }
 
     .headline{
-        margin-bottom: var(--spacing-06);
+        margin-bottom: var(--spacing-05);
     }
 
     .result-text{
@@ -55,7 +55,7 @@ h1.my-4{
     }
 
     .headline{
-        margin-bottom: var(--spacing-07);
+        margin-bottom: var(--spacing-06);
     }
 }
 

--- a/webapp/app/static/css/eligibility.css
+++ b/webapp/app/static/css/eligibility.css
@@ -19,8 +19,8 @@
 }
 
 .failure-success-icon {
-    min-width: 100px;
-    padding-bottom: var(--spacing-04);
+    min-width: calc(75px + 2 * var(--spacing-03));
+    padding: 0 var(--spacing-03) var(--spacing-03) var(--spacing-03);
 }
 
 h1.my-4{

--- a/webapp/app/static/icons/failure_icon.svg
+++ b/webapp/app/static/icons/failure_icon.svg
@@ -1,4 +1,4 @@
-<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="75" height="75" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M50 0C22.4 0 0 22.4 0 50C0 77.6 22.4 100 50 100C77.6 100 100 77.6 100 50C100 22.4 77.6 0 50 0Z" fill="#C0003C"/>
 <rect x="29.6875" y="35.937" width="7.8125" height="47.6767" transform="rotate(-45 29.6875 35.937)" fill="white"/>
 <rect width="7.8125" height="47.6767" transform="matrix(-0.707107 -0.707107 -0.707107 0.707107 70.3125 35.9375)" fill="white"/>

--- a/webapp/app/static/icons/success_icon.svg
+++ b/webapp/app/static/icons/success_icon.svg
@@ -1,3 +1,3 @@
-<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="75" height="75" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path fill-rule="evenodd" clip-rule="evenodd" d="M0 50C0 22.4 22.4 0 50 0C77.6 0 100 22.4 100 50C100 77.6 77.6 100 50 100C22.4 100 0 77.6 0 50ZM39.9982 60.8423L72.9482 27.8923L79.9982 34.9923L39.9982 74.9923L19.9982 54.9923L27.0482 47.9423L39.9982 60.8423Z" fill="#005C45"/>
 </svg>

--- a/webapp/app/templates/eligibility/display_failure.html
+++ b/webapp/app/templates/eligibility/display_failure.html
@@ -20,15 +20,15 @@
         </div>
     </div>
 
-    <div class="spacing-b-07 row m-0">
+    <div class="spacing-b-09">
         <h2>{{ _('form.eligibility.use-elster') }}</h2>
-        <span class="result-text">
-            <p>{{ _('form.eligibility.use-elster-text') }}</p>
+        <div class="result-text">
+            <p class="use-elster-intro">{{ _('form.eligibility.use-elster-text') }}</p>
             <ol>
                 <li>{{ _('form.eligibility.use-elster.list-item-1') }}</li>
                 <li>{{ _('form.eligibility.use-elster.list-item-2') }}</li>
             </ol>
-        </span>
+        </div>
     </div>
 
 

--- a/webapp/app/templates/eligibility/display_failure.html
+++ b/webapp/app/templates/eligibility/display_failure.html
@@ -13,7 +13,7 @@
             <div class="col-2 failure-success-icon">
                 <img src="{{ url_for('static', filename='icons/failure_icon.svg') }}" alt="{{ _('success_icon') }}"/>
             </div>
-            <div class="col-10 w-100">
+            <div class="col-10">
                 <h1>{{ render_info.step_title }}</h1>
                 <p class="result-text">{{ error_text }} {{ render_info.step_intro }}</p>
             </div>

--- a/webapp/app/templates/eligibility/display_failure.html
+++ b/webapp/app/templates/eligibility/display_failure.html
@@ -3,19 +3,21 @@
 {% import "macros.html" as macros %}
 
 {% block additional_stylesheets %}
-{{ super() }}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/eligibility.css') }}">
+    {{ super() }}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/eligibility.css') }}">
 {% endblock %}
 
 {% block step_content %}
-    <div class="section-intro">
-        <div class="headline row p-0">
-            <img src="{{ url_for('static', filename='icons/failure_icon.svg') }}"  alt="{{ _('success_icon') }}"/>
-            <h1 class="col-lg-10">{{ render_info.step_title }}</h1>
+    <div class="section-intro simple-card">
+        <div class="row p-0">
+            <div class="col-2 failure-success-icon">
+                <img src="{{ url_for('static', filename='icons/failure_icon.svg') }}" alt="{{ _('success_icon') }}"/>
+            </div>
+            <div class="col-10 w-100">
+                <h1>{{ render_info.step_title }}</h1>
+                <p class="result-text">{{ error_text }} {{ render_info.step_intro }}</p>
+            </div>
         </div>
-        <span class="result-text">
-            <p>{{ error_text }} {{ render_info.step_intro }}</p>
-        </span>
     </div>
 
     <div class="spacing-b-07 row m-0">
@@ -36,7 +38,7 @@
             url="https://www.elster.de/eportal/start",
             icon="↗",
             target="_blank"
-        )}}
+        ) }}
     </div>
     </div>
 {% endblock %}

--- a/webapp/app/templates/eligibility/display_failure.html
+++ b/webapp/app/templates/eligibility/display_failure.html
@@ -15,7 +15,7 @@
             </div>
             <div class="col-10">
                 <h1 class="headline">{{ render_info.step_title }}</h1>
-                <p class="result-text m-0">{{ error_text }} {{ render_info.step_intro }}</p>
+                <p class="result-text">{{ error_text }} {{ render_info.step_intro }}</p>
             </div>
         </div>
     </div>

--- a/webapp/app/templates/eligibility/display_failure.html
+++ b/webapp/app/templates/eligibility/display_failure.html
@@ -14,8 +14,8 @@
                 <img src="{{ url_for('static', filename='icons/failure_icon.svg') }}" alt="{{ _('success_icon') }}"/>
             </div>
             <div class="col-10">
-                <h1>{{ render_info.step_title }}</h1>
-                <p class="result-text">{{ error_text }} {{ render_info.step_intro }}</p>
+                <h1 class="headline">{{ render_info.step_title }}</h1>
+                <p class="result-text m-0">{{ error_text }} {{ render_info.step_intro }}</p>
             </div>
         </div>
     </div>

--- a/webapp/app/templates/eligibility/display_success.html
+++ b/webapp/app/templates/eligibility/display_success.html
@@ -20,19 +20,21 @@
         </div>
     </div>
 
-    <div class="spacing-b-07 row m-0 ">
+    <div class="spacing-b-08">
         <h2>{{ _('form.eligibility.success-next-step') }}</h2>
-        <span class="result-text">
-            <p class="result-text">{{ _('form.eligibility.success-next-step-text') }}</p>
-            {% if 'dependent_notes' in render_info.additional_info %}
-                <ul class="form-list">
-                    {% for dependent_note in render_info.additional_info['dependent_notes']%}
-                        <li>{{ dependent_note }}</li>
-                    {% endfor %}
-                </ul>
-            {% endif%}
-        </span>
+        <p class="result-text">{{ _('form.eligibility.success-next-step-text') }}</p>
     </div>
+
+    {% if 'dependent_notes' in render_info.additional_info %}
+        <div class="spacing-b-08">
+            <h2 class="dependent-notes-heading">{{ _('form.eligibility.success-attention.heading') }}</h2>
+            <ul class="form-list">
+                {% for dependent_note in render_info.additional_info['dependent_notes'] %}
+                    <li>{{ dependent_note }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
 
     <div class="spacing-b-11 row m-0">
         {{ components.primaryButton( text=_('form.eligibility.use-register-button'), url=url_for('unlock_code_request')) }}

--- a/webapp/app/templates/eligibility/display_success.html
+++ b/webapp/app/templates/eligibility/display_success.html
@@ -14,8 +14,8 @@
                 <img src="{{ url_for('static', filename='icons/success_icon.svg') }}" alt="{{ _('success_icon') }}"/>
             </div>
             <div class="col-10">
-                <h1>{{ render_info.step_title }}</h1>
-                <p class="result-text">{{ error_text }} {{ render_info.step_intro }}</p>
+                <h1 class="headline">{{ render_info.step_title }}</h1>
+                <p class="result-text m-0">{{ error_text }} {{ render_info.step_intro }}</p>
             </div>
         </div>
     </div>

--- a/webapp/app/templates/eligibility/display_success.html
+++ b/webapp/app/templates/eligibility/display_success.html
@@ -13,7 +13,7 @@
             <div class="col-2 failure-success-icon">
                 <img src="{{ url_for('static', filename='icons/success_icon.svg') }}" alt="{{ _('success_icon') }}"/>
             </div>
-            <div class="col-10 w-100">
+            <div class="col-10">
                 <h1>{{ render_info.step_title }}</h1>
                 <p class="result-text">{{ error_text }} {{ render_info.step_intro }}</p>
             </div>

--- a/webapp/app/templates/eligibility/display_success.html
+++ b/webapp/app/templates/eligibility/display_success.html
@@ -8,14 +8,16 @@
 {% endblock %}
 
 {% block step_content %}
-    <div class="section-intro">
-        <div class="headline row p-0">
-            <img src="{{ url_for('static', filename='icons/success_icon.svg') }}"  alt="{{ _('success_icon') }}"/>
-            <h1 class="col-lg-10">{{ render_info.step_title }}</h1>
+    <div class="section-intro simple-card">
+        <div class="row p-0">
+            <div class="col-2 failure-success-icon">
+                <img src="{{ url_for('static', filename='icons/success_icon.svg') }}" alt="{{ _('success_icon') }}"/>
+            </div>
+            <div class="col-10 w-100">
+                <h1>{{ render_info.step_title }}</h1>
+                <p class="result-text">{{ error_text }} {{ render_info.step_intro }}</p>
+            </div>
         </div>
-        <span class="result-text">
-            <p>{{ render_info.step_intro }}</p>
-        </span>
     </div>
 
     <div class="spacing-b-07 row m-0 ">

--- a/webapp/app/templates/eligibility/display_success.html
+++ b/webapp/app/templates/eligibility/display_success.html
@@ -15,7 +15,7 @@
             </div>
             <div class="col-10">
                 <h1 class="headline">{{ render_info.step_title }}</h1>
-                <p class="result-text m-0">{{ error_text }} {{ render_info.step_intro }}</p>
+                <p class="result-text">{{ error_text }} {{ render_info.step_intro }}</p>
             </div>
         </div>
     </div>

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-08-30 10:25+0200\n"
+"POT-Creation-Date: 2021-09-03 10:09+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -18,109 +18,109 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: app/routes.py:57
+#: app/routes.py:58
 msgid "nav.home"
 msgstr "Übersicht"
 
-#: app/routes.py:58
+#: app/routes.py:59
 msgid "nav.how-it-works"
 msgstr "Informieren"
 
-#: app/routes.py:59
+#: app/routes.py:60
 msgid "nav.eligibility"
 msgstr "Nutzung prüfen"
 
-#: app/routes.py:60
+#: app/routes.py:61
 msgid "nav.register"
 msgstr "Registrieren"
 
-#: app/routes.py:62
+#: app/routes.py:63
 msgid "nav.lotse-form"
 msgstr "Ihre Steuererklärung"
 
-#: app/routes.py:64
+#: app/routes.py:65
 msgid "nav.logout"
 msgstr "Abmelden"
 
-#: app/routes.py:68
+#: app/routes.py:69
 msgid "login.not-logged-in-warning"
 msgstr "Sie müssen eingeloggt sein um das zu sehen."
 
-#: app/routes.py:118
+#: app/routes.py:121
 msgid "unlock_code_request.logged_in.title"
 msgstr "Sind Sie sicher, dass Sie sich erneut registrieren möchten?"
 
-#: app/routes.py:119
+#: app/routes.py:122
 msgid "unlock_code_request.logged_in.intro"
 msgstr ""
 "Sie sind bereits angemeldet. Wählen Sie „Zurück zur Steuererklärung, wenn"
 " Sie mit Ihrer Steuererklärung fortfahren möchten. Wenn Sie sich erneut "
 "registrieren möchten, müssen Sie sich zuerst abmelden."
 
-#: app/routes.py:145
+#: app/routes.py:148
 msgid "unlock_code_revocation.logged_in.title"
 msgstr "Sind Sie sicher, dass Sie Ihren Freischaltcode stornieren möchten?"
 
-#: app/routes.py:146
+#: app/routes.py:149
 msgid "unlock_code_revocation.logged_in.intro"
 msgstr ""
 "Sie sind bereits angemeldet. Wählen Sie „Zurück zur Steuererklärung“, "
 "wenn Sie mit Ihrer Steuererklärung fortfahren möchten. Wenn Sie Ihren "
 "Freischaltcode stornieren möchten, müssen Sie sich zuerst abmelden."
 
-#: app/routes.py:157 app/routes.py:254
+#: app/routes.py:160 app/routes.py:257
 msgid "404.header-title"
 msgstr "Fehler 404 - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:175 app/templates/basis/base.html:30
+#: app/routes.py:178 app/templates/basis/base.html:30
 msgid "page.title"
 msgstr "Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:180
+#: app/routes.py:183
 msgid "howitworks.header-title"
 msgstr "Informieren - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:185
+#: app/routes.py:188
 msgid "contact.header-title"
 msgstr "Kontakt - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:190
+#: app/routes.py:193
 msgid "imprint.header-title"
 msgstr "Impressum - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:195
+#: app/routes.py:198
 msgid "barrierefreiheit.header-title"
 msgstr "Barrierefreiheit - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:200
+#: app/routes.py:203
 msgid "data_privacy.header-title"
 msgstr "Datenschutz - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:205
+#: app/routes.py:208
 msgid "agb.header-title"
 msgstr "Nutzungsbedingungen - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:215
+#: app/routes.py:218
 msgid "about.header-title"
 msgstr "Projektinfos - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:220
+#: app/routes.py:223
 msgid "about_digitalservice.header-title"
 msgstr "Digital Service - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:246
+#: app/routes.py:249
 msgid "erica-error.header-title"
 msgstr "Übermittlungsfehler - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:250 app/routes.py:258
+#: app/routes.py:253 app/routes.py:261
 msgid "400.header-title"
 msgstr "Fehler 400 - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:262
+#: app/routes.py:265
 msgid "429.header-title"
 msgstr "Fehler 429 - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:267
+#: app/routes.py:270
 msgid "500.header-title"
 msgstr "Fehler 500 - Der Steuerlotse für Rente und Pension"
 
@@ -4786,48 +4786,52 @@ msgstr ""
 msgid "landing.interviews-link"
 msgstr "Mehr erfahren"
 
-#: app/templates/eligibility/display_failure.html:13
-#: app/templates/eligibility/display_success.html:13
+#: app/templates/eligibility/display_failure.html:14
+#: app/templates/eligibility/display_success.html:14
 msgid "success_icon"
 msgstr "Abgehakt Icon auf grünem Kreis"
 
-#: app/templates/eligibility/display_failure.html:22
+#: app/templates/eligibility/display_failure.html:24
 msgid "form.eligibility.use-elster"
 msgstr "Wie geht es weiter?"
 
-#: app/templates/eligibility/display_failure.html:24
+#: app/templates/eligibility/display_failure.html:26
 msgid "form.eligibility.use-elster-text"
 msgstr ""
 "Es gibt zwei mögliche Wege Ihre Steuererklärung ohne den Steuerlotsen zu "
 "machen:"
 
-#: app/templates/eligibility/display_failure.html:26
+#: app/templates/eligibility/display_failure.html:28
 msgid "form.eligibility.use-elster.list-item-1"
 msgstr ""
 "Sie können die vollumfänglichen Steuererklärungsvordrucke nutzen. Die "
 "notwendigen Formulare dazu erhalten Sie zum Beispiel in Ihrem Finanzamt."
 
-#: app/templates/eligibility/display_failure.html:27
+#: app/templates/eligibility/display_failure.html:29
 msgid "form.eligibility.use-elster.list-item-2"
 msgstr ""
 "Sie können Ihre Steuererklärung online über das Steuerportal Mein ELSTER "
 "machen."
 
-#: app/templates/eligibility/display_failure.html:35
+#: app/templates/eligibility/display_failure.html:37
 msgid "form.eligibility.use-elster-button"
 msgstr "Zu Mein ELSTER"
 
-#: app/templates/eligibility/display_success.html:22
+#: app/templates/eligibility/display_success.html:24
 msgid "form.eligibility.success-next-step"
 msgstr "Wie geht es weiter?"
 
-#: app/templates/eligibility/display_success.html:24
+#: app/templates/eligibility/display_success.html:25
 msgid "form.eligibility.success-next-step-text"
 msgstr ""
 "Als Nächstes können Sie sich registrieren. Dazu brauchen Sie Ihre Steuer-"
 "Identifikationsnummer und Ihr Geburtsdatum."
 
-#: app/templates/eligibility/display_success.html:36
+#: app/templates/eligibility/display_success.html:29
+msgid "form.eligibility.success-attention.heading"
+msgstr "Bitte beachten Sie."
+
+#: app/templates/eligibility/display_success.html:40
 msgid "form.eligibility.use-register-button"
 msgstr "Registrieren"
 


### PR DESCRIPTION
# Short Description
- Style the eligibility result pages according to Figma.
- However, I made two changes that I also discussed with Caro: 1. the icons are 75 instead of 100 pixels wide, it just looked way better to us and 2. I did not extend the box over the base.html's right border of col-lg-9, because we never do this in any other step and changing the base html just for one step, that also works without changing the base just doesn't seem a good idea or worth the effort for me. You may disagree^^

# Changes
- Make icons smaller svgs
- Add padding below icons to have a better look on mobile
- Adapt cols and rows
- Reformat one file (sorry!)

# Feedback
- There was no mobile version provided and I'm not a 100% on how I handled that, so maybe you wanna have a look at that?
