### PR TITLE
Add dependent note for capital investment

### DIFF
--- a/webapp/app/forms/steps/eligibility_steps.py
+++ b/webapp/app/forms/steps/eligibility_steps.py
@@ -38,6 +38,14 @@ def data_fits_data_model(data_model, stored_data):
     return True
 
 
+def data_fits_one_model(data_models, stored_data):
+    """
+    Method to find out whether the data entered by the user fits at least one model
+    """
+    fits_models = [data_fits_data_model(data_model, stored_data) for data_model in data_models]
+    return any(fits_models)
+
+
 class EligibilityStepMixin:
 
     @classmethod
@@ -741,8 +749,10 @@ class EligibilitySuccessDisplaySteuerlotseStep(EligibilityStepMixin, DisplaySteu
         if data_fits_data_model(UserBNoElsterAccountEligibilityData, self.stored_data):
             dependent_notes.append(_('form.eligibility.result-note.user_b_elster_account'))
             dependent_notes.append(_('form.eligibility.result-note.user_b_elster_account-registration'))
-        if data_fits_data_model(CheaperCheckEligibilityData, self.stored_data):
-            dependent_notes.append(_('form.eligibility.result-note.cheaper_check'))
+        if data_fits_one_model(
+                [CheaperCheckEligibilityData, MinimalInvestmentIncome, MoreThanMinimalInvestmentIncome],
+                self.stored_data):
+            dependent_notes.append(_('form.eligibility.result-note.capital_investment'))
 
         self.render_info.additional_info['dependent_notes'] = dependent_notes
         self.render_info.next_url = None

--- a/webapp/app/forms/steps/eligibility_steps.py
+++ b/webapp/app/forms/steps/eligibility_steps.py
@@ -38,7 +38,7 @@ def data_fits_data_model(data_model, stored_data):
     return True
 
 
-def data_fits_one_data_model(data_models, stored_data):
+def data_fits_data_model_from_list(data_models, stored_data):
     """
     Method to find out whether the data entered by the user fits at least one model
     """
@@ -749,7 +749,7 @@ class EligibilitySuccessDisplaySteuerlotseStep(EligibilityStepMixin, DisplaySteu
         if data_fits_data_model(UserBNoElsterAccountEligibilityData, self.stored_data):
             dependent_notes.append(_('form.eligibility.result-note.user_b_elster_account'))
             dependent_notes.append(_('form.eligibility.result-note.user_b_elster_account-registration'))
-        if data_fits_one_data_model(
+        if data_fits_data_model_from_list(
                 [CheaperCheckEligibilityData, MinimalInvestmentIncome, MoreThanMinimalInvestmentIncome],
                 self.stored_data):
             dependent_notes.append(_('form.eligibility.result-note.capital_investment'))

--- a/webapp/app/forms/steps/eligibility_steps.py
+++ b/webapp/app/forms/steps/eligibility_steps.py
@@ -38,7 +38,7 @@ def data_fits_data_model(data_model, stored_data):
     return True
 
 
-def data_fits_one_model(data_models, stored_data):
+def data_fits_one_data_model(data_models, stored_data):
     """
     Method to find out whether the data entered by the user fits at least one model
     """
@@ -749,7 +749,7 @@ class EligibilitySuccessDisplaySteuerlotseStep(EligibilityStepMixin, DisplaySteu
         if data_fits_data_model(UserBNoElsterAccountEligibilityData, self.stored_data):
             dependent_notes.append(_('form.eligibility.result-note.user_b_elster_account'))
             dependent_notes.append(_('form.eligibility.result-note.user_b_elster_account-registration'))
-        if data_fits_one_model(
+        if data_fits_one_data_model(
                 [CheaperCheckEligibilityData, MinimalInvestmentIncome, MoreThanMinimalInvestmentIncome],
                 self.stored_data):
             dependent_notes.append(_('form.eligibility.result-note.capital_investment'))

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-09-03 10:31+0200\n"
+"POT-Creation-Date: 2021-09-03 14:23+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -282,33 +282,33 @@ msgstr "Registrieren"
 msgid "form.auth-revocation.title"
 msgstr "Freischaltcode Stornierung"
 
-#: app/forms/steps/eligibility_steps.py:60
+#: app/forms/steps/eligibility_steps.py:68
 msgid "form.eligibility.failure.title"
 msgstr "Sie können den Steuerlotsen zurzeit nicht für Ihre Steuererklärung nutzen."
 
-#: app/forms/steps/eligibility_steps.py:61
+#: app/forms/steps/eligibility_steps.py:69
 msgid "form.eligibility.failure.intro"
 msgstr ""
 "Der Steuerlotse ist im Juni mit den Grundfunktionen gestartet und wird in"
 " den kommenden Wochen und Monaten auf Basis der Rückmeldungen stetig "
 "verbessert und erweitert."
 
-#: app/forms/steps/eligibility_steps.py:66
-#: app/forms/steps/eligibility_steps.py:93
-#: app/forms/steps/eligibility_steps.py:153
-#: app/forms/steps/eligibility_steps.py:734
+#: app/forms/steps/eligibility_steps.py:74
+#: app/forms/steps/eligibility_steps.py:101
+#: app/forms/steps/eligibility_steps.py:161
+#: app/forms/steps/eligibility_steps.py:742
 msgid "form.eligibility.header-title"
 msgstr "Nutzung Prüfen - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/eligibility_steps.py:99
+#: app/forms/steps/eligibility_steps.py:107
 msgid "form.eligibility.back_link_text"
 msgstr "Zur vorherigen Frage"
 
-#: app/forms/steps/eligibility_steps.py:147
+#: app/forms/steps/eligibility_steps.py:155
 msgid "form.eligibility.start-title"
 msgstr "Finden Sie heraus, ob Sie den Steuerlotsen nutzen können"
 
-#: app/forms/steps/eligibility_steps.py:148
+#: app/forms/steps/eligibility_steps.py:156
 msgid "form.eligibility.start-intro"
 msgstr ""
 "Der Steuerlotse bietet Rentner:innen und Pensionär:innen eine "
@@ -317,44 +317,44 @@ msgstr ""
 "zugeschnitten. Durch die Beantwortung weniger Fragen finden Sie heraus, "
 "ob Sie alle Voraussetzungen erfüllen."
 
-#: app/forms/steps/eligibility_steps.py:162
+#: app/forms/steps/eligibility_steps.py:170
 #: app/templates/eligibility/display_start.html:6
 msgid "form.eligibility.check-now-button"
 msgstr "Fragebogen starten"
 
-#: app/forms/steps/eligibility_steps.py:167
+#: app/forms/steps/eligibility_steps.py:175
 msgid "form.eligibility.marital_status-title"
 msgstr "Was war Ihr letzter Familienstand im Jahr 2020?"
 
-#: app/forms/steps/eligibility_steps.py:180
+#: app/forms/steps/eligibility_steps.py:188
 msgid "form.eligibility.marital_status.married"
 msgstr "verheiratet / in eingetragener Lebenspartnerschaft"
 
-#: app/forms/steps/eligibility_steps.py:181
+#: app/forms/steps/eligibility_steps.py:189
 msgid "form.eligibility.marital_status.single"
 msgstr "ledig"
 
-#: app/forms/steps/eligibility_steps.py:182
+#: app/forms/steps/eligibility_steps.py:190
 msgid "form.eligibility.marital_status.divorced"
 msgstr "geschieden / Lebenspartnerschaft aufgehoben"
 
-#: app/forms/steps/eligibility_steps.py:183
+#: app/forms/steps/eligibility_steps.py:191
 msgid "form.eligibility.marital_status.widowed"
 msgstr "verwitwet"
 
-#: app/forms/steps/eligibility_steps.py:189
+#: app/forms/steps/eligibility_steps.py:197
 msgid "form.eligibility.marital_status.back_link_text"
 msgstr "Zurück zum Start"
 
-#: app/forms/steps/eligibility_steps.py:198
+#: app/forms/steps/eligibility_steps.py:206
 msgid "form.eligibility.separated_since_last_year-title"
 msgstr "Haben Sie im Jahr 2020 als Paar dauernd getrennt gelebt?"
 
-#: app/forms/steps/eligibility_steps.py:204
+#: app/forms/steps/eligibility_steps.py:212
 msgid "form.eligibility.separated_since_last_year.detail.title"
 msgstr "Ich weiß nicht, was dauernd getrennt lebend bedeutet."
 
-#: app/forms/steps/eligibility_steps.py:205
+#: app/forms/steps/eligibility_steps.py:213
 msgid "form.eligibility.separated_since_last_year.detail.text"
 msgstr ""
 "Wenn Sie Ihre Lebens- und Wirtschaftsgemeinschaft dauerhaft aufgelöst "
@@ -363,35 +363,35 @@ msgstr ""
 "Betten schlafen, eigene Konten besitzen und getrennt haushalten (ohne den"
 " anderen kochen oder Wäsche waschen)."
 
-#: app/forms/steps/eligibility_steps.py:206
+#: app/forms/steps/eligibility_steps.py:214
 msgid "form.eligibility.separated_since_last_year.yes"
 msgstr "Ja, wir haben dauernd getrennt gelebt."
 
-#: app/forms/steps/eligibility_steps.py:207
+#: app/forms/steps/eligibility_steps.py:215
 msgid "form.eligibility.separated_since_last_year.no"
 msgstr "Nein, wir haben nicht dauernd getrennt gelebt."
 
-#: app/forms/steps/eligibility_steps.py:218
+#: app/forms/steps/eligibility_steps.py:226
 msgid "form.eligibility.separated_lived_together-title"
 msgstr "Haben Sie an mindestens einem Tag im Jahr 2020  zusammengelebt?"
 
-#: app/forms/steps/eligibility_steps.py:224
+#: app/forms/steps/eligibility_steps.py:232
 msgid "form.eligibility.separated_lived_together.yes"
 msgstr "Ja, wir haben im Jahr 2020 auch zusammengelebt."
 
-#: app/forms/steps/eligibility_steps.py:225
+#: app/forms/steps/eligibility_steps.py:233
 msgid "form.eligibility.separated_lived_together.no"
 msgstr "Nein, wir haben das gesamte Jahr 2020 über getrennt gelebt."
 
-#: app/forms/steps/eligibility_steps.py:236
+#: app/forms/steps/eligibility_steps.py:244
 msgid "form.eligibility.separated_joint_taxes-title"
 msgstr "Möchten Sie die Steuererklärung 2020 gemeinsam als Paar machen?"
 
-#: app/forms/steps/eligibility_steps.py:242
+#: app/forms/steps/eligibility_steps.py:250
 msgid "form.eligibility.separated_joint_taxes.detail.title"
 msgstr "Was passiert bei der Zusammenveranlagung?"
 
-#: app/forms/steps/eligibility_steps.py:243
+#: app/forms/steps/eligibility_steps.py:251
 msgid "form.eligibility.separated_joint_taxes.detail.text"
 msgstr ""
 "Wenn Sie Ihre Steuererklärung gemeinsam machen, werden Sie zusammen "
@@ -399,32 +399,32 @@ msgstr ""
 "als gemeinsame Einkommensteuererklärung beim Finanzamt abgegeben werden. "
 "Das Finanzamt erlässt dann nur einen Steuerbescheid."
 
-#: app/forms/steps/eligibility_steps.py:244
+#: app/forms/steps/eligibility_steps.py:252
 msgid "form.eligibility.separated_joint_taxes.yes"
 msgstr "Ja, wir möchten die Zusammenveranlagung nutzen."
 
-#: app/forms/steps/eligibility_steps.py:245
+#: app/forms/steps/eligibility_steps.py:253
 msgid "form.eligibility.separated_joint_taxes.no"
 msgstr "Nein, wir möchten die Steuererklärung einzeln machen."
 
-#: app/forms/steps/eligibility_steps.py:252
+#: app/forms/steps/eligibility_steps.py:260
 msgid "form.eligibility.married_joint_taxes_failure-error"
 msgstr ""
 "Der Steuerlotse bildet die Einzelveranlagung für verheiratete Paare sowie"
 " für Paare in eingetragener Lebenspartnerschaft zurzeit nicht ab."
 
-#: app/forms/steps/eligibility_steps.py:262
-#: app/forms/steps/eligibility_steps.py:369
+#: app/forms/steps/eligibility_steps.py:270
+#: app/forms/steps/eligibility_steps.py:377
 msgid "form.eligibility.joint_taxes-title"
 msgstr "Möchten Sie die Steuererklärung 2020 gemeinsam als Paar machen?"
 
-#: app/forms/steps/eligibility_steps.py:268
-#: app/forms/steps/eligibility_steps.py:375
+#: app/forms/steps/eligibility_steps.py:276
+#: app/forms/steps/eligibility_steps.py:383
 msgid "form.eligibility.joint_taxes.detail.title"
 msgstr "Was passiert bei der Zusammenveranlagung?"
 
-#: app/forms/steps/eligibility_steps.py:269
-#: app/forms/steps/eligibility_steps.py:376
+#: app/forms/steps/eligibility_steps.py:277
+#: app/forms/steps/eligibility_steps.py:384
 msgid "form.eligibility.joint_taxes.detail.text"
 msgstr ""
 "Wenn Sie Ihre Steuererklärung gemeinsam machen, werden Sie zusammen "
@@ -432,77 +432,77 @@ msgstr ""
 "als gemeinsame Einkommensteuererklärung beim Finanzamt abgegeben werden. "
 "Das Finanzamt erlässt dann nur einen Steuerbescheid."
 
-#: app/forms/steps/eligibility_steps.py:270
-#: app/forms/steps/eligibility_steps.py:377
+#: app/forms/steps/eligibility_steps.py:278
+#: app/forms/steps/eligibility_steps.py:385
 msgid "form.eligibility.joint_taxes.yes"
 msgstr "Ja, wir möchten die Zusammenveranlagung nutzen."
 
-#: app/forms/steps/eligibility_steps.py:271
-#: app/forms/steps/eligibility_steps.py:378
+#: app/forms/steps/eligibility_steps.py:279
+#: app/forms/steps/eligibility_steps.py:386
 msgid "form.eligibility.joint_taxes.no"
 msgstr "Nein, wir möchten die Steuererklärung einzeln machen."
 
-#: app/forms/steps/eligibility_steps.py:278
-#: app/forms/steps/eligibility_steps.py:385
+#: app/forms/steps/eligibility_steps.py:286
+#: app/forms/steps/eligibility_steps.py:393
 msgid "form.eligibility.alimony_failure-error"
 msgstr ""
 "Wenn Sie Unterhalt zahlen oder beziehen, müssen Sie im Steuerformular "
 "Angaben machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:288
-#: app/forms/steps/eligibility_steps.py:395
+#: app/forms/steps/eligibility_steps.py:296
+#: app/forms/steps/eligibility_steps.py:403
 msgid "form.eligibility.alimony-title"
 msgstr "Zahlen oder beziehen Sie Unterhalt?"
 
-#: app/forms/steps/eligibility_steps.py:294
-#: app/forms/steps/eligibility_steps.py:305
-#: app/forms/steps/eligibility_steps.py:401
+#: app/forms/steps/eligibility_steps.py:302
+#: app/forms/steps/eligibility_steps.py:313
+#: app/forms/steps/eligibility_steps.py:409
 msgid "form.eligibility.alimony.detail.title"
 msgstr "Was bedeutet das?"
 
-#: app/forms/steps/eligibility_steps.py:295
-#: app/forms/steps/eligibility_steps.py:306
-#: app/forms/steps/eligibility_steps.py:402
+#: app/forms/steps/eligibility_steps.py:303
+#: app/forms/steps/eligibility_steps.py:314
+#: app/forms/steps/eligibility_steps.py:410
 msgid "form.eligibility.alimony.detail.text"
 msgstr ""
 "Beantworten Sie die Frage mit »Ja«, wenn Sie Unterhalt an einen "
 "geschiedenen bzw. dauernd getrennt lebenden Partner oder an bedürftige "
 "Personen leisten oder selbst Unterhalt erhalten."
 
-#: app/forms/steps/eligibility_steps.py:296
-#: app/forms/steps/eligibility_steps.py:403
+#: app/forms/steps/eligibility_steps.py:304
+#: app/forms/steps/eligibility_steps.py:411
 msgid "form.eligibility.alimony.yes"
 msgstr "Ja, ich zahle oder beziehe Unterhalt."
 
-#: app/forms/steps/eligibility_steps.py:297
-#: app/forms/steps/eligibility_steps.py:404
+#: app/forms/steps/eligibility_steps.py:305
+#: app/forms/steps/eligibility_steps.py:412
 msgid "form.eligibility.alimony.no"
 msgstr "Nein, weder zahle, noch beziehe ich Unterhalt."
 
-#: app/forms/steps/eligibility_steps.py:307
+#: app/forms/steps/eligibility_steps.py:315
 msgid "form.eligibility.alimony.multiple.yes"
 msgstr ""
 "Ja, ich oder mein Partner bzw. meine Partnerin zahlen oder beziehen "
 "Unterhalt."
 
-#: app/forms/steps/eligibility_steps.py:308
+#: app/forms/steps/eligibility_steps.py:316
 msgid "form.eligibility.alimony.multiple.no"
 msgstr ""
 "Nein, weder zahlen, noch beziehen ich oder mein Partner bzw. meine "
 "Partnerin Unterhalt."
 
-#: app/forms/steps/eligibility_steps.py:319
-#: app/forms/steps/eligibility_steps.py:421
+#: app/forms/steps/eligibility_steps.py:327
+#: app/forms/steps/eligibility_steps.py:429
 msgid "form.eligibility.user_a_has_elster_account-title"
 msgstr "Haben Sie ein Konto bei Mein ELSTER?"
 
-#: app/forms/steps/eligibility_steps.py:325
-#: app/forms/steps/eligibility_steps.py:427
+#: app/forms/steps/eligibility_steps.py:333
+#: app/forms/steps/eligibility_steps.py:435
 msgid "form.eligibility.user_a_has_elster_account.detail.title"
 msgstr "Was ist Mein ELSTER?"
 
-#: app/forms/steps/eligibility_steps.py:326
-#: app/forms/steps/eligibility_steps.py:428
+#: app/forms/steps/eligibility_steps.py:334
+#: app/forms/steps/eligibility_steps.py:436
 msgid "form.eligibility.user_a_has_elster_account.detail.text"
 msgstr ""
 "ELSTER steht für »Elektronische Steuererklärung« und ist die offizielle "
@@ -511,18 +511,18 @@ msgstr ""
 "ELSTER” können Privatpersonen die für die Einkommensteuererklärung "
 "notwendigen Formulare ausfüllen und abschicken."
 
-#: app/forms/steps/eligibility_steps.py:327
-#: app/forms/steps/eligibility_steps.py:429
+#: app/forms/steps/eligibility_steps.py:335
+#: app/forms/steps/eligibility_steps.py:437
 msgid "form.eligibility.user_a_has_elster_account.yes"
 msgstr "Ja"
 
-#: app/forms/steps/eligibility_steps.py:328
-#: app/forms/steps/eligibility_steps.py:430
+#: app/forms/steps/eligibility_steps.py:336
+#: app/forms/steps/eligibility_steps.py:438
 msgid "form.eligibility.user_a_has_elster_account.no"
 msgstr "Nein"
 
-#: app/forms/steps/eligibility_steps.py:335
-#: app/forms/steps/eligibility_steps.py:411
+#: app/forms/steps/eligibility_steps.py:343
+#: app/forms/steps/eligibility_steps.py:419
 msgid "form.eligibility.elster_account_failure-error"
 msgstr ""
 "Für die Überprüfung Ihrer Identität braucht unser Service einen "
@@ -533,25 +533,25 @@ msgstr ""
 "Steuerlotsen so weiterzuentwickeln, dass er auch genutzt werden kann, "
 "wenn bereits ein Konto bei Mein ELSTER vorhanden ist."
 
-#: app/forms/steps/eligibility_steps.py:345
+#: app/forms/steps/eligibility_steps.py:353
 msgid "form.eligibility.user_b_has_elster_account-title"
 msgstr "Hat Ihr Partner beziehungsweise Ihre Partnerin ein Konto bei Mein ELSTER?"
 
-#: app/forms/steps/eligibility_steps.py:351
+#: app/forms/steps/eligibility_steps.py:359
 msgid "form.eligibility.user_b_has_elster_account.yes"
 msgstr "Ja"
 
-#: app/forms/steps/eligibility_steps.py:352
+#: app/forms/steps/eligibility_steps.py:360
 msgid "form.eligibility.user_b_has_elster_account.no"
 msgstr "Nein"
 
-#: app/forms/steps/eligibility_steps.py:359
+#: app/forms/steps/eligibility_steps.py:367
 msgid "form.eligibility.divorced_joint_taxes_failure-error"
 msgstr ""
 "Der Steuerlotse bildet die Einzelveranlagung für geschiedene Paare "
 "zurzeit nicht ab."
 
-#: app/forms/steps/eligibility_steps.py:437
+#: app/forms/steps/eligibility_steps.py:445
 msgid "form.eligibility.pension_failure-error"
 msgstr ""
 "Sie können Ihre Steuererklärung nur mit dem Steuerlotsen machen, wenn die"
@@ -564,13 +564,13 @@ msgstr ""
 "nicht prüfen, arbeiten aber an einer Möglichkeit, Ihnen mehr "
 "Informationen zur Verfügung zu stellen."
 
-#: app/forms/steps/eligibility_steps.py:447
+#: app/forms/steps/eligibility_steps.py:455
 msgid "form.eligibility.pension-title"
 msgstr ""
 "Beziehen Sie eine Rente bzw. eine Pension von einer oder mehrerer dieser "
 "Stellen:"
 
-#: app/forms/steps/eligibility_steps.py:448
+#: app/forms/steps/eligibility_steps.py:456
 msgid "form.eligibility.pension-intro"
 msgstr ""
 "<ul><li>Träger der gesetzlichen Rentenversicherung</li> <li>der "
@@ -579,37 +579,37 @@ msgstr ""
 " der sog. „Rürup- Rente\"</li><li>Anbieter der sog. „Riester-"
 "Rente\"</li><li>frühere Arbeitgeber</li></ul>"
 
-#: app/forms/steps/eligibility_steps.py:454
+#: app/forms/steps/eligibility_steps.py:462
 msgid "form.eligibility.pension.yes"
 msgstr "Ja, ich beziehe meine Rente ausschließlich aus den genannten Stellen."
 
-#: app/forms/steps/eligibility_steps.py:455
+#: app/forms/steps/eligibility_steps.py:463
 msgid "form.eligibility.pension.no"
 msgstr "Nein, ich beziehe meine Rente aus weiteren Stellen."
 
-#: app/forms/steps/eligibility_steps.py:463
+#: app/forms/steps/eligibility_steps.py:471
 msgid "form.eligibility.pension.multiple.yes"
 msgstr ""
 "Ja, wir beziehen unsere Rente beziehungsweise Pensionen ausschließlich "
 "aus den genannten Stellen."
 
-#: app/forms/steps/eligibility_steps.py:464
+#: app/forms/steps/eligibility_steps.py:472
 msgid "form.eligibility.pension.multiple.no"
 msgstr ""
 "Nein, wir beziehen unsere Rente beziehungsweise Pensionen aus weiteren "
 "Stellen."
 
-#: app/forms/steps/eligibility_steps.py:475
+#: app/forms/steps/eligibility_steps.py:483
 msgid "form.eligibility.investment_income-title"
 msgstr "Haben Sie Kapitalerträge?"
 
-#: app/forms/steps/eligibility_steps.py:481
-#: app/forms/steps/eligibility_steps.py:492
+#: app/forms/steps/eligibility_steps.py:489
+#: app/forms/steps/eligibility_steps.py:500
 msgid "form.eligibility.investment_income.detail.title"
 msgstr "Ich weiß nicht, ob ich Kapitalerträge habe."
 
-#: app/forms/steps/eligibility_steps.py:482
-#: app/forms/steps/eligibility_steps.py:493
+#: app/forms/steps/eligibility_steps.py:490
+#: app/forms/steps/eligibility_steps.py:501
 msgid "form.eligibility.investment_income.detail.text"
 msgstr ""
 "Kapitalerträge sind die Gewinne aus Geldanlagen. Hierzu gehören z.B. "
@@ -617,36 +617,36 @@ msgstr ""
 " aus Aktien oder GmbH-Anteilen. Unter Kapitalerträge fällt aber z.B. "
 "auch, wenn Sie privat Geld verliehen haben und dafür Zinsen erhalten."
 
-#: app/forms/steps/eligibility_steps.py:483
+#: app/forms/steps/eligibility_steps.py:491
 msgid "form.eligibility.investment_income.yes"
 msgstr "Ja, ich habe Kapitalerträge."
 
-#: app/forms/steps/eligibility_steps.py:484
+#: app/forms/steps/eligibility_steps.py:492
 msgid "form.eligibility.investment_income.no"
 msgstr "Nein, ich habe keine Kapitalerträge."
 
-#: app/forms/steps/eligibility_steps.py:494
+#: app/forms/steps/eligibility_steps.py:502
 msgid "form.eligibility.investment_income.multiple.yes"
 msgstr "Ja, wir haben Kapitalerträge."
 
-#: app/forms/steps/eligibility_steps.py:495
+#: app/forms/steps/eligibility_steps.py:503
 msgid "form.eligibility.investment_income.multiple.no"
 msgstr "Nein, wir haben keine Kapitalerträge."
 
-#: app/forms/steps/eligibility_steps.py:506
+#: app/forms/steps/eligibility_steps.py:514
 msgid "form.eligibility.minimal_investment_income-title"
 msgstr ""
 "Haben Sie ausschließlich Kapitalerträge, die nicht versteuert werden "
 "müssen, weil diese den in Anspruch genommenen Sparer-Pauschbetrag nicht "
 "überschreiten?"
 
-#: app/forms/steps/eligibility_steps.py:512
-#: app/forms/steps/eligibility_steps.py:523
+#: app/forms/steps/eligibility_steps.py:520
+#: app/forms/steps/eligibility_steps.py:531
 msgid "form.eligibility.minimal_investment_income.detail.title"
 msgstr "Was ist der Sparer-Pauschbetrag?"
 
-#: app/forms/steps/eligibility_steps.py:513
-#: app/forms/steps/eligibility_steps.py:524
+#: app/forms/steps/eligibility_steps.py:521
+#: app/forms/steps/eligibility_steps.py:532
 msgid "form.eligibility.minimal_investment_income.detail.text"
 msgstr ""
 "Wenn Sie für Ihre Kapitalerträge bei Ihrer Bank einen "
@@ -655,43 +655,43 @@ msgstr ""
 "Rahmen des Sparer-Pauschbetrags sind 801€ für Alleinstehende und 1.602€ "
 "für gemeinsam Veranlagte steuerfrei."
 
-#: app/forms/steps/eligibility_steps.py:514
+#: app/forms/steps/eligibility_steps.py:522
 msgid "form.eligibility.minimal_investment_income.yes"
 msgstr ""
 "Ja, alle meine Kapitalerträge liegen unter dem Sparerpauschbetrag, den "
 "ich in Anspruch genommen habe."
 
-#: app/forms/steps/eligibility_steps.py:515
+#: app/forms/steps/eligibility_steps.py:523
 msgid "form.eligibility.minimal_investment_income.no"
 msgstr "Nein, das trifft auf die Kapitalerträge nicht zu."
 
-#: app/forms/steps/eligibility_steps.py:525
+#: app/forms/steps/eligibility_steps.py:533
 msgid "form.eligibility.minimal_investment_income.multiple.yes"
 msgstr ""
 "Ja, alle unsere Kapitalerträge liegen unter dem Sparerpauschbetrag, den "
 "wir in Anspruch genommen haben."
 
-#: app/forms/steps/eligibility_steps.py:526
+#: app/forms/steps/eligibility_steps.py:534
 msgid "form.eligibility.minimal_investment_income.multiple.no"
 msgstr "Nein, das trifft auf die Kapitalerträge nicht zu."
 
-#: app/forms/steps/eligibility_steps.py:533
+#: app/forms/steps/eligibility_steps.py:541
 msgid "form.eligibility.taxed_investment_failure-error"
 msgstr ""
 "Wenn Sie unversteuerte Kapitalerträge haben, müssen Sie Angaben im "
 "Steuerformular machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:543
+#: app/forms/steps/eligibility_steps.py:551
 msgid "form.eligibility.taxed_investment-title"
 msgstr ""
 "Sind die Kapitalerträge besteuert, weil die erforderlichen Steuern "
 "bereits abgeführt wurden?"
 
-#: app/forms/steps/eligibility_steps.py:549
+#: app/forms/steps/eligibility_steps.py:557
 msgid "form.eligibility.taxed_investment.detail.title"
 msgstr "Ich weiß nicht, um welche Steuern es sich handelt."
 
-#: app/forms/steps/eligibility_steps.py:550
+#: app/forms/steps/eligibility_steps.py:558
 msgid "form.eligibility.taxed_investment.detail.text"
 msgstr ""
 "<p><strong>Abgeltungsteuer</strong><br>Die Abgeltungsteuer wird auf Ihre "
@@ -713,33 +713,33 @@ msgstr ""
 "Erträge bei Ablauf der Versicherung und Auszahlung noch versteuert "
 "werden. Wenn dies auf Sie zutrifft, wählen Sie bitte »Nein« aus.</p>"
 
-#: app/forms/steps/eligibility_steps.py:551
+#: app/forms/steps/eligibility_steps.py:559
 msgid "form.eligibility.taxed_investment.yes"
 msgstr "Ja, alle Steuern wurden bereits abgeführt."
 
-#: app/forms/steps/eligibility_steps.py:552
+#: app/forms/steps/eligibility_steps.py:560
 msgid "form.eligibility.taxed_investment.no"
 msgstr "Nein, es gibt Steuern, die noch nicht abgeführt wurden."
 
-#: app/forms/steps/eligibility_steps.py:559
+#: app/forms/steps/eligibility_steps.py:567
 msgid "form.eligibility.cheaper_check_failure-error"
 msgstr ""
 "Wenn Sie die Günstigerprüfung beantragen möchten, müssen Sie Angaben im "
 "Steuerformular machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:569
+#: app/forms/steps/eligibility_steps.py:577
 msgid "form.eligibility.cheaper_check-title"
 msgstr ""
 "Haben Sie ein geringes Einkommen und möchten daher eine Günstigerprüfung "
 "beantragen?"
 
-#: app/forms/steps/eligibility_steps.py:575
-#: app/forms/steps/eligibility_steps.py:586
+#: app/forms/steps/eligibility_steps.py:583
+#: app/forms/steps/eligibility_steps.py:594
 msgid "form.eligibility.cheaper_check.detail.title"
 msgstr "Was ist die Günstigerprüfung?"
 
-#: app/forms/steps/eligibility_steps.py:576
-#: app/forms/steps/eligibility_steps.py:587
+#: app/forms/steps/eligibility_steps.py:584
+#: app/forms/steps/eligibility_steps.py:595
 msgid "form.eligibility.cheaper_check.detail.text"
 msgstr ""
 "Die Günstigerprüfung ist ein Verfahren, bei dem das Finanzamt den "
@@ -750,72 +750,72 @@ msgstr ""
 "persönlichen Steuersatz besteuert werden anstatt der Besteuerung Ihrer "
 "Kapitalerträge mit der Abgeltungsteuer."
 
-#: app/forms/steps/eligibility_steps.py:577
+#: app/forms/steps/eligibility_steps.py:585
 msgid "form.eligibility.cheaper_check_eligibility.yes"
 msgstr "Ja, ich möchte die Günstigerprüfung beantragen."
 
-#: app/forms/steps/eligibility_steps.py:578
+#: app/forms/steps/eligibility_steps.py:586
 msgid "form.eligibility.cheaper_check_eligibility.no"
 msgstr "Nein, ich möchte die Günstigerprüfung nicht beantragen."
 
-#: app/forms/steps/eligibility_steps.py:588
+#: app/forms/steps/eligibility_steps.py:596
 msgid "form.eligibility.cheaper_check_eligibility.multiple.yes"
 msgstr "Ja, wir möchten die Günstigerprüfung beantragen."
 
-#: app/forms/steps/eligibility_steps.py:589
+#: app/forms/steps/eligibility_steps.py:597
 msgid "form.eligibility.cheaper_check_eligibility.multiple.no"
 msgstr "Nein, wir möchten die Günstigerprüfung nicht beantragen."
 
-#: app/forms/steps/eligibility_steps.py:600
+#: app/forms/steps/eligibility_steps.py:608
 msgid "form.eligibility.employment_income-title"
 msgstr "Haben Sie Einkünfte aus einer Erwerbstätigkeit?"
 
-#: app/forms/steps/eligibility_steps.py:606
-#: app/forms/steps/eligibility_steps.py:617
+#: app/forms/steps/eligibility_steps.py:614
+#: app/forms/steps/eligibility_steps.py:625
 msgid "form.eligibility.employment_income.detail.title"
 msgstr "Ich weiß nicht, ob ich erwerbstätig bin."
 
-#: app/forms/steps/eligibility_steps.py:607
-#: app/forms/steps/eligibility_steps.py:618
+#: app/forms/steps/eligibility_steps.py:615
+#: app/forms/steps/eligibility_steps.py:626
 msgid "form.eligibility.employment_income.detail.text"
 msgstr ""
 "Sie sind zum Beispiel erwerbstätig, wenn Sie  mindestens eine Stunde in "
 "der Woche gegen Entgelt einer beruflichen Tätigkeit nachgehen, "
 "selbstständig sind, einem Gewerbe, Handwerk oder freien Beruf nachgehen."
 
-#: app/forms/steps/eligibility_steps.py:608
+#: app/forms/steps/eligibility_steps.py:616
 msgid "form.eligibility.employment_income.yes"
 msgstr "Ja, ich habe Einkünfte aus einer Erwerbstätigkeit."
 
-#: app/forms/steps/eligibility_steps.py:609
+#: app/forms/steps/eligibility_steps.py:617
 msgid "form.eligibility.employment_income.no"
 msgstr "Nein, ich habe keine Einkünfte aus einer Erwerbstätigkeit."
 
-#: app/forms/steps/eligibility_steps.py:619
+#: app/forms/steps/eligibility_steps.py:627
 msgid "form.eligibility.employment_income.multiple.yes"
 msgstr "Ja, wir haben Einkünfte aus einer Erwerbstätigkeit."
 
-#: app/forms/steps/eligibility_steps.py:620
+#: app/forms/steps/eligibility_steps.py:628
 msgid "form.eligibility.employment_income.multiple.no"
 msgstr "Nein, wir haben keine Einkünfte aus einer Erwerbstätigkeit."
 
-#: app/forms/steps/eligibility_steps.py:627
+#: app/forms/steps/eligibility_steps.py:635
 msgid "form.eligibility.marginal_employment_failure-error"
 msgstr ""
 "Wenn Sie Einkünfte haben, die noch zu versteuern sind, müssen Sie Angaben"
 " im Steuerformular machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:637
+#: app/forms/steps/eligibility_steps.py:645
 msgid "form.eligibility.marginal_employment-title"
 msgstr ""
 "Handelt es sich bei der Erwerbstätigkeit um eine geringfügige "
 "Beschäftigung bis zu 450€, die bereits pauschal besteuert wurde?"
 
-#: app/forms/steps/eligibility_steps.py:643
+#: app/forms/steps/eligibility_steps.py:651
 msgid "form.eligibility.marginal_employment.detail.title"
 msgstr "Was bedeutet das?"
 
-#: app/forms/steps/eligibility_steps.py:644
+#: app/forms/steps/eligibility_steps.py:652
 msgid "form.eligibility.marginal_employment.detail.text"
 msgstr ""
 "Wer nicht mehr als 450 Euro im Monat verdient, gilt als geringfügig "
@@ -823,107 +823,107 @@ msgstr ""
 "Minijob vom Arbeitgeber mit einem Satz von zwei Prozent pauschal "
 "versteuert."
 
-#: app/forms/steps/eligibility_steps.py:645
+#: app/forms/steps/eligibility_steps.py:653
 msgid "form.eligibility.marginal_employment.yes"
 msgstr ""
 "Ja, es handelt sich um eine geringfügige Beschäftigung. Die Einkünfte "
 "wurden bereits pauschal versteuert."
 
-#: app/forms/steps/eligibility_steps.py:646
+#: app/forms/steps/eligibility_steps.py:654
 msgid "form.eligibility.marginal_employment.no"
 msgstr ""
 "Nein, es handelt sich nicht um eine geringfügige Beschäftigung. Die "
 "Einkünfte wurden noch nicht pauschal besteuert."
 
-#: app/forms/steps/eligibility_steps.py:653
+#: app/forms/steps/eligibility_steps.py:661
 msgid "form.eligibility.income_other_failure-error"
 msgstr ""
 "Wenn Sie Einkünfte haben, die noch zu versteuern sind, müssen Sie Angaben"
 " im Steuerformular machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:663
+#: app/forms/steps/eligibility_steps.py:671
 msgid "form.eligibility.income-other-title"
 msgstr ""
 "Haben Sie noch weitere Einkünfte als die bisher genannten Einkünfte? Zum "
 "Beispiel aus einer Vermietung?"
 
-#: app/forms/steps/eligibility_steps.py:669
-#: app/forms/steps/eligibility_steps.py:680
+#: app/forms/steps/eligibility_steps.py:677
+#: app/forms/steps/eligibility_steps.py:688
 msgid "form.eligibility.income-other.detail.title"
 msgstr "Ich bin mir nicht sicher."
 
-#: app/forms/steps/eligibility_steps.py:670
-#: app/forms/steps/eligibility_steps.py:681
+#: app/forms/steps/eligibility_steps.py:678
+#: app/forms/steps/eligibility_steps.py:689
 msgid "form.eligibility.income-other.detail.text"
 msgstr ""
 "Wenn Sie außer Ihren Renteneinkünften bzw. Pensionen, Kapitalerträgen "
 "oder Einkünften aus einer Erwerbstätigkeit weitere Einkünfte wie zum "
 "Beispiel aus einer Vermietung haben, wählen Sie bitte »Ja«."
 
-#: app/forms/steps/eligibility_steps.py:671
+#: app/forms/steps/eligibility_steps.py:679
 msgid "form.eligibility.income-other.yes"
 msgstr "Ja, ich habe noch weitere Einkünfte."
 
-#: app/forms/steps/eligibility_steps.py:672
+#: app/forms/steps/eligibility_steps.py:680
 msgid "form.eligibility.income-other.no"
 msgstr "Nein, ich habe keine weiteren Einkünfte."
 
-#: app/forms/steps/eligibility_steps.py:682
+#: app/forms/steps/eligibility_steps.py:690
 msgid "form.eligibility.income-other.multiple.yes"
 msgstr "Ja, wir haben noch weitere Einkünfte."
 
-#: app/forms/steps/eligibility_steps.py:683
+#: app/forms/steps/eligibility_steps.py:691
 msgid "form.eligibility.income-other.multiple.no"
 msgstr "Nein, wir haben keine weiteren Einkünfte."
 
-#: app/forms/steps/eligibility_steps.py:690
+#: app/forms/steps/eligibility_steps.py:698
 msgid "form.eligibility.foreign_country_failure-error"
 msgstr ""
 "Wenn Sie letztes Jahr im Ausland gelebt haben, müssen Sie Angaben im "
 "Steuerformular machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:700
+#: app/forms/steps/eligibility_steps.py:708
 msgid "form.eligibility.foreign-country-title"
 msgstr ""
 "Leben Sie dauerhaft im Ausland und kommen nur gelegentlich, zum Beispiel "
 "zu Besuchszwecken, nach Deutschland?"
 
-#: app/forms/steps/eligibility_steps.py:706
-#: app/forms/steps/eligibility_steps.py:717
+#: app/forms/steps/eligibility_steps.py:714
+#: app/forms/steps/eligibility_steps.py:725
 msgid "form.eligibility.foreign-country.detail.title"
 msgstr "Ab welcher Dauer lebt man dauerhaft im Ausland?"
 
-#: app/forms/steps/eligibility_steps.py:707
-#: app/forms/steps/eligibility_steps.py:718
+#: app/forms/steps/eligibility_steps.py:715
+#: app/forms/steps/eligibility_steps.py:726
 msgid "form.eligibility.foreign-country.detail.text"
 msgstr ""
 "Sie leben dauerhaft im Ausland, wenn Sie länger als 183 Tage im Jahr in "
 "einem anderen Land gelebt haben. Sollte dies der Fall sein, wählen Sie "
 "»Ja« aus. "
 
-#: app/forms/steps/eligibility_steps.py:708
+#: app/forms/steps/eligibility_steps.py:716
 msgid "form.eligibility.foreign-country.yes"
 msgstr "Ja, ich lebe dauerhaft im Ausland."
 
-#: app/forms/steps/eligibility_steps.py:709
+#: app/forms/steps/eligibility_steps.py:717
 msgid "form.eligibility.foreign-country.no"
 msgstr "Nein, ich lebe dauerhaft in Deutschland."
 
-#: app/forms/steps/eligibility_steps.py:719
+#: app/forms/steps/eligibility_steps.py:727
 msgid "form.eligibility.foreign-country.multiple.yes"
 msgstr "Ja, wir leben dauerhaft im Ausland."
 
-#: app/forms/steps/eligibility_steps.py:720
+#: app/forms/steps/eligibility_steps.py:728
 msgid "form.eligibility.foreign-country.multiple.no"
 msgstr "Nein, wir leben dauerhaft in Deutschland."
 
-#: app/forms/steps/eligibility_steps.py:727
+#: app/forms/steps/eligibility_steps.py:735
 msgid "form.eligibility.result-title"
 msgstr ""
 "Sie können Ihre Steuererklärung für das Jahr 2020 mit dem Steuerlotsen "
 "machen."
 
-#: app/forms/steps/eligibility_steps.py:728
+#: app/forms/steps/eligibility_steps.py:736
 msgid "form.eligibility.result-intro"
 msgstr ""
 "Wenn Sie alle Fragen korrekt beantwortet haben, können Sie den "
@@ -932,13 +932,13 @@ msgstr ""
 "die Finanzverwaltung übermitteln. Außerdem haben Sie keine weiteren "
 "Einkünfte, die Sie in Ihrer Steuererklärung geltend machen müssen."
 
-#: app/forms/steps/eligibility_steps.py:742
+#: app/forms/steps/eligibility_steps.py:750
 msgid "form.eligibility.result-note.user_b_elster_account"
 msgstr ""
 "Wenn Sie Ihre Steuererklärung gemeinsam als Paar machen möchten, muss "
 "sich trotzdem nur eine Person registrieren."
 
-#: app/forms/steps/eligibility_steps.py:743
+#: app/forms/steps/eligibility_steps.py:751
 msgid "form.eligibility.result-note.user_b_elster_account-registration"
 msgstr ""
 "Bitte registrieren Sie sich mit den Angaben der Person, die noch kein "
@@ -947,17 +947,7 @@ msgstr ""
 " erstellt und per Post versendet. Aus technischen Gründen geschieht das "
 "allerdings nur, wenn Sie noch kein Konto bei Mein ELSTER haben."
 
-#: app/forms/steps/eligibility_steps.py:745
-msgid "form.eligibility.result-note.cheaper_check"
-msgstr ""
-"Die Besteuerung von Kapitalerträgen erledigen Banken und Versicherungen "
-"für Sie. Wenn Sie mit der Höhe der Besteuerung oder den für Sie "
-"abgeführten Steuern nicht einverstanden sind, können Sie in der "
-"Einkommensteuererklärung eine Änderung der Steuerbelastung beantragen. "
-"Der Steuerlotse bietet Ihnen dafür allerdings derzeit keine "
-"Möglichkeiten."
-
-#: app/forms/steps/eligibility_steps.py:748
+#: app/forms/steps/eligibility_steps.py:755
 msgid "form.eligibility.result-note.capital_investment"
 msgstr ""
 "Die Besteuerung von Kapitalerträgen erledigen Banken und Versicherungen "

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-08-30 10:25+0200\n"
+"POT-Creation-Date: 2021-09-03 10:31+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -18,109 +18,109 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.1\n"
 
-#: app/routes.py:57
+#: app/routes.py:58
 msgid "nav.home"
 msgstr "Übersicht"
 
-#: app/routes.py:58
+#: app/routes.py:59
 msgid "nav.how-it-works"
 msgstr "Informieren"
 
-#: app/routes.py:59
+#: app/routes.py:60
 msgid "nav.eligibility"
 msgstr "Nutzung prüfen"
 
-#: app/routes.py:60
+#: app/routes.py:61
 msgid "nav.register"
 msgstr "Registrieren"
 
-#: app/routes.py:62
+#: app/routes.py:63
 msgid "nav.lotse-form"
 msgstr "Ihre Steuererklärung"
 
-#: app/routes.py:64
+#: app/routes.py:65
 msgid "nav.logout"
 msgstr "Abmelden"
 
-#: app/routes.py:68
+#: app/routes.py:69
 msgid "login.not-logged-in-warning"
 msgstr "Sie müssen eingeloggt sein um das zu sehen."
 
-#: app/routes.py:118
+#: app/routes.py:121
 msgid "unlock_code_request.logged_in.title"
 msgstr "Sind Sie sicher, dass Sie sich erneut registrieren möchten?"
 
-#: app/routes.py:119
+#: app/routes.py:122
 msgid "unlock_code_request.logged_in.intro"
 msgstr ""
 "Sie sind bereits angemeldet. Wählen Sie „Zurück zur Steuererklärung, wenn"
 " Sie mit Ihrer Steuererklärung fortfahren möchten. Wenn Sie sich erneut "
 "registrieren möchten, müssen Sie sich zuerst abmelden."
 
-#: app/routes.py:145
+#: app/routes.py:148
 msgid "unlock_code_revocation.logged_in.title"
 msgstr "Sind Sie sicher, dass Sie Ihren Freischaltcode stornieren möchten?"
 
-#: app/routes.py:146
+#: app/routes.py:149
 msgid "unlock_code_revocation.logged_in.intro"
 msgstr ""
 "Sie sind bereits angemeldet. Wählen Sie „Zurück zur Steuererklärung“, "
 "wenn Sie mit Ihrer Steuererklärung fortfahren möchten. Wenn Sie Ihren "
 "Freischaltcode stornieren möchten, müssen Sie sich zuerst abmelden."
 
-#: app/routes.py:157 app/routes.py:254
+#: app/routes.py:160 app/routes.py:257
 msgid "404.header-title"
 msgstr "Fehler 404 - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:175 app/templates/basis/base.html:30
+#: app/routes.py:178 app/templates/basis/base.html:30
 msgid "page.title"
 msgstr "Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:180
+#: app/routes.py:183
 msgid "howitworks.header-title"
 msgstr "Informieren - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:185
+#: app/routes.py:188
 msgid "contact.header-title"
 msgstr "Kontakt - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:190
+#: app/routes.py:193
 msgid "imprint.header-title"
 msgstr "Impressum - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:195
+#: app/routes.py:198
 msgid "barrierefreiheit.header-title"
 msgstr "Barrierefreiheit - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:200
+#: app/routes.py:203
 msgid "data_privacy.header-title"
 msgstr "Datenschutz - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:205
+#: app/routes.py:208
 msgid "agb.header-title"
 msgstr "Nutzungsbedingungen - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:215
+#: app/routes.py:218
 msgid "about.header-title"
 msgstr "Projektinfos - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:220
+#: app/routes.py:223
 msgid "about_digitalservice.header-title"
 msgstr "Digital Service - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:246
+#: app/routes.py:249
 msgid "erica-error.header-title"
 msgstr "Übermittlungsfehler - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:250 app/routes.py:258
+#: app/routes.py:253 app/routes.py:261
 msgid "400.header-title"
 msgstr "Fehler 400 - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:262
+#: app/routes.py:265
 msgid "429.header-title"
 msgstr "Fehler 429 - Der Steuerlotse für Rente und Pension"
 
-#: app/routes.py:267
+#: app/routes.py:270
 msgid "500.header-title"
 msgstr "Fehler 500 - Der Steuerlotse für Rente und Pension"
 
@@ -956,6 +956,17 @@ msgstr ""
 "Einkommensteuererklärung eine Änderung der Steuerbelastung beantragen. "
 "Der Steuerlotse bietet Ihnen dafür allerdings derzeit keine "
 "Möglichkeiten."
+
+#: app/forms/steps/eligibility_steps.py:748
+msgid "form.eligibility.result-note.capital_investment"
+msgstr ""
+"Die Besteuerung von Kapitalerträgen erledigen Banken und Versicherungen "
+"für Sie. Wenn Sie Freistellungsaufträge erteilt haben, dann erhalten Sie "
+"dort auch Ihren Sparerfreibetrag. Wenn Sie keine Freistellungsaufträge "
+"erteilt haben oder mit der Höhe der für Sie abgeführten Steuern nicht "
+"einverstanden sind, dann können Sie in der Einkommensteuererklärung eine "
+"Änderung der Steuerbelastung beantragen. Der Steuerlotse bietet Ihnen "
+"dafür allerdings derzeit keine Möglichkeiten."
 
 #: app/forms/steps/logout_steps.py:16
 msgid "form.logout.input-title"

--- a/webapp/tests/forms/steps/test_eligibility_steps.py
+++ b/webapp/tests/forms/steps/test_eligibility_steps.py
@@ -31,7 +31,8 @@ from app.forms.steps.eligibility_steps import MarriedJointTaxesEligibilityFailur
     ForeignCountriesEligibilityFailureDisplaySteuerlotseStep, EligibilitySuccessDisplaySteuerlotseStep, \
     SeparatedEligibilityInputFormSteuerlotseStep, MaritalStatusInputFormSteuerlotseStep, \
     EligibilityStepMixin, SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep, \
-    EligibilityStartDisplaySteuerlotseStep, SeparatedJointTaxesEligibilityInputFormSteuerlotseStep
+    EligibilityStartDisplaySteuerlotseStep, SeparatedJointTaxesEligibilityInputFormSteuerlotseStep, \
+    data_fits_one_data_model, data_fits_data_model
 from app.forms.steps.steuerlotse_step import RedirectSteuerlotseStep
 from app.model.recursive_data import PreviousFieldsMissingError
 from tests.forms.mock_steuerlotse_steps import MockRenderStep, MockStartStep, MockFormStep, MockFinalStep, \
@@ -118,6 +119,46 @@ class TestEligibilityStepSpecificsMixin(unittest.TestCase):
         num_of_users = EligibilityStepMixin().number_of_users(input_data)
 
         self.assertEqual(1, num_of_users)
+
+
+class TestDataFitsDataModel:
+
+    def test_if_model_fails_then_return_false(self):
+        failing_model = MagicMock(parse_obj=MagicMock(side_effect=ValidationError([], None)))
+        result = data_fits_data_model(failing_model, {})
+
+        assert result is False
+
+    def test_if_model_does_not_fail_then_return_true(self):
+        succeeding_model = MagicMock()
+        result = data_fits_data_model(succeeding_model, {})
+
+        assert result is True
+
+
+class TestDataFitsOneDataModel:
+
+    def test_if_all_models_fail_then_return_false(self):
+        failing_model = MagicMock(parse_obj=MagicMock(side_effect=ValidationError([], None)))
+        models = [failing_model, failing_model,failing_model]
+        result = data_fits_one_data_model(models, {})
+
+        assert result is False
+
+    def test_if_one_model_does_not_fail_then_return_true(self):
+        failing_model = MagicMock(parse_obj=MagicMock(side_effect=ValidationError([], None)))
+        succeeding_model = MagicMock()
+        models = [failing_model, succeeding_model, failing_model]
+        result = data_fits_one_data_model(models, {})
+
+        assert result is True
+
+    def test_if_all_models_does_not_fail_then_return_true(self):
+        succeeding_model = MagicMock()
+        models = [succeeding_model, succeeding_model,succeeding_model]
+        result = data_fits_one_data_model(models, {})
+
+        assert result is True
 
 
 class TestEligibilityInputFormSteuerlotseStepIsPreviousStep(unittest.TestCase):

--- a/webapp/tests/forms/steps/test_eligibility_steps.py
+++ b/webapp/tests/forms/steps/test_eligibility_steps.py
@@ -32,7 +32,7 @@ from app.forms.steps.eligibility_steps import MarriedJointTaxesEligibilityFailur
     SeparatedEligibilityInputFormSteuerlotseStep, MaritalStatusInputFormSteuerlotseStep, \
     EligibilityStepMixin, SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep, \
     EligibilityStartDisplaySteuerlotseStep, SeparatedJointTaxesEligibilityInputFormSteuerlotseStep, \
-    data_fits_one_data_model, data_fits_data_model
+    data_fits_data_model_from_list, data_fits_data_model
 from app.forms.steps.steuerlotse_step import RedirectSteuerlotseStep
 from app.model.recursive_data import PreviousFieldsMissingError
 from tests.forms.mock_steuerlotse_steps import MockRenderStep, MockStartStep, MockFormStep, MockFinalStep, \
@@ -141,7 +141,7 @@ class TestDataFitsOneDataModel:
     def test_if_all_models_fail_then_return_false(self):
         failing_model = MagicMock(parse_obj=MagicMock(side_effect=ValidationError([], None)))
         models = [failing_model, failing_model,failing_model]
-        result = data_fits_one_data_model(models, {})
+        result = data_fits_data_model_from_list(models, {})
 
         assert result is False
 
@@ -149,14 +149,14 @@ class TestDataFitsOneDataModel:
         failing_model = MagicMock(parse_obj=MagicMock(side_effect=ValidationError([], None)))
         succeeding_model = MagicMock()
         models = [failing_model, succeeding_model, failing_model]
-        result = data_fits_one_data_model(models, {})
+        result = data_fits_data_model_from_list(models, {})
 
         assert result is True
 
     def test_if_all_models_does_not_fail_then_return_true(self):
         succeeding_model = MagicMock()
         models = [succeeding_model, succeeding_model,succeeding_model]
-        result = data_fits_one_data_model(models, {})
+        result = data_fits_data_model_from_list(models, {})
 
         assert result is True
 

--- a/webapp/tests/forms/steps/test_eligibility_steps.py
+++ b/webapp/tests/forms/steps/test_eligibility_steps.py
@@ -2596,7 +2596,7 @@ class TestEligibilitySuccessDisplaySteuerlotseStep(unittest.TestCase):
         self.assertEqual(expected_information, step.render_info.additional_info['dependent_notes'])
 
     def test_if_user_wants_no_cheaper_check_then_set_correct_info(self):
-        expected_information = ['form.eligibility.result-note.cheaper_check']
+        expected_information = ['form.eligibility.result-note.capital_investment']
         session_data = {'marital_status_eligibility': 'single',
                         'user_a_has_elster_account_eligibility': 'no',
                         'alimony_eligibility': 'no',
@@ -2611,10 +2611,25 @@ class TestEligibilitySuccessDisplaySteuerlotseStep(unittest.TestCase):
 
         self.assertEqual(expected_information, step.render_info.additional_info['dependent_notes'])
 
+    def test_if_user_has_no_minimal_investment_income_then_set_correct_info(self):
+        expected_information = ['form.eligibility.result-note.capital_investment']
+        session_data = {'marital_status_eligibility': 'single',
+                        'user_a_has_elster_account_eligibility': 'no',
+                        'alimony_eligibility': 'no',
+                        'pension_eligibility': 'yes',
+                        'investment_income_eligibility': 'yes',
+                        'minimal_investment_income_eligibility': 'yes',
+                        'taxed_investment_income_eligibility': 'yes', }
+        with patch('app.forms.steps.eligibility_steps._', MagicMock(side_effect=lambda text_id: text_id)):
+            step = EligibilitySuccessDisplaySteuerlotseStep(endpoint='eligibility', stored_data=session_data)
+            step.handle()
+
+        self.assertEqual(expected_information, step.render_info.additional_info['dependent_notes'])
+
     def test_if_user_b_has_no_elster_account_and_user_wants_no_cheaper_check_then_set_correct_info(self):
         expected_information = ['form.eligibility.result-note.user_b_elster_account',
                                 'form.eligibility.result-note.user_b_elster_account-registration',
-                                'form.eligibility.result-note.cheaper_check']
+                                'form.eligibility.result-note.capital_investment']
         session_data = {'marital_status_eligibility': 'married',
                         'separated_since_last_year_eligibility': 'no',
                         'user_a_has_elster_account_eligibility': 'yes',
@@ -2626,6 +2641,26 @@ class TestEligibilitySuccessDisplaySteuerlotseStep(unittest.TestCase):
                         'minimal_investment_income_eligibility': 'no',
                         'taxed_investment_income_eligibility': 'yes',
                         'cheaper_check_eligibility': 'no', }
+        with patch('app.forms.steps.eligibility_steps._', MagicMock(side_effect=lambda text_id: text_id)):
+            step = EligibilitySuccessDisplaySteuerlotseStep(endpoint='eligibility', stored_data=session_data)
+            step.handle()
+
+        self.assertEqual(expected_information, step.render_info.additional_info['dependent_notes'])
+
+    def test_if_user_b_has_no_elster_account_and_user_has_minimal_investment_income_check_then_set_correct_info(self):
+        expected_information = ['form.eligibility.result-note.user_b_elster_account',
+                                'form.eligibility.result-note.user_b_elster_account-registration',
+                                'form.eligibility.result-note.capital_investment']
+        session_data = {'marital_status_eligibility': 'married',
+                        'separated_since_last_year_eligibility': 'no',
+                        'user_a_has_elster_account_eligibility': 'yes',
+                        'user_b_has_elster_account_eligibility': 'no',
+                        'joint_taxes_eligibility': 'yes',
+                        'alimony_eligibility': 'no',
+                        'pension_eligibility': 'yes',
+                        'investment_income_eligibility': 'yes',
+                        'minimal_investment_income_eligibility': 'yes',
+                        'taxed_investment_income_eligibility': 'yes', }
         with patch('app.forms.steps.eligibility_steps._', MagicMock(side_effect=lambda text_id: text_id)):
             step = EligibilitySuccessDisplaySteuerlotseStep(endpoint='eligibility', stored_data=session_data)
             step.handle()


### PR DESCRIPTION
# Short Description
This adds a dependent note for capital investment on the success page of the eligibility flow. Because the new text is very close to the one for the cheaper check, the new text replaces the  dependent note of the cheaper check.

# Changes
- Add `data_fits_one_model`
- Add new dependent note to the success page

# Feedback
- Do you see any problems?
- Do you have any ideas for a better name for `data_fits_one_data_model`?
