### PR TITLE
Change last edited date for data privacy declaration

### DIFF
--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-09-13 13:16+0200\n"
+"POT-Creation-Date: 2021-09-17 17:13+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -2738,23 +2738,23 @@ msgstr ""
 msgid "form.lotse.summary-button-edit"
 msgstr "Ändern"
 
-#: app/templates/components.html:112 app/templates/components.html:120
+#: app/templates/components.html:114 app/templates/components.html:122
 msgid "form.optional"
 msgstr "optional"
 
-#: app/templates/components.html:137
+#: app/templates/components.html:139
 msgid "errors.warning-image.aria-label"
 msgstr "Fehlermeldung"
 
-#: app/templates/components.html:166
+#: app/templates/components.html:169
 msgid "plus.alt.text"
 msgstr "Plus-Zeichen"
 
-#: app/templates/components.html:169
+#: app/templates/components.html:172
 msgid "minus.alt.text"
 msgstr "Minus-Zeichen"
 
-#: app/templates/components.html:245
+#: app/templates/components.html:246
 msgid "button.help"
 msgstr "Weitere Informationen"
 
@@ -3804,7 +3804,7 @@ msgstr "Datenschutzerklärung"
 
 #: app/templates/content/data_privacy.html:6
 msgid "data_privacy.last_updated"
-msgstr "Zuletzt aktualisiert: 31.05.2021"
+msgstr "Zuletzt aktualisiert: 13.09.2021"
 
 #: app/templates/content/data_privacy.html:7
 msgid "data_privacy.intro"
@@ -4866,11 +4866,11 @@ msgstr ""
 "Als Nächstes können Sie sich registrieren. Dazu brauchen Sie Ihre Steuer-"
 "Identifikationsnummer und Ihr Geburtsdatum."
 
-#: app/templates/eligibility/display_success.html:31
+#: app/templates/eligibility/display_success.html:32
 msgid "form.eligibility.success-attention.heading"
 msgstr "Bitte beachten Sie"
 
-#: app/templates/eligibility/display_success.html:41
+#: app/templates/eligibility/display_success.html:42
 msgid "form.eligibility.use-register-button"
 msgstr "Registrieren"
 
@@ -5142,11 +5142,11 @@ msgstr ""
 "zuständigen Finanzamt beantragt. Die neue Steuernummer wird Ihnen dann "
 "mit dem Steuerbescheid mitgeteilt."
 
-#: app/templates/unlock_code/activation_failure.html:15
+#: app/templates/unlock_code/activation_failure.html:20
 msgid "form.unlock-code-activation.failure.reasons-title"
 msgstr "Mögliche Ursachen:"
 
-#: app/templates/unlock_code/activation_failure.html:17
+#: app/templates/unlock_code/activation_failure.html:22
 msgid "form.unlock-code-activation.failure.reasons-1"
 msgstr ""
 "Ihr Freischaltcode ist nicht korrekt. Eine Ursache kann die Verwechslung "
@@ -5154,7 +5154,7 @@ msgstr ""
 "schnell mit dem Buchstaben O oder der Buchstabe B schnell mit der Ziffer "
 "8 verwechselt werden. Prüfen Sie Ihre Angabe."
 
-#: app/templates/unlock_code/activation_failure.html:18
+#: app/templates/unlock_code/activation_failure.html:23
 msgid "form.unlock-code-activation.failure.reasons-2"
 msgstr ""
 "Haben Sie sich vor dem 03.07.2021 registriert? In diesem Fall können Sie "
@@ -5162,7 +5162,7 @@ msgstr ""
 "Registrieren Sie sich bitte erneut. Sie erhalten dann einen Brief mit "
 "einem neuen Freischaltcode."
 
-#: app/templates/unlock_code/activation_failure.html:19
+#: app/templates/unlock_code/activation_failure.html:24
 msgid "form.unlock-code-activation.failure.reasons-3"
 msgstr ""
 "Ihre Anmeldung ist bereits mehr als 5 Mal fehlgeschlagen. Dann ist Ihr "


### PR DESCRIPTION
# Short Description
- We didn't change the last-editied-date for the data privacy declaration when we changed the address

# Changes
- The address changes went live on Sep 13th, so I changed the date

# Feedback
- I just reconstructed the date from memory. I'm sure you already told me, but is there a way I can check which image was deployed in a particular production deploy in the Actions tab?
