### PR TITLE
Details component details

### DIFF
--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -209,7 +209,7 @@
             <div id="details-body-{{ details_id }}" class="collapse" aria-labelledby="heading-{{ card_id }}"
                 data-parent="#details-{{ details_id }}">
                 <div class="card-body container pt-0">
-                    <div class="row">
+                    <div class="row m-0">
                         <div class="col-1 px-0">
                             <div class="block-quote-line"></div>
                         </div>

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -155,7 +155,7 @@
             {% for id, card in accordion.entries.items() -%}
                 {% set card_id = 'card-' + id -%}
                 <div class="card mt-2">
-                    <div class="card-header d-sm-flex justify-content-between align-items-center row collapsed w-100"
+                    <div class="card-header d-sm-flex justify-content-between row collapsed w-100"
                          id="heading-{{ card_id }}" data-toggle="collapse"
                          data-target="#{{ card_id }}" aria-expanded="false"
                          aria-controls="collapseOne">
@@ -194,17 +194,15 @@
     <div id="details-{{ details_id }}" class="details-card ml-0 pl-0">
         <div class="card">
             <div class="card-header unstyled-card-header d-sm-flex justify-content-between align-items-center cursor-pointer mb-0">
-                <div class="collapsed" data-toggle="collapse"
+                <div class="collapsed w-100" data-toggle="collapse"
                             data-target="#details-body-{{ details_id }}"
                             aria-expanded="false" aria-controls="collapseOne">
-                    <div class="container">
-                        <div class="row">
-                            <button class="btn details-icon col-1 control-show-more" type="button" tabindex="-1" aria-hidden="true"></button>
-                            <button class="btn details-icon col-1 control-show-less" type="button" tabindex="-1" aria-hidden="true"></button>
-                            <button class="btn col" type="button">
+                    <div class="details-header row">
+                            <button class="btn details-icon control-show-more" type="button" tabindex="-1" aria-hidden="true"></button>
+                            <button class="btn details-icon control-show-less" type="button" tabindex="-1" aria-hidden="true"></button>
+                            <button class="btn" type="button">
                                 <span class="mb-0">{{title}}</span>
                             </button>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -207,6 +207,13 @@
 .details-card .card-header {
     border: 0;
     background: inherit;
+    align-items: start;
+    flex-wrap: nowrap;
+}
+
+.details-header {
+    flex-wrap: nowrap;
+    margin: 0;
 }
 
 .details-card .card-header span {
@@ -217,7 +224,7 @@
 
 @media (max-width: 1024px) {
     .details-card .card-header span {
-        font-size: var(--text-sm);
+        font-size: var(--text-base);
     }
 }
 
@@ -249,20 +256,24 @@
 }
 
 .details-card .card-header .details-icon {
-    width: 100%;
-    background:  url("/icons/details_arrow_down.svg") no-repeat center;
+    width: 14px;
+    min-width: 14px;
+    height: var(--lineheight-default);
+    padding: 0;
+    margin-top: .375rem;
+    background:  url("/icons/details_arrow_down.svg") no-repeat left;
 }
 
 .details-card .card-header .collapsed:hover .details-icon{
-    background:  url("/icons/details_arrow_right_hover.svg") no-repeat center;
+    background:  url("/icons/details_arrow_right_hover.svg") no-repeat left;
 }
 
 .details-card .card-header .collapsed button:focus .details-icon{
-    background:  url("/icons/details_arrow_right_focus.svg") no-repeat center;
+    background:  url("/icons/details_arrow_right_focus.svg") no-repeat left;
 }
 
 .details-card .card-header .collapsed .details-icon{
-    background:  url("/icons/details_arrow_right.svg") no-repeat center;
+    background:  url("/icons/details_arrow_right.svg") no-repeat left;
 }
 
 .details-card .card-body {
@@ -294,8 +305,10 @@
     /* We need to still show it to keep focus on the element */
     height: 1px;
     width: 1px;
+    min-width: 1px;
     background-color: inherit;
     padding: 0;
+    margin: 0;
     overflow: hidden;
     position: absolute;
 }
@@ -304,8 +317,10 @@
     /* We need to still show it to keep focus on the element */
     height: 1px;
     width: 1px;
+    min-width: 1px;
     background-color: inherit;
     padding: 0;
+    margin: 0;
     overflow: hidden;
     position: absolute;
 }

--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -281,18 +281,22 @@
 }
 
 .details-card .details-content{
-    padding: 1em 1em 0 1em;
+    padding: 1em 1em 0 0;
 }
 
 .card-body-less-padding {
     padding: 1em 1em var(--spacing-01) var(--spacing-01);
 }
 
+.details-card .card-body {
+    padding: 0 0 var(--spacing-04) 0;
+}
+
 
 .details-card .card-body .block-quote-line{
     width: 2px;
     height: 100%;
-    margin: 0 auto;
+    margin: 0 auto 0 5px;
     background-color: var(--border-color);
 }
 

--- a/webapp/client/public/css/variables.css
+++ b/webapp/client/public/css/variables.css
@@ -51,12 +51,12 @@
 
   /* Line Height */
   
-  --lineheight-none: 1;
-  --lineheight-xs: 1.1;
-  --lineheight-s: 1.2;
-  --lineheight-m: 1.3;
-  --lineheight-default: 1.45;
-  --lineheight-l: 1.6;
+  --lineheight-none: 1em;
+  --lineheight-xs: 1.1em;
+  --lineheight-s: 1.2em;
+  --lineheight-m: 1.3em;
+  --lineheight-default: 1.45em;
+  --lineheight-l: 1.6em;
 
   /* Spacing */
 


### PR DESCRIPTION
# Short Description
- The Details component had undesired wrap behavior, see [this ticket](https://steuerlotse.atlassian.net/browse/STL-1292)

# Changes
- Adapt font size for mobile
- Fix wrap behavior
- Align arrow image on top left of the component, make it stick there, also when wrapped
- Make line-height dependent on `em` - it didn't work for me to have it without a unit although as I wanted to use it as a height - not only line-height
- I finally aligned the quote line!! 🎉 

# Feedback
- Do you think the line-height change breaks anything?
