### PR TITLE
Update data before handle

### DIFF
--- a/webapp/app/forms/flows/eligibility_step_chooser.py
+++ b/webapp/app/forms/flows/eligibility_step_chooser.py
@@ -83,7 +83,7 @@ class EligibilityStepChooser(StepChooser):
             endpoint=endpoint,
         )
 
-    def determine_prev_step(self, current_step_name):
+    def determine_prev_step(self, current_step_name, stored_data):
         """
             Loops through each step in the list up, starting from the current step.
             Asks each step if it is the previous step and returns the correct previous step.
@@ -92,7 +92,6 @@ class EligibilityStepChooser(StepChooser):
         current_step_idx = self.step_order.index(current_step_name)
         if current_step_idx == 0:  # Start step has no previous step
             return None
-        stored_data = get_session_data(self.session_data_identifier, default_data=self.default_data())
         for possible_previous_step_idx in range(current_step_idx - 1, 0, -1):
             possible_previous_step = self.steps[self.step_order[possible_previous_step_idx]]
             if possible_previous_step.is_previous_step(current_step_name, stored_data):

--- a/webapp/app/forms/flows/step_chooser.py
+++ b/webapp/app/forms/flows/step_chooser.py
@@ -40,7 +40,7 @@ class StepChooser:
         else:
             return None
 
-    def get_correct_step(self, step_name: str, update_data: bool) -> SteuerlotseStep:
+    def get_correct_step(self, step_name: str, update_data: bool = False) -> SteuerlotseStep:
         if self._get_possible_redirect(step_name):
             return RedirectSteuerlotseStep(self._get_possible_redirect(step_name), endpoint=self.endpoint)
         stored_data = get_session_data(self.session_data_identifier, default_data=self.default_data())

--- a/webapp/app/forms/flows/step_chooser.py
+++ b/webapp/app/forms/flows/step_chooser.py
@@ -1,6 +1,3 @@
-from typing import Optional
-
-from flask import request
 from werkzeug.exceptions import abort
 
 from app.config import Config
@@ -43,12 +40,12 @@ class StepChooser:
         else:
             return None
 
-    def get_correct_step(self, step_name) -> SteuerlotseStep:
+    def get_correct_step(self, step_name: str, update_data: bool) -> SteuerlotseStep:
         if self._get_possible_redirect(step_name):
             return RedirectSteuerlotseStep(self._get_possible_redirect(step_name), endpoint=self.endpoint)
         stored_data = get_session_data(self.session_data_identifier, default_data=self.default_data())
 
-        if request.method == 'POST':
+        if update_data:
             stored_data = self.steps[step_name].update_data(stored_data)
 
         # By default set `prev_step` and `next_step` in order of definition

--- a/webapp/app/forms/flows/step_chooser.py
+++ b/webapp/app/forms/flows/step_chooser.py
@@ -56,16 +56,16 @@ class StepChooser:
             endpoint=self.endpoint,
             stored_data=stored_data,
             overview_step=self.overview_step,
-            prev_step=self.determine_prev_step(step_name),
-            next_step=self.determine_next_step(step_name),
+            prev_step=self.determine_prev_step(step_name, stored_data),
+            next_step=self.determine_next_step(step_name, stored_data),
             session_data_identifier=self.session_data_identifier
         )
 
-    def determine_prev_step(self, current_step_name):
+    def determine_prev_step(self, current_step_name, stored_data):
         idx = self.step_order.index(current_step_name)
         return self.steps[self.step_order[idx - 1]] if idx > 0 else None
 
-    def determine_next_step(self, current_step_name):
+    def determine_next_step(self, current_step_name, stored_data):
         idx = self.step_order.index(current_step_name)
         return self.steps[self.step_order[idx + 1]] if idx < len(self.step_order) - 1 else None
 

--- a/webapp/app/forms/flows/step_chooser.py
+++ b/webapp/app/forms/flows/step_chooser.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from flask import request
 from werkzeug.exceptions import abort
 
 from app.config import Config
@@ -46,6 +47,9 @@ class StepChooser:
         if self._get_possible_redirect(step_name):
             return RedirectSteuerlotseStep(self._get_possible_redirect(step_name), endpoint=self.endpoint)
         stored_data = get_session_data(self.session_data_identifier, default_data=self.default_data())
+
+        if request.method == 'POST':
+            stored_data = self.steps[step_name].update_data(stored_data)
 
         # By default set `prev_step` and `next_step` in order of definition
         return self.steps[step_name](

--- a/webapp/app/forms/steps/steuerlotse_step.py
+++ b/webapp/app/forms/steps/steuerlotse_step.py
@@ -119,9 +119,10 @@ class FormSteuerlotseStep(SteuerlotseStep):
     
     @classmethod
     def update_data(cls, stored_data):
-        form = cls.create_form(request, prefilled_data=stored_data)
-        if request.method == 'POST' and form.validate():
-            stored_data.update(form.data)
+        if request.method == 'POST':
+            form = cls.create_form(request, prefilled_data=stored_data)
+            if form.validate():
+                stored_data.update(form.data)
         return stored_data
 
     def _pre_handle(self):

--- a/webapp/app/forms/steps/steuerlotse_step.py
+++ b/webapp/app/forms/steps/steuerlotse_step.py
@@ -107,6 +107,17 @@ class FormSteuerlotseStep(SteuerlotseStep):
         self.form = self.InputForm
 
     @classmethod
+    def create_form(cls, request, prefilled_data):
+        # If `form_data` is present it will always override `data` during
+        # value binding. For `BooleanFields` an empty/missing value in the `form_data`
+        # will lead to an unchecked box.
+        form_data = request.form
+        if len(form_data) == 0:
+            form_data = None
+
+        return cls.InputForm(form_data, **prefilled_data)
+    
+    @classmethod
     def update_data(cls, stored_data):
         form = cls.create_form(request, prefilled_data=stored_data)
         if request.method == 'POST' and form.validate():
@@ -129,17 +140,6 @@ class FormSteuerlotseStep(SteuerlotseStep):
             logger.info(f"Redirect to next Step {self.render_info.next_url}")
             return redirect(self.render_info.next_url)
         return self.render()
-
-    @classmethod
-    def create_form(cls, request, prefilled_data):
-        # If `form_data` is present it will always override `data` during
-        # value binding. For `BooleanFields` an empty/missing value in the `form_data`
-        # will lead to an unchecked box.
-        form_data = request.form
-        if len(form_data) == 0:
-            form_data = None
-
-        return cls.InputForm(form_data, **prefilled_data)
 
     def render(self, **kwargs):
         """

--- a/webapp/app/forms/steps/steuerlotse_step.py
+++ b/webapp/app/forms/steps/steuerlotse_step.py
@@ -106,12 +106,16 @@ class FormSteuerlotseStep(SteuerlotseStep):
         # TODO rename this to form_class once MultiStepFlow is obsolete
         self.form = self.InputForm
 
+    @classmethod
+    def update_data(cls, stored_data):
+        form = cls.create_form(request, prefilled_data=stored_data)
+        if request.method == 'POST' and form.validate():
+            stored_data.update(form.data)
+        return stored_data
+
     def _pre_handle(self):
         super()._pre_handle()
-        form = self.create_form(request, prefilled_data=self.stored_data)
-        if request.method == 'POST' and form.validate():
-            self.stored_data.update(form.data)
-        self.render_info.form = form
+        self.render_info.form = self.create_form(request, prefilled_data=self.stored_data)
 
     def _post_handle(self):
         override_session_data(self.stored_data, self.session_data_identifier)

--- a/webapp/app/routes.py
+++ b/webapp/app/routes.py
@@ -115,7 +115,9 @@ def register_request_handlers(app):
 
     @app.route('/eligibility/step/<step>', methods=['GET', 'POST'])
     def eligibility(step):
-        return EligibilityStepChooser(endpoint='eligibility').get_correct_step(step_name=step).handle()
+        return EligibilityStepChooser(endpoint='eligibility') \
+            .get_correct_step(step_name=step, update_data=request.method == 'POST') \
+            .handle()
 
     @app.route('/lotse/step/<step>', methods=['GET', 'POST'])
     @login_required
@@ -127,7 +129,9 @@ def register_request_handlers(app):
                     StepGemeinsamerHaushalt.name, StepReligion.name, StepSpenden.name,
                     StepSummary.name, StepConfirmation.name, StepFiling.name, StepAck.name]:
             return flow.handle(step_name=step)
-        return LotseStepChooser(endpoint='lotse').get_correct_step(step_name=step).handle()
+        return LotseStepChooser(endpoint='lotse') \
+            .get_correct_step(step_name=step, update_data=request.method == 'POST') \
+            .handle()
 
     @app.route('/unlock_code_request/step', methods=['GET', 'POST'])
     @app.route('/unlock_code_request/step/<step>', methods=['GET', 'POST'])

--- a/webapp/app/routes.py
+++ b/webapp/app/routes.py
@@ -115,8 +115,9 @@ def register_request_handlers(app):
 
     @app.route('/eligibility/step/<step>', methods=['GET', 'POST'])
     def eligibility(step):
+        update_data = request.method == 'POST'
         return EligibilityStepChooser(endpoint='eligibility') \
-            .get_correct_step(step_name=step, update_data=request.method == 'POST') \
+            .get_correct_step(step_name=step, update_data=update_data) \
             .handle()
 
     @app.route('/lotse/step/<step>', methods=['GET', 'POST'])
@@ -129,8 +130,9 @@ def register_request_handlers(app):
                     StepGemeinsamerHaushalt.name, StepReligion.name, StepSpenden.name,
                     StepSummary.name, StepConfirmation.name, StepFiling.name, StepAck.name]:
             return flow.handle(step_name=step)
+        update_data = request.method == 'POST'
         return LotseStepChooser(endpoint='lotse') \
-            .get_correct_step(step_name=step, update_data=request.method == 'POST') \
+            .get_correct_step(step_name=step, update_data=update_data) \
             .handle()
 
     @app.route('/unlock_code_request/step', methods=['GET', 'POST'])

--- a/webapp/tests/forms/flows/test_eligibility_step_chooser.py
+++ b/webapp/tests/forms/flows/test_eligibility_step_chooser.py
@@ -104,7 +104,7 @@ class TestEligibilityStepChooserDeterminePrevStep(unittest.TestCase):
         ])
 
         with patch('app.forms.flows.eligibility_step_chooser.get_session_data'):
-            self.step_chooser.determine_prev_step(given_step_name)
+            self.step_chooser.determine_prev_step(given_step_name, {})
 
         self.step_chooser.steps['step-0'].is_previous_step.assert_not_called()
         self.step_chooser.steps['step-1'].is_previous_step.assert_called()
@@ -122,7 +122,7 @@ class TestEligibilityStepChooserDeterminePrevStep(unittest.TestCase):
         ])
 
         with patch('app.forms.flows.eligibility_step_chooser.get_session_data'):
-            prev_step = self.step_chooser.determine_prev_step(given_step_name)
+            prev_step = self.step_chooser.determine_prev_step(given_step_name, {})
 
         self.assertEqual('step-2', prev_step.name)
 
@@ -135,7 +135,7 @@ class TestEligibilityStepChooserDeterminePrevStep(unittest.TestCase):
         ])
 
         with patch('app.forms.flows.eligibility_step_chooser.get_session_data'):
-            prev_step = self.step_chooser.determine_prev_step(given_step_name)
+            prev_step = self.step_chooser.determine_prev_step(given_step_name, {})
 
         self.assertIsNone(prev_step)
 
@@ -148,6 +148,6 @@ class TestEligibilityStepChooserDeterminePrevStep(unittest.TestCase):
         ])
 
         with patch('app.forms.flows.eligibility_step_chooser.get_session_data'):
-            prev_step = self.step_chooser.determine_prev_step(given_step_name)
+            prev_step = self.step_chooser.determine_prev_step(given_step_name, {})
 
         self.assertEqual('step-0', prev_step.name)

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -1,4 +1,6 @@
+import datetime
 import unittest
+from unittest.mock import patch
 
 import pytest
 from flask import Flask
@@ -10,7 +12,7 @@ from app.forms.session_data import serialize_session_data, deserialize_session_d
 from app.forms.flows.step_chooser import StepChooser
 from app.forms.steps.steuerlotse_step import RedirectSteuerlotseStep
 from tests.forms.mock_steuerlotse_steps import MockStartStep, MockMiddleStep, MockFinalStep, MockFormWithInputStep, \
-    MockRenderStep, MockFormStep
+    MockRenderStep, MockFormStep, MockYesNoStep
 from tests.utils import create_session_form_data
 
 
@@ -38,10 +40,10 @@ class TestStepChooserGetCorrectStep(unittest.TestCase):
         self.req = test_request_context
 
     def setUp(self) -> None:
-        testing_steps = [MockStartStep, MockRenderStep, MockFormStep, MockFinalStep]
+        testing_steps = [MockStartStep, MockRenderStep, MockFormWithInputStep, MockYesNoStep, MockFinalStep]
         self.endpoint_correct = "lotse"
         self.step_chooser = StepChooser(title="Testing StepChooser", steps=testing_steps,
-                                        endpoint=self.endpoint_correct, overview_step=MockFormStep)
+                                        endpoint=self.endpoint_correct, overview_step=MockFormWithInputStep)
 
     def test_if_correct_step_name_then_return_step_correctly_initialised(self):
         chosen_step = self.step_chooser.get_correct_step(MockRenderStep.name)
@@ -51,7 +53,7 @@ class TestStepChooserGetCorrectStep(unittest.TestCase):
         self.assertEqual(self.endpoint_correct, chosen_step.endpoint)
         self.assertEqual(self.step_chooser.overview_step, chosen_step.overview_step)
         self.assertEqual(MockStartStep, chosen_step._prev_step)
-        self.assertEqual(MockFormStep, chosen_step._next_step)
+        self.assertEqual(MockFormWithInputStep, chosen_step._next_step)
 
     def test_if_incorrect_step_name_then_raise_404_exception(self):
         self.assertRaises(NotFound, self.step_chooser.get_correct_step, "Incorrect Step Name")
@@ -85,6 +87,41 @@ class TestStepChooserGetCorrectStep(unittest.TestCase):
         chosen_step_at_end = self.step_chooser.get_correct_step(MockFinalStep.name)
         self.assertIsNone(chosen_step_at_begin._prev_step)
         self.assertIsNone(chosen_step_at_end._next_step)
+
+    def test_update_data_is_called_on_post_request(self):
+        self.req.request.method = 'POST'
+        with patch('app.forms.steps.steuerlotse_step.FormSteuerlotseStep.update_data') as update_mock:
+            self.step_chooser.get_correct_step(MockFormWithInputStep.name)
+
+        update_mock.assert_called_once()
+
+    def test_update_data_is_not_called_on_get_request(self):
+        self.req.request.method = 'GET'
+        with patch('app.forms.steps.steuerlotse_step.FormSteuerlotseStep.update_data') as update_mock:
+            self.step_chooser.get_correct_step(MockFormWithInputStep.name)
+
+        update_mock.assert_not_called()
+
+    def test_data_is_updated_on_post_request(self):
+        original_data = {'date': ['12', '12', '1980'], 'decimal': '42', 'pet': 'lizard'}
+        self.req.request.method = 'POST'
+        self.req.request.form = ImmutableMultiDict(original_data)
+        returned_step = self.step_chooser.get_correct_step(MockFormWithInputStep.name)
+
+        assert returned_step.stored_data == {'date': datetime.date(1980, 12, 12), 'decimal': 42.00, 'pet': 'lizard'}
+
+    def test_yes_no_field_content_overriden_if_empty(self):
+        original_data = {'yes_no_field': 'yes'}
+        self.req.request.method = 'POST'
+        self.req.request.form = ImmutableMultiDict(original_data)
+        returned_step = self.step_chooser.get_correct_step(MockYesNoStep.name)
+
+        assert returned_step.stored_data == {'yes_no_field': 'yes'}
+
+        self.req.request.form = ImmutableMultiDict({})
+        returned_step = self.step_chooser.get_correct_step(MockYesNoStep.name)
+
+        assert returned_step.stored_data == {'yes_no_field': None}
 
 
 class TestInteractionBetweenSteps(unittest.TestCase):

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -46,7 +46,7 @@ class TestStepChooserGetCorrectStep(unittest.TestCase):
                                         endpoint=self.endpoint_correct, overview_step=MockFormWithInputStep)
 
     def test_if_correct_step_name_then_return_step_correctly_initialised(self):
-        chosen_step = self.step_chooser.get_correct_step(MockRenderStep.name, False)
+        chosen_step = self.step_chooser.get_correct_step(MockRenderStep.name)
 
         self.assertIsInstance(chosen_step, MockRenderStep)
         self.assertEqual(MockRenderStep.name, chosen_step.name)
@@ -56,10 +56,10 @@ class TestStepChooserGetCorrectStep(unittest.TestCase):
         self.assertEqual(MockFormWithInputStep, chosen_step._next_step)
 
     def test_if_incorrect_step_name_then_raise_404_exception(self):
-        self.assertRaises(NotFound, self.step_chooser.get_correct_step, "Incorrect Step Name", False)
+        self.assertRaises(NotFound, self.step_chooser.get_correct_step, "Incorrect Step Name")
 
     def test_if_start_step_then_return_redirect_to_first_step(self):
-        chosen_step = self.step_chooser.get_correct_step("start", False)
+        chosen_step = self.step_chooser.get_correct_step("start")
 
         self.assertIsInstance(chosen_step, RedirectSteuerlotseStep)
         self.assertEqual(chosen_step.redirection_step_name, self.step_chooser.first_step.name)
@@ -69,22 +69,22 @@ class TestStepChooserGetCorrectStep(unittest.TestCase):
                                             steps=[MockStartStep, MockMiddleStep, MockFinalStep],
                                             endpoint=self.endpoint_correct)
 
-        chosen_step = simple_step_chooser.get_correct_step(MockStartStep.name, False)
+        chosen_step = simple_step_chooser.get_correct_step(MockStartStep.name)
         self.assertIsInstance(chosen_step, MockStartStep)
         self.assertEqual(MockMiddleStep, chosen_step._next_step)
 
-        chosen_step = simple_step_chooser.get_correct_step(MockMiddleStep.name, False)
+        chosen_step = simple_step_chooser.get_correct_step(MockMiddleStep.name)
         self.assertEqual(MockStartStep, chosen_step._prev_step)
         self.assertIsInstance(chosen_step, MockMiddleStep)
         self.assertEqual(MockFinalStep, chosen_step._next_step)
 
-        chosen_step = simple_step_chooser.get_correct_step(MockFinalStep.name, False)
+        chosen_step = simple_step_chooser.get_correct_step(MockFinalStep.name)
         self.assertEqual(MockMiddleStep, chosen_step._prev_step)
         self.assertIsInstance(chosen_step, MockFinalStep)
 
     def test_if_step_at_ends_then_return_empty_string(self):
-        chosen_step_at_begin = self.step_chooser.get_correct_step(MockStartStep.name, False)
-        chosen_step_at_end = self.step_chooser.get_correct_step(MockFinalStep.name, False)
+        chosen_step_at_begin = self.step_chooser.get_correct_step(MockStartStep.name)
+        chosen_step_at_end = self.step_chooser.get_correct_step(MockFinalStep.name)
         self.assertIsNone(chosen_step_at_begin._prev_step)
         self.assertIsNone(chosen_step_at_end._next_step)
 

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -46,7 +46,7 @@ class TestStepChooserGetCorrectStep(unittest.TestCase):
                                         endpoint=self.endpoint_correct, overview_step=MockFormWithInputStep)
 
     def test_if_correct_step_name_then_return_step_correctly_initialised(self):
-        chosen_step = self.step_chooser.get_correct_step(MockRenderStep.name)
+        chosen_step = self.step_chooser.get_correct_step(MockRenderStep.name, False)
 
         self.assertIsInstance(chosen_step, MockRenderStep)
         self.assertEqual(MockRenderStep.name, chosen_step.name)
@@ -56,10 +56,10 @@ class TestStepChooserGetCorrectStep(unittest.TestCase):
         self.assertEqual(MockFormWithInputStep, chosen_step._next_step)
 
     def test_if_incorrect_step_name_then_raise_404_exception(self):
-        self.assertRaises(NotFound, self.step_chooser.get_correct_step, "Incorrect Step Name")
+        self.assertRaises(NotFound, self.step_chooser.get_correct_step, "Incorrect Step Name", False)
 
     def test_if_start_step_then_return_redirect_to_first_step(self):
-        chosen_step = self.step_chooser.get_correct_step("start")
+        chosen_step = self.step_chooser.get_correct_step("start", False)
 
         self.assertIsInstance(chosen_step, RedirectSteuerlotseStep)
         self.assertEqual(chosen_step.redirection_step_name, self.step_chooser.first_step.name)
@@ -69,36 +69,34 @@ class TestStepChooserGetCorrectStep(unittest.TestCase):
                                             steps=[MockStartStep, MockMiddleStep, MockFinalStep],
                                             endpoint=self.endpoint_correct)
 
-        chosen_step = simple_step_chooser.get_correct_step(MockStartStep.name)
+        chosen_step = simple_step_chooser.get_correct_step(MockStartStep.name, False)
         self.assertIsInstance(chosen_step, MockStartStep)
         self.assertEqual(MockMiddleStep, chosen_step._next_step)
 
-        chosen_step = simple_step_chooser.get_correct_step(MockMiddleStep.name)
+        chosen_step = simple_step_chooser.get_correct_step(MockMiddleStep.name, False)
         self.assertEqual(MockStartStep, chosen_step._prev_step)
         self.assertIsInstance(chosen_step, MockMiddleStep)
         self.assertEqual(MockFinalStep, chosen_step._next_step)
 
-        chosen_step = simple_step_chooser.get_correct_step(MockFinalStep.name)
+        chosen_step = simple_step_chooser.get_correct_step(MockFinalStep.name, False)
         self.assertEqual(MockMiddleStep, chosen_step._prev_step)
         self.assertIsInstance(chosen_step, MockFinalStep)
 
     def test_if_step_at_ends_then_return_empty_string(self):
-        chosen_step_at_begin = self.step_chooser.get_correct_step(MockStartStep.name)
-        chosen_step_at_end = self.step_chooser.get_correct_step(MockFinalStep.name)
+        chosen_step_at_begin = self.step_chooser.get_correct_step(MockStartStep.name, False)
+        chosen_step_at_end = self.step_chooser.get_correct_step(MockFinalStep.name, False)
         self.assertIsNone(chosen_step_at_begin._prev_step)
         self.assertIsNone(chosen_step_at_end._next_step)
 
-    def test_update_data_is_called_on_post_request(self):
-        self.req.request.method = 'POST'
+    def test_update_data_is_called_if_update_data_set(self):
         with patch('app.forms.steps.steuerlotse_step.FormSteuerlotseStep.update_data') as update_mock:
-            self.step_chooser.get_correct_step(MockFormWithInputStep.name)
+            self.step_chooser.get_correct_step(MockFormWithInputStep.name, update_data=True)
 
         update_mock.assert_called_once()
 
-    def test_update_data_is_not_called_on_get_request(self):
-        self.req.request.method = 'GET'
+    def test_update_data_is_not_called_if_update_data_not_set(self):
         with patch('app.forms.steps.steuerlotse_step.FormSteuerlotseStep.update_data') as update_mock:
-            self.step_chooser.get_correct_step(MockFormWithInputStep.name)
+            self.step_chooser.get_correct_step(MockFormWithInputStep.name, update_data=False)
 
         update_mock.assert_not_called()
 
@@ -150,6 +148,6 @@ class TestInteractionBetweenSteps(unittest.TestCase):
             if session is not None:
                 req.session = session
 
-            step_chooser.get_correct_step(step_name).handle()
+            step_chooser.get_correct_step(step_name, method == 'POST').handle()
 
             return req.session

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -102,27 +102,6 @@ class TestStepChooserGetCorrectStep(unittest.TestCase):
 
         update_mock.assert_not_called()
 
-    def test_data_is_updated_on_post_request(self):
-        original_data = {'date': ['12', '12', '1980'], 'decimal': '42', 'pet': 'lizard'}
-        self.req.request.method = 'POST'
-        self.req.request.form = ImmutableMultiDict(original_data)
-        returned_step = self.step_chooser.get_correct_step(MockFormWithInputStep.name)
-
-        assert returned_step.stored_data == {'date': datetime.date(1980, 12, 12), 'decimal': 42.00, 'pet': 'lizard'}
-
-    def test_yes_no_field_content_overriden_if_empty(self):
-        original_data = {'yes_no_field': 'yes'}
-        self.req.request.method = 'POST'
-        self.req.request.form = ImmutableMultiDict(original_data)
-        returned_step = self.step_chooser.get_correct_step(MockYesNoStep.name)
-
-        assert returned_step.stored_data == {'yes_no_field': 'yes'}
-
-        self.req.request.form = ImmutableMultiDict({})
-        returned_step = self.step_chooser.get_correct_step(MockYesNoStep.name)
-
-        assert returned_step.stored_data == {'yes_no_field': None}
-
 
 class TestInteractionBetweenSteps(unittest.TestCase):
     @pytest.fixture(autouse=True)

--- a/webapp/tests/forms/steps/lotse/test_personal_data_steps.py
+++ b/webapp/tests/forms/steps/lotse/test_personal_data_steps.py
@@ -113,8 +113,7 @@ class TestStepSteuernummer:
                                                          num=expected_number_of_users)
         with app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_LOTSE_DATA_KEY: create_session_form_data(session_data)})
-            step = LotseStepChooser(endpoint='lotse').get_correct_step(
-                StepSteuernummer.name)
+            step = LotseStepChooser(endpoint='lotse').get_correct_step(StepSteuernummer.name, False)
             step._pre_handle()
 
         assert expected_steuernummer_exists_label == step.form.steuernummer_exists.kwargs['label']
@@ -133,8 +132,7 @@ class TestStepSteuernummer:
                                                          num=expected_number_of_users)
         with app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_LOTSE_DATA_KEY: create_session_form_data(session_data)})
-            step = LotseStepChooser(endpoint='lotse').get_correct_step(
-                StepSteuernummer.name)
+            step = LotseStepChooser(endpoint='lotse').get_correct_step(StepSteuernummer.name, False)
             step._pre_handle()
 
         assert expected_steuernummer_exists_label == step.form.steuernummer_exists.kwargs['label']

--- a/webapp/tests/forms/steps/lotse/test_personal_data_steps.py
+++ b/webapp/tests/forms/steps/lotse/test_personal_data_steps.py
@@ -113,7 +113,7 @@ class TestStepSteuernummer:
                                                          num=expected_number_of_users)
         with app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_LOTSE_DATA_KEY: create_session_form_data(session_data)})
-            step = LotseStepChooser(endpoint='lotse').get_correct_step(StepSteuernummer.name, False)
+            step = LotseStepChooser(endpoint='lotse').get_correct_step(StepSteuernummer.name)
             step._pre_handle()
 
         assert expected_steuernummer_exists_label == step.form.steuernummer_exists.kwargs['label']
@@ -132,7 +132,7 @@ class TestStepSteuernummer:
                                                          num=expected_number_of_users)
         with app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_LOTSE_DATA_KEY: create_session_form_data(session_data)})
-            step = LotseStepChooser(endpoint='lotse').get_correct_step(StepSteuernummer.name, False)
+            step = LotseStepChooser(endpoint='lotse').get_correct_step(StepSteuernummer.name)
             step._pre_handle()
 
         assert expected_steuernummer_exists_label == step.form.steuernummer_exists.kwargs['label']

--- a/webapp/tests/forms/steps/test_eligibility_steps.py
+++ b/webapp/tests/forms/steps/test_eligibility_steps.py
@@ -80,16 +80,16 @@ class TestEligibilityStepChooser(unittest.TestCase):
                              'kapitaleink': 'yes', 'other': 'no'}
 
     def test_if_correct_step_name_then_return_correct_step(self):
-        response_step = self.step_chooser.get_correct_step(MockRenderStep.name, False)
+        response_step = self.step_chooser.get_correct_step(MockRenderStep.name)
 
         self.assertIsInstance(response_step, MockRenderStep)
 
     def test_if_incorrect_step_name_then_raise_404_exception(self):
-        self.assertRaises(NotFound, self.step_chooser.get_correct_step, "Incorrect Step Name", False)
+        self.assertRaises(NotFound, self.step_chooser.get_correct_step, "Incorrect Step Name")
 
     def test_if_start_step_then_return_redirect_step(self):
         self.step_chooser.default_data = lambda: None
-        response_step = self.step_chooser.get_correct_step("start", False)
+        response_step = self.step_chooser.get_correct_step("start")
 
         self.assertIsInstance(response_step, RedirectSteuerlotseStep)
         self.assertEqual(response_step.redirection_step_name, MockStartStep.name)
@@ -407,7 +407,7 @@ class TestSeparatedEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(MaritalStatusInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -429,7 +429,7 @@ class TestSeparatedEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -441,7 +441,7 @@ class TestSeparatedEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -453,7 +453,7 @@ class TestSeparatedEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -496,7 +496,7 @@ class TestSeparatedLivedTogetherEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(SeparatedEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -518,7 +518,7 @@ class TestSeparatedLivedTogetherEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -529,7 +529,7 @@ class TestSeparatedLivedTogetherEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(self.correct_session_data,
@@ -542,7 +542,7 @@ class TestSeparatedLivedTogetherEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -586,7 +586,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -596,7 +596,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -606,7 +606,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(self.correct_session_data,
@@ -617,7 +617,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(self.correct_session_data,
@@ -631,7 +631,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, False)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -688,7 +688,7 @@ class TestMarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest.
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(SeparatedEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -711,7 +711,7 @@ class TestMarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest.
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -724,7 +724,7 @@ class TestMarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest.
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -737,7 +737,7 @@ class TestMarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest.
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -794,7 +794,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -806,7 +806,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -830,7 +830,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -844,7 +844,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -860,7 +860,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -876,7 +876,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.alimony_eligibility.kwargs['choices'])
@@ -891,7 +891,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.alimony_eligibility.kwargs['choices'])
@@ -935,7 +935,7 @@ class TestUserAElsterAccountEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name, False)
+                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -960,7 +960,7 @@ class TestUserAElsterAccountEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name, False)
+                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -975,7 +975,7 @@ class TestUserAElsterAccountEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name, False)
+                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -992,7 +992,7 @@ class TestUserAElsterAccountEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name, False)
+                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1051,7 +1051,7 @@ class TestUserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1077,7 +1077,7 @@ class TestUserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1093,7 +1093,7 @@ class TestUserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittest
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1111,7 +1111,7 @@ class TestUserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittest
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1166,7 +1166,7 @@ class TestDivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(MaritalStatusInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1188,7 +1188,7 @@ class TestDivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1200,7 +1200,7 @@ class TestDivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1212,7 +1212,7 @@ class TestDivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1268,7 +1268,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1278,7 +1278,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(MaritalStatusInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1288,7 +1288,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(MaritalStatusInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1300,7 +1300,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1313,7 +1313,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1336,7 +1336,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1349,7 +1349,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1365,7 +1365,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1422,7 +1422,7 @@ class TestSingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1446,7 +1446,7 @@ class TestSingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1460,7 +1460,7 @@ class TestSingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1477,7 +1477,7 @@ class TestSingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1535,7 +1535,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1550,7 +1550,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1565,7 +1565,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1592,7 +1592,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1609,7 +1609,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1628,7 +1628,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1647,7 +1647,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.pension_eligibility.kwargs['choices'])
@@ -1665,7 +1665,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.pension_eligibility.kwargs['choices'])
@@ -1710,7 +1710,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1720,7 +1720,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -1738,7 +1738,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1756,7 +1756,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1776,7 +1776,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1796,7 +1796,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.investment_income_eligibility.kwargs['choices'])
@@ -1815,7 +1815,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.investment_income_eligibility.kwargs['choices'])
@@ -1861,7 +1861,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1873,7 +1873,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -1892,7 +1892,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1911,7 +1911,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1932,7 +1932,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1953,7 +1953,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.minimal_investment_income_eligibility.kwargs['choices'])
@@ -1973,7 +1973,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.minimal_investment_income_eligibility.kwargs['choices'])
@@ -2022,7 +2022,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(TaxedInvestmentIncomeEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -2033,7 +2033,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -2043,7 +2043,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2063,7 +2063,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2083,7 +2083,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2105,7 +2105,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -2167,7 +2167,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -2177,7 +2177,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2198,7 +2198,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2219,7 +2219,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2242,7 +2242,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -2264,7 +2264,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.cheaper_check_eligibility.kwargs['choices'])
@@ -2285,7 +2285,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.cheaper_check_eligibility.kwargs['choices'])
@@ -2334,7 +2334,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -2344,7 +2344,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -2354,7 +2354,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -2364,7 +2364,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2386,7 +2386,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2408,7 +2408,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2432,7 +2432,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -2455,7 +2455,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.employment_income_eligibility.kwargs['choices'])
@@ -2477,7 +2477,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.employment_income_eligibility.kwargs['choices'])
@@ -2529,7 +2529,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2540,7 +2540,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(MarginalEmploymentIncomeEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -2551,7 +2551,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2574,7 +2574,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2597,7 +2597,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2622,7 +2622,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -2667,7 +2667,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2689,7 +2689,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2703,7 +2703,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2714,7 +2714,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2738,7 +2738,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2749,7 +2749,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(self.correct_session_data,
@@ -2775,7 +2775,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -2799,7 +2799,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.other_income_eligibility.kwargs['choices'])
@@ -2822,7 +2822,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.other_income_eligibility.kwargs['choices'])
@@ -2876,7 +2876,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(ForeignCountriesEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -2887,7 +2887,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
             expected_url = step.url_for_step(IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2899,7 +2899,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2924,7 +2924,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2935,7 +2935,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(self.correct_session_data,
@@ -2945,7 +2945,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
             self.assertEqual(FULL_SESSION_DATA,
@@ -2970,7 +2970,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.foreign_country_eligibility.kwargs['choices'])
@@ -2994,7 +2994,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.foreign_country_eligibility.kwargs['choices'])

--- a/webapp/tests/forms/steps/test_eligibility_steps.py
+++ b/webapp/tests/forms/steps/test_eligibility_steps.py
@@ -80,16 +80,16 @@ class TestEligibilityStepChooser(unittest.TestCase):
                              'kapitaleink': 'yes', 'other': 'no'}
 
     def test_if_correct_step_name_then_return_correct_step(self):
-        response_step = self.step_chooser.get_correct_step(MockRenderStep.name)
+        response_step = self.step_chooser.get_correct_step(MockRenderStep.name, False)
 
         self.assertIsInstance(response_step, MockRenderStep)
 
     def test_if_incorrect_step_name_then_raise_404_exception(self):
-        self.assertRaises(NotFound, self.step_chooser.get_correct_step, "Incorrect Step Name")
+        self.assertRaises(NotFound, self.step_chooser.get_correct_step, "Incorrect Step Name", False)
 
     def test_if_start_step_then_return_redirect_step(self):
         self.step_chooser.default_data = lambda: None
-        response_step = self.step_chooser.get_correct_step("start")
+        response_step = self.step_chooser.get_correct_step("start", False)
 
         self.assertIsInstance(response_step, RedirectSteuerlotseStep)
         self.assertEqual(response_step.redirection_step_name, MockStartStep.name)
@@ -236,8 +236,8 @@ class TestEligibilityStartDisplaySteuerlotseStep(unittest.TestCase):
         }
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession(session_data)
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                EligibilityStartDisplaySteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(EligibilityStartDisplaySteuerlotseStep.name,
+                                                                          False)
             step.handle()
 
             self.assertEqual({}, deserialize_session_data(req.session[_ELIGIBILITY_DATA_KEY]))
@@ -255,8 +255,8 @@ class TestEligibilityStartDisplaySteuerlotseStep(unittest.TestCase):
 
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession(session_data)
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                EligibilityStartDisplaySteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(EligibilityStartDisplaySteuerlotseStep.name,
+                                                                          False)
             step.handle()
 
             self.assertEqual(other_session_data, deserialize_session_data(req.session[other_session_key]))
@@ -266,8 +266,8 @@ class TestEligibilityStartDisplaySteuerlotseStep(unittest.TestCase):
         session_data = {}
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession(session_data)
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                EligibilityStartDisplaySteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(EligibilityStartDisplaySteuerlotseStep.name,
+                                                                          False)
             step.handle()
 
             self.assertEqual({}, deserialize_session_data(req.session[_ELIGIBILITY_DATA_KEY]))
@@ -280,8 +280,8 @@ class TestEligibilityStartDisplaySteuerlotseStep(unittest.TestCase):
         }
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession(session_data)
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                EligibilityStartDisplaySteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(EligibilityStartDisplaySteuerlotseStep.name,
+                                                                          False)
             step.handle()
 
             self.assertEqual(other_session_data, deserialize_session_data(req.session[other_session_key]))
@@ -294,8 +294,8 @@ class TestMaritalStatusInputFormSteuerlotseStep(unittest.TestCase):
 
     def test_if_post_and_married_then_set_next_step_correct(self):
         with self.app.test_request_context(method='POST', data={'marital_status_eligibility': 'married'}):
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                MaritalStatusInputFormSteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(MaritalStatusInputFormSteuerlotseStep.name,
+                                                                          True)
             expected_url = step.url_for_step(SeparatedEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -303,8 +303,8 @@ class TestMaritalStatusInputFormSteuerlotseStep(unittest.TestCase):
 
     def test_if_post_and_widowed_then_set_next_step_correct(self):
         with self.app.test_request_context(method='POST', data={'marital_status_eligibility': 'widowed'}):
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                MaritalStatusInputFormSteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(MaritalStatusInputFormSteuerlotseStep.name,
+                                                                          True)
             expected_url = step.url_for_step(SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -312,8 +312,8 @@ class TestMaritalStatusInputFormSteuerlotseStep(unittest.TestCase):
 
     def test_if_post_and_single_then_set_next_step_correct(self):
         with self.app.test_request_context(method='POST', data={'marital_status_eligibility': 'single'}):
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                MaritalStatusInputFormSteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(MaritalStatusInputFormSteuerlotseStep.name,
+                                                                          True)
             expected_url = step.url_for_step(SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -321,8 +321,8 @@ class TestMaritalStatusInputFormSteuerlotseStep(unittest.TestCase):
 
     def test_if_post_and_divorced_then_set_next_step_correct(self):
         with self.app.test_request_context(method='POST', data={'marital_status_eligibility': 'divorced'}):
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                MaritalStatusInputFormSteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(MaritalStatusInputFormSteuerlotseStep.name,
+                                                                          True)
             expected_url = step.url_for_step(DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -330,8 +330,8 @@ class TestMaritalStatusInputFormSteuerlotseStep(unittest.TestCase):
 
     def test_set_prev_input_step_correctly(self):
         with self.app.test_request_context(method='GET') as req:
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                MaritalStatusInputFormSteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(MaritalStatusInputFormSteuerlotseStep.name,
+                                                                          False)
             expected_url = step.url_for_step(EligibilityStartDisplaySteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -342,8 +342,8 @@ class TestMaritalStatusInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                MaritalStatusInputFormSteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(MaritalStatusInputFormSteuerlotseStep.name,
+                                                                          False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -353,8 +353,8 @@ class TestMaritalStatusInputFormSteuerlotseStep(unittest.TestCase):
         session_data = {'marital_status_eligibility': 'single', }
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                MaritalStatusInputFormSteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(MaritalStatusInputFormSteuerlotseStep.name,
+                                                                          False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -364,8 +364,8 @@ class TestMaritalStatusInputFormSteuerlotseStep(unittest.TestCase):
         only_necessary_data = {'marital_status_eligibility': 'single', }
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
-            step = EligibilityStepChooser('eligibility').get_correct_step(
-                MaritalStatusInputFormSteuerlotseStep.name)
+            step = EligibilityStepChooser('eligibility').get_correct_step(MaritalStatusInputFormSteuerlotseStep.name,
+                                                                          False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -385,7 +385,7 @@ class TestSeparatedEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedEligibilityInputFormSteuerlotseStep.name)
+                SeparatedEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -396,7 +396,7 @@ class TestSeparatedEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedEligibilityInputFormSteuerlotseStep.name)
+                SeparatedEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -407,7 +407,7 @@ class TestSeparatedEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedEligibilityInputFormSteuerlotseStep.name)
+                SeparatedEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(MaritalStatusInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -417,7 +417,7 @@ class TestSeparatedEligibilityInputFormSteuerlotseStep(unittest.TestCase):
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedEligibilityInputFormSteuerlotseStep.name)
+                SeparatedEligibilityInputFormSteuerlotseStep.name, True)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -429,7 +429,7 @@ class TestSeparatedEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedEligibilityInputFormSteuerlotseStep.name)
+                SeparatedEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -441,7 +441,7 @@ class TestSeparatedEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedEligibilityInputFormSteuerlotseStep.name)
+                SeparatedEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -453,7 +453,7 @@ class TestSeparatedEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedEligibilityInputFormSteuerlotseStep.name)
+                SeparatedEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -474,7 +474,7 @@ class TestSeparatedLivedTogetherEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
+                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -485,7 +485,7 @@ class TestSeparatedLivedTogetherEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
+                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -496,7 +496,7 @@ class TestSeparatedLivedTogetherEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
+                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(SeparatedEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -506,7 +506,7 @@ class TestSeparatedLivedTogetherEligibilityInputFormSteuerlotseStep(unittest.Tes
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
+                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name, True)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -518,7 +518,7 @@ class TestSeparatedLivedTogetherEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
+                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -529,7 +529,7 @@ class TestSeparatedLivedTogetherEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
+                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(self.correct_session_data,
@@ -542,7 +542,7 @@ class TestSeparatedLivedTogetherEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
+                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -564,7 +564,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -575,7 +575,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -586,7 +586,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -596,7 +596,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, False)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -606,7 +606,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(self.correct_session_data,
@@ -617,7 +617,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(self.correct_session_data,
@@ -631,7 +631,7 @@ class TestSeparatedJointTaxesEligibilityInputFormSteuerlotseStep(unittest.TestCa
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
+                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -666,7 +666,7 @@ class TestMarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest.
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -677,7 +677,7 @@ class TestMarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest.
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(MarriedJointTaxesEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -688,7 +688,7 @@ class TestMarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest.
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(SeparatedEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -698,7 +698,7 @@ class TestMarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest.
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, True)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -711,7 +711,7 @@ class TestMarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest.
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -724,7 +724,7 @@ class TestMarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest.
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -737,7 +737,7 @@ class TestMarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest.
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -772,7 +772,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -783,7 +783,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(MarriedAlimonyEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -794,7 +794,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -806,7 +806,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -816,7 +816,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, True)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -830,7 +830,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -844,7 +844,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -860,7 +860,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -876,7 +876,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.alimony_eligibility.kwargs['choices'])
@@ -891,7 +891,7 @@ class TestMarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Tes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.alimony_eligibility.kwargs['choices'])
@@ -913,7 +913,7 @@ class TestUserAElsterAccountEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
+                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -924,7 +924,7 @@ class TestUserAElsterAccountEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
+                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -935,7 +935,7 @@ class TestUserAElsterAccountEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
+                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -945,7 +945,7 @@ class TestUserAElsterAccountEligibilityInputFormSteuerlotseStep(unittest.TestCas
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
+                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name, True)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -960,7 +960,7 @@ class TestUserAElsterAccountEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
+                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -975,7 +975,7 @@ class TestUserAElsterAccountEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
+                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -992,7 +992,7 @@ class TestUserAElsterAccountEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
+                UserAElsterAccountEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1029,7 +1029,7 @@ class TestUserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -1040,7 +1040,7 @@ class TestUserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(UserBElsterAccountEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -1051,7 +1051,7 @@ class TestUserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1061,7 +1061,7 @@ class TestUserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittest
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, True)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -1077,7 +1077,7 @@ class TestUserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1093,7 +1093,7 @@ class TestUserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittest
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1111,7 +1111,7 @@ class TestUserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittest
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1144,7 +1144,7 @@ class TestDivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -1155,7 +1155,7 @@ class TestDivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(DivorcedJointTaxesEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -1166,7 +1166,7 @@ class TestDivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(MaritalStatusInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1176,7 +1176,7 @@ class TestDivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, True)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -1188,7 +1188,7 @@ class TestDivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1200,7 +1200,7 @@ class TestDivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1212,7 +1212,7 @@ class TestDivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep(unittest
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
+                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1246,7 +1246,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -1257,7 +1257,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(SingleAlimonyEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -1268,7 +1268,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1278,7 +1278,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(MaritalStatusInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1288,7 +1288,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(MaritalStatusInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1300,7 +1300,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1313,7 +1313,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(SeparatedJointTaxesEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1323,7 +1323,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, True)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -1336,7 +1336,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1349,7 +1349,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1365,7 +1365,7 @@ class TestSingleAlimonyDecisionEligibilityInputFormSteuerlotseStep(unittest.Test
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1400,7 +1400,7 @@ class TestSingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -1411,7 +1411,7 @@ class TestSingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(SingleElsterAccountEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -1422,7 +1422,7 @@ class TestSingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1432,7 +1432,7 @@ class TestSingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittes
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, True)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -1446,7 +1446,7 @@ class TestSingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittes
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1460,7 +1460,7 @@ class TestSingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1477,7 +1477,7 @@ class TestSingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep(unittes
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
+                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1513,7 +1513,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -1524,7 +1524,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(PensionEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -1535,7 +1535,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1550,7 +1550,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(UserAElsterAccountEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1565,7 +1565,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1575,7 +1575,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name, True)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -1592,7 +1592,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1609,7 +1609,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1628,7 +1628,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1647,7 +1647,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.pension_eligibility.kwargs['choices'])
@@ -1665,7 +1665,7 @@ class TestPensionDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCase):
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                PensionDecisionEligibilityInputFormSteuerlotseStep.name)
+                PensionDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.pension_eligibility.kwargs['choices'])
@@ -1688,7 +1688,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -1699,7 +1699,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -1710,7 +1710,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(PensionDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1720,7 +1720,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -1738,7 +1738,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1756,7 +1756,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1776,7 +1776,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1796,7 +1796,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.investment_income_eligibility.kwargs['choices'])
@@ -1815,7 +1815,7 @@ class TestInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.investment_income_eligibility.kwargs['choices'])
@@ -1839,7 +1839,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -1850,7 +1850,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -1861,7 +1861,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -1873,7 +1873,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -1892,7 +1892,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1911,7 +1911,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -1932,7 +1932,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -1953,7 +1953,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.minimal_investment_income_eligibility.kwargs['choices'])
@@ -1973,7 +1973,7 @@ class TestMinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(uni
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.minimal_investment_income_eligibility.kwargs['choices'])
@@ -2011,7 +2011,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2022,7 +2022,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(TaxedInvestmentIncomeEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -2033,7 +2033,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -2043,7 +2043,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2063,7 +2063,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2083,7 +2083,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2105,7 +2105,7 @@ class TestTaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep(unitt
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -2145,7 +2145,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2156,7 +2156,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(CheaperCheckEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -2167,7 +2167,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -2177,7 +2177,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2198,7 +2198,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2219,7 +2219,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2242,7 +2242,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -2264,7 +2264,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.cheaper_check_eligibility.kwargs['choices'])
@@ -2285,7 +2285,7 @@ class TestCheaperCheckDecisionEligibilityInputFormSteuerlotseStep(unittest.TestC
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
+                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.cheaper_check_eligibility.kwargs['choices'])
@@ -2312,7 +2312,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2323,7 +2323,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2334,7 +2334,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(CheaperCheckDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -2344,7 +2344,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -2354,7 +2354,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
         self.assertEqual(expected_url, step.render_info.prev_url)
@@ -2364,7 +2364,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2386,7 +2386,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2408,7 +2408,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2432,7 +2432,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -2455,7 +2455,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.employment_income_eligibility.kwargs['choices'])
@@ -2477,7 +2477,7 @@ class TestEmploymentDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCas
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
+                EmploymentDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.employment_income_eligibility.kwargs['choices'])
@@ -2518,7 +2518,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2529,7 +2529,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2540,7 +2540,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(MarginalEmploymentIncomeEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -2551,7 +2551,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2574,7 +2574,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2597,7 +2597,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2622,7 +2622,7 @@ class TestMarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep(un
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
+                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -2667,7 +2667,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2678,7 +2678,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(IncomeOtherEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -2689,7 +2689,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(EmploymentDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2703,7 +2703,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(alternative_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2714,7 +2714,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2738,7 +2738,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2749,7 +2749,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(self.correct_session_data,
@@ -2775,7 +2775,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(only_necessary_data,
@@ -2799,7 +2799,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.other_income_eligibility.kwargs['choices'])
@@ -2822,7 +2822,7 @@ class TestIncomeOtherDecisionEligibilityInputFormSteuerlotseStep(unittest.TestCa
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
+                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.other_income_eligibility.kwargs['choices'])
@@ -2865,7 +2865,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, True)
             expected_url = step.url_for_step(EligibilitySuccessDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -2876,7 +2876,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(ForeignCountriesEligibilityFailureDisplaySteuerlotseStep.name)
             step.handle()
 
@@ -2887,7 +2887,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             expected_url = step.url_for_step(IncomeOtherDecisionEligibilityInputFormSteuerlotseStep.name)
             step.handle()
 
@@ -2899,7 +2899,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
                 patch('app.model.recursive_data.RecursiveDataModel.one_previous_field_has_to_be_set',
                       MagicMock(side_effect=PreviousFieldsMissingError)):
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
 
             self.assertRaises(IncorrectEligibilityData, step.handle)
 
@@ -2924,7 +2924,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data_with_incorrect_key)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(session_data,
@@ -2935,7 +2935,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
             req.session = SecureCookieSession(
                 {_ELIGIBILITY_DATA_KEY: create_session_form_data(self.correct_session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(self.correct_session_data,
@@ -2945,7 +2945,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(FULL_SESSION_DATA)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step.handle()
 
             self.assertEqual(FULL_SESSION_DATA,
@@ -2970,7 +2970,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.foreign_country_eligibility.kwargs['choices'])
@@ -2994,7 +2994,7 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep(unittest.T
         with self.app.test_request_context(method='GET') as req:
             req.session = SecureCookieSession({_ELIGIBILITY_DATA_KEY: create_session_form_data(session_data)})
             step = EligibilityStepChooser('eligibility').get_correct_step(
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
+                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name, False)
             step._pre_handle()
 
         self.assertEqual(expected_choices, step.form.foreign_country_eligibility.kwargs['choices'])

--- a/webapp/tests/forms/steps/test_steuerlotse_step.py
+++ b/webapp/tests/forms/steps/test_steuerlotse_step.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import unittest
 from unittest.mock import patch, MagicMock, call
@@ -462,6 +463,83 @@ class TestFormSteuerlotseStepCreateForm(unittest.TestCase):
 
         assert type(created_form) == form_step.InputForm
         assert dir(created_form) == dir(form_step.InputForm()) # check that it has the correct input fields
+
+
+class TestFormSteuerlotseStepUpdateData:
+    @pytest.fixture(autouse=True)
+    def attach_fixtures(self, test_request_context):
+        self.req = test_request_context
+
+    def test_if_post_and_form_valid_then_updates_empty_data_correctly(self):
+        req_form_data = {'date': ['12', '12', '1980'], 'decimal': '42', 'pet': 'lizard'}
+        self.req.request.method = 'POST'
+        self.req.request.form = ImmutableMultiDict(req_form_data)
+
+        updated_data = MockFormWithInputStep.update_data({})
+
+        assert updated_data == {'date': datetime.date(1980, 12, 12), 'decimal': 42.00, 'pet': 'lizard'}
+
+    def test_if_post_and_form_valid_then_updates_existing_data_correctly(self):
+        req_form_data = {'date': ['12', '12', '1980'], 'decimal': '42', 'pet': 'lizard'}
+        self.req.request.method = 'POST'
+        self.req.request.form = ImmutableMultiDict(req_form_data)
+
+        updated_data = MockFormWithInputStep.update_data({'date': datetime.date(1980, 1, 1)})
+
+        assert updated_data == {'date': datetime.date(1980, 12, 12), 'decimal': 42.00, 'pet': 'lizard'}
+
+    def test_if_post_and_form_valid_then_leaves_other_data_unchanged(self):
+        req_form_data = {'date': ['12', '12', '1980'], 'decimal': '42', 'pet': 'lizard'}
+        self.req.request.method = 'POST'
+        self.req.request.form = ImmutableMultiDict(req_form_data)
+
+        updated_data = MockFormWithInputStep.update_data({'other': 'This is none of your concern.'})
+
+        assert updated_data == {'other': 'This is none of your concern.', 'date': datetime.date(1980, 12, 12),
+                                'decimal': 42.00, 'pet': 'lizard'}
+
+    def test_if_post_and_form_valid_but_incomplete_and_key_in_stored_data_then_keep_old_data(self):
+        req_form_data = {'date': ['12', '12', '1980'], 'decimal': '42'}
+        self.req.request.method = 'POST'
+        self.req.request.form = ImmutableMultiDict(req_form_data)
+
+        updated_data = MockFormWithInputStep.update_data({'pet': 'lizard'})
+
+        assert updated_data == {'date': datetime.date(1980, 12, 12), 'decimal': 42.00, 'pet': 'lizard'}
+
+    def test_if_post_and_form_valid_and_yes_no_field_empty_then_yes_no_field_content_overridden(self):
+        req_form_data = {}
+        self.req.request.method = 'POST'
+        self.req.request.form = ImmutableMultiDict(req_form_data)
+
+        updated_data = MockYesNoStep.update_data({'yes_no_field': 'yes'})
+
+        assert updated_data == {'yes_no_field': None}
+
+    def test_if_post_and_form_valid_but_incomplete_and_key_not_in_stored_data_then_add_empty_default(self):
+        req_form_data = {'date': ['12', '12', '1980']}
+        self.req.request.method = 'POST'
+        self.req.request.form = ImmutableMultiDict(req_form_data)
+
+        updated_data = MockFormWithInputStep.update_data({})
+
+        assert updated_data == {'date': datetime.date(1980, 12, 12), 'decimal': None, 'pet': ''}
+
+    def test_if_post_and_form_invalid_then_do_not_update_data(self):
+        req_form_data = {'data': 'invalid'}
+        self.req.request.method = 'POST'
+        self.req.request.form = ImmutableMultiDict(req_form_data)
+
+        with patch('tests.forms.mock_steuerlotse_steps.MockFormWithInputStep.create_form',
+                   MagicMock(return_value=MagicMock(name='InputForm', validate=MagicMock(return_value=False)))):
+            updated_data = MockFormWithInputStep.update_data({'data': 'original'})
+
+        assert updated_data == {'data': 'original'}
+
+    def test_if_get_then_do_not_update_data(self):
+        self.req.request.method = 'GET'
+        updated_data = MockFormWithInputStep.update_data({'data': 'original'})
+        assert updated_data == {'data': 'original'}
 
 
 class TestFormSteuerlotseStepDeleteDependentData(unittest.TestCase):

--- a/webapp/tests/forms/steps/test_steuerlotse_step.py
+++ b/webapp/tests/forms/steps/test_steuerlotse_step.py
@@ -447,23 +447,6 @@ class TestSteuerlotseFormStepHandle(unittest.TestCase):
 
                 update_fun.assert_called_once_with(expected_data, form_step.session_data_identifier)
 
-    def test_yes_no_field_content_overriden_if_empty(self):
-        with self.app.test_request_context(method='POST') as req:
-            req.request.form = ImmutableMultiDict({'yes_no_field': 'yes'})
-            mock_yesno_step = MockYesNoStep(endpoint="lotse", stored_data={}, next_step=MockRenderStep)
-            mock_yesno_step.handle()
-            data_after_first_handle = mock_yesno_step.stored_data
-        self.assertEqual({'yes_no_field': 'yes'}, data_after_first_handle)
-
-        with self.app.test_request_context(method='POST') as req:
-            req.request.form = ImmutableMultiDict({})
-            mock_yesno_step = MockYesNoStep(endpoint="lotse", stored_data=data_after_first_handle,
-                                            next_step=MockRenderStep)
-            mock_yesno_step.handle()
-            data_after_second_handle = mock_yesno_step.stored_data
-
-        self.assertEqual({'yes_no_field': None}, data_after_second_handle)
-
 
 class TestFormSteuerlotseStepCreateForm(unittest.TestCase):
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
# Short Description
- This is a follow-up to #196
- This is the second step towards the new logic refactoring of the steuerlotse steps.
We want to determine the correct next step in the step_chooser on the basis of the current data.
- In order to have the complete data for that, we need to update the data of the posting step before determining the next step (currently, we are doing that afterwards). So in the step_chooser.

# Changes
- Add update_data in the steuerlotse_step
- Pass stored_data into every call of determine_next_step and determine_prev_step
- Move and add tests for data updating

# Feedback
- Does anything not make sense to you?
- Do you see any missing tests?