### PR TITLE
Details qa adjustments

### DIFF
--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -203,7 +203,7 @@
                     <div class="row details-row">
                             <button class="btn details-icon control-show-more" type="button" tabindex="-1" aria-hidden="true"></button>
                             <button class="btn details-icon control-show-less" type="button" tabindex="-1" aria-hidden="true"></button>
-                            <button class="btn" type="button">
+                            <button class="btn details-header-text-button" type="button">
                                 <span class="mb-0">{{title}}</span>
                             </button>
                     </div>

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -211,7 +211,7 @@
             </div>
             <div id="details-body-{{ details_id }}" class="collapse" aria-labelledby="heading-{{ details_id }}"
                 data-parent="#details-{{ details_id }}">
-                <div class="card-body container pt-0">
+                <div class="card-body pt-0">
                     <div class="details-row row">
                             <div class="block-quote-line"></div>
                         <div class="details-content">

--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -256,8 +256,8 @@
 }
 
 .details-card .card-header .details-icon {
-    width: 14px;
-    min-width: 14px;
+    width: 12px;
+    min-width: 12px;
     height: var(--lineheight-default);
     padding: 0;
     margin-top: .375rem;
@@ -296,7 +296,7 @@
 .details-card .card-body .block-quote-line {
     width: 2px;
     min-width: 2px;
-    margin: 0 var(--spacing-03) 0 5px;
+    margin: 0 var(--spacing-03) 0 4px;
     background-color: var(--border-color);
 }
 
@@ -327,6 +327,10 @@
     margin: 0;
     overflow: hidden;
     position: absolute;
+}
+
+.details-header-text-button {
+    padding: var(--spacing-01);
 }
 
 /* PANEL */

--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -260,7 +260,7 @@
     min-width: 12px;
     height: var(--lineheight-default);
     padding: 0;
-    margin-top: .375rem;
+    margin-top: 0;
     background:  url("/icons/details_arrow_down.svg") no-repeat left;
 }
 
@@ -342,7 +342,12 @@
 }
 
 .details-header-text-button {
-    padding: var(--spacing-01);
+    padding: 0 var(--spacing-01);
+}
+
+.details-header-text-button span {
+    display: inline-block;
+    height: var(--lineheight-default);
 }
 
 /* PANEL */

--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -280,8 +280,20 @@
     border: 0;
 }
 
-.details-card .details-content{
-    padding: 1em 1em 0 0;
+.details-card .details-content {
+    padding: var(--spacing-02) 1em var(--spacing-02) 0;
+}
+
+.details-card .details-content p:last-child {
+    margin-bottom: 0;
+}
+
+.details-card .details-content ul:last-child {
+    margin-bottom: 0;
+}
+
+.details-card .details-content ul li:last-child {
+    margin-bottom: 0 !important;
 }
 
 .card-body-less-padding {

--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -264,15 +264,15 @@
     background:  url("/icons/details_arrow_down.svg") no-repeat left;
 }
 
-.details-card .card-header .collapsed:hover .details-icon{
+.details-card .card-header .collapsed:hover .control-show-more {
     background:  url("/icons/details_arrow_right_hover.svg") no-repeat left;
 }
 
-.details-card .card-header .collapsed button:focus .details-icon{
+.details-card .card-header .collapsed button:focus .control-show-more {
     background:  url("/icons/details_arrow_right_focus.svg") no-repeat left;
 }
 
-.details-card .card-header .collapsed .details-icon{
+.details-card .card-header .collapsed .control-show-more {
     background:  url("/icons/details_arrow_right.svg") no-repeat left;
 }
 
@@ -317,24 +317,24 @@
     outline: none;
 }
 
-.details-card .card-header:not(.collapsed) .control-show-more {
+.details-card .card-header>div:not(.collapsed) .control-show-more {
     /* We need to still show it to keep focus on the element */
     height: 1px;
     width: 1px;
     min-width: 1px;
-    background-color: inherit;
+    background: inherit;
     padding: 0;
     margin: 0;
     overflow: hidden;
     position: absolute;
 }
 
-.details-card .card-header.collapsed .control-show-less {
+.details-card .card-header>div.collapsed .control-show-less {
     /* We need to still show it to keep focus on the element */
     height: 1px;
     width: 1px;
     min-width: 1px;
-    background-color: inherit;
+    background: inherit;
     padding: 0;
     margin: 0;
     overflow: hidden;

--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -260,7 +260,6 @@
     min-width: 12px;
     height: var(--lineheight-default);
     padding: 0;
-    margin-top: 0;
     background:  url("/icons/details_arrow_down.svg") no-repeat left;
 }
 
@@ -284,15 +283,7 @@
     padding: var(--spacing-02) 1em var(--spacing-02) 0;
 }
 
-.details-card .details-content p:last-child {
-    margin-bottom: 0;
-}
-
-.details-card .details-content ul:last-child {
-    margin-bottom: 0;
-}
-
-.details-card .details-content ul li:last-child {
+.details-card .details-content :last-child {
     margin-bottom: 0 !important;
 }
 


### PR DESCRIPTION
# Short Description
- There were three additional QA adjustments that I didn't address before:
- Reduced space between the arrow and the text of the details card header
- Reduced space above and below the text in the details body
- The arrow wasn't centered on the text exactly

# Changes
- Fix the above points
- Hide the one-pixel alternative arrow

# Feedback
- Do you see any problems with the explicitly set height of the arrow to lineheight-default?
