### PR TITLE
Fix radio button UI

### DIFF
--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -64,7 +64,7 @@
 {% macro radio_field(field, position_details_after=False, first_field=False) -%}
     <fieldset class="grouped-input-fields">
         {{ field_label(field, class="text-input-field-label", position_details_after=position_details_after) }}
-        <div class="radio-button-buttons">
+        <div class="radio-button-list">
         {% for subfield in field %}
             <div>
                 {% if field.errors and loop.index0==0 %}

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -64,6 +64,7 @@
 {% macro radio_field(field, position_details_after=False, first_field=False) -%}
     <fieldset class="grouped-input-fields">
         {{ field_label(field, class="text-input-field-label", position_details_after=position_details_after) }}
+        <div class="radio-button-buttons">
         {% for subfield in field %}
             <div>
                 {% if field.errors and loop.index0==0 %}
@@ -74,6 +75,7 @@
                 {{ field_label(subfield, class="col-sm-10 col-form-label", position_details_after=position_details_after) }}
             </div>
         {% endfor %}
+        </div>
         {%- if position_details_after %}
             {{ render_detail(field) }}
         {% endif %}

--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -528,30 +528,23 @@ input[type="radio"] + label::before {
     height: 30px;
     min-width: 30px;
     margin-right: 12px;
-    border-radius: 50%;
-    border: 2px solid var(--text-color);
-    background: white;
+    background: url("/icons/radio_button_default.svg") no-repeat center;
 }
 
 input[type="radio"]:checked + label::before {
-    background: radial-gradient(var(--link-active-color) 40%, var(--bg-white) 50%, transparent 0%, transparent);
-    border-color: var(--link-active-color);
+    background: url("/icons/radio_button_checked.svg") no-repeat center;
 }
 
-input[type="radio"]:checked + label:hover::before{
-    background: radial-gradient(var(--hover-border-color) 40%, var(--bg-white) 50%, transparent 0%, transparent);
-    border-color: var(--hover-border-color);
+input[type="radio"]:checked + label:hover::before {
+    background: url("/icons/radio_button_checked_hover.svg") no-repeat center;
 }
 
-input[type="radio"]:not(:checked):focus + label::before{
-    background: var(--focus-color);
-    border-color: black;
-    box-shadow: 0 0 0 2px var(--focus-color);
+input[type="radio"]:not(:checked):focus + label::before {
+    background: url("/icons/radio_button_focus.svg") no-repeat center;
 }
 
-input[type="radio"]:checked:focus + label::before{
-    border-color: black;
-    box-shadow: 0 0 0 2px var(--focus-color);
+input[type="radio"]:checked:focus + label::before {
+    background: url("/icons/radio_button_checked_focus.svg") no-repeat center;
 }
 
 .radio-button-buttons {

--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -547,7 +547,7 @@ input[type="radio"]:checked:focus + label::before {
     background: url("/icons/radio_button_checked_focus.svg") no-repeat center;
 }
 
-.radio-button-buttons {
+.radio-button-list {
     padding-top: var(--spacing-02);
 }
 

--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -510,6 +510,14 @@ a.back-link:focus a.back-link:active{
 /* RADIO BUTTONS */
 input[type="radio"] {
     opacity: 0;
+    position: absolute;
+}
+
+input[type="radio"] + label {
+    display: flex;
+    padding-left: 0;
+    padding-top: 0;
+    font-size: var(--text-medium);
 }
 
 input[type="radio"] + label::before {
@@ -518,6 +526,7 @@ input[type="radio"] + label::before {
     vertical-align: bottom;
     width: 30px;
     height: 30px;
+    min-width: 30px;
     margin-right: 12px;
     border-radius: 50%;
     border: 2px solid var(--text-color);
@@ -525,12 +534,12 @@ input[type="radio"] + label::before {
 }
 
 input[type="radio"]:checked + label::before {
-    background: radial-gradient(var(--link-active-color) 40%, var(--bg-white) 40%, transparent 0%, transparent);
+    background: radial-gradient(var(--link-active-color) 40%, var(--bg-white) 50%, transparent 0%, transparent);
     border-color: var(--link-active-color);
 }
 
 input[type="radio"]:checked + label:hover::before{
-    background: radial-gradient(var(--hover-border-color) 40%, var(--bg-white) 40%, transparent 0%, transparent);
+    background: radial-gradient(var(--hover-border-color) 40%, var(--bg-white) 50%, transparent 0%, transparent);
     border-color: var(--hover-border-color);
 }
 
@@ -543,6 +552,10 @@ input[type="radio"]:not(:checked):focus + label::before{
 input[type="radio"]:checked:focus + label::before{
     border-color: black;
     box-shadow: 0 0 0 2px var(--focus-color);
+}
+
+.radio-button-buttons {
+    padding-top: var(--spacing-02);
 }
 
 .field-label {

--- a/webapp/client/public/icons/radio_button_checked.svg
+++ b/webapp/client/public/icons/radio_button_checked.svg
@@ -1,0 +1,4 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="15" cy="15" r="14" fill="white" stroke="#0B0C0C" stroke-width="2"/>
+<circle cx="15" cy="15" r="8" fill="#0B0C0C"/>
+</svg>

--- a/webapp/client/public/icons/radio_button_checked_focus.svg
+++ b/webapp/client/public/icons/radio_button_checked_focus.svg
@@ -1,0 +1,4 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="15" cy="15" r="14" fill="#FFC979" stroke="#0B0C0C" stroke-width="2"/>
+<circle cx="15" cy="15" r="8" fill="#0B0C0C"/>
+</svg>

--- a/webapp/client/public/icons/radio_button_checked_hover.svg
+++ b/webapp/client/public/icons/radio_button_checked_hover.svg
@@ -1,0 +1,4 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="15" cy="15" r="14" fill="white" stroke="#003B52" stroke-width="2"/>
+<circle cx="15" cy="15" r="8" fill="#003B52"/>
+</svg>

--- a/webapp/client/public/icons/radio_button_default.svg
+++ b/webapp/client/public/icons/radio_button_default.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="15" cy="15" r="14" fill="white" stroke="#0B0C0C" stroke-width="2"/>
+</svg>

--- a/webapp/client/public/icons/radio_button_focus.svg
+++ b/webapp/client/public/icons/radio_button_focus.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="15" cy="15" r="13.5" fill="#FFC979" stroke="#0B0C0C" stroke-width="3"/>
+</svg>

--- a/webapp/client/public/icons/radio_button_hover.svg
+++ b/webapp/client/public/icons/radio_button_hover.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="15" cy="15" r="14" fill="white" stroke="#005576" stroke-width="2"/>
+</svg>


### PR DESCRIPTION
# Short Description
- The radio buttons were looking...odd. That was because the actual (hidden) input was not completely hidden and took up space.

# Changes
- Make actual input small and positioned absolutely
- Set min-width on the circle in order to avoid resizing on screen resizing
- Add more padding between buttons and label
- Replace CSS radial buttons with SVGs for every state

# Feedback
- Did you expect something like this?
