### PR TITLE
React components for registration page

### DIFF
--- a/webapp/client/src/components/FormFieldConsentBox.js
+++ b/webapp/client/src/components/FormFieldConsentBox.js
@@ -2,7 +2,6 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import FormFieldScaffolding from "./FormFieldScaffolding";
 
-
 const ConsentBox = styled.div`
   &.checkbox {
     padding: 0;
@@ -22,16 +21,16 @@ const ConsentBox = styled.div`
   }
 
   &.checkbox input:focus + label {
-      box-shadow: 0 0 0 3px var(--focus-color);
-      background-color: var(--focus-color);
+    box-shadow: 0 0 0 3px var(--focus-color);
+    background-color: var(--focus-color);
   }
 
   &.checkbox input:checked + label {
-      background-color: var(--link-color);
-      background-image: url("../images/checked.svg");
-      background-repeat: no-repeat;
-      background-size: 22px;
-      background-position: center;
+    background-color: var(--link-color);
+    background-image: url("../images/checked.svg");
+    background-repeat: no-repeat;
+    background-size: 22px;
+    background-position: center;
   }
 
   & label.checkmark {
@@ -52,7 +51,7 @@ function FormFieldConsentBox({
   required,
   autofocus,
   labelText,
-  errors
+  errors,
 }) {
   return (
     <FormFieldScaffolding
@@ -64,11 +63,20 @@ function FormFieldConsentBox({
       hideLabel
       render={() => (
         <ConsentBox className="form-row checkbox consent-box col-lg-10">
-          <input type="checkbox" id={fieldId} defaultValue={value} required={required} autoFocus={autofocus}/>
+          <input
+            type="checkbox"
+            id={fieldId}
+            defaultValue={value}
+            required={required}
+            autoFocus={autofocus}
+          />
           {/* TODO: there should be only one label for an input */}
           {/* eslint-disable-next-line */}
           <label htmlFor={fieldId} className="checkmark" />
-          <label htmlFor={fieldId} className="col-sm-10 col-form-label ml-3 pt-0">
+          <label
+            htmlFor={fieldId}
+            className="col-sm-10 col-form-label ml-3 pt-0"
+          >
             {labelText}
           </label>
         </ConsentBox>
@@ -80,7 +88,8 @@ function FormFieldConsentBox({
 FormFieldConsentBox.propTypes = {
   fieldName: PropTypes.string.isRequired,
   fieldId: PropTypes.string.isRequired,
-  labelText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  labelText: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+    .isRequired,
   value: PropTypes.string,
   errors: PropTypes.arrayOf(PropTypes.string).isRequired,
   required: PropTypes.bool,
@@ -88,7 +97,7 @@ FormFieldConsentBox.propTypes = {
 };
 
 FormFieldConsentBox.defaultProps = {
-  value: 'y',  // the default of WTForms BooleanField
+  value: "y", // the default of WTForms BooleanField
   required: false,
   autofocus: false,
 };

--- a/webapp/client/src/components/FormFieldConsentBox.js
+++ b/webapp/client/src/components/FormFieldConsentBox.js
@@ -1,0 +1,95 @@
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import FormFieldScaffolding from "./FormFieldScaffolding";
+
+
+const ConsentBox = styled.div`
+  &.checkbox {
+    padding: 0;
+    margin-top: var(--spacing-02);
+    flex-wrap: inherit;
+  }
+
+  &.consent-box {
+    background-color: var(--bg-highlight-color);
+    padding: var(--spacing-04);
+  }
+
+  &.checkbox input {
+    width: 30px;
+    height: 30px;
+    opacity: 0;
+  }
+
+  &.checkbox input:focus + label {
+      box-shadow: 0 0 0 3px var(--focus-color);
+      background-color: var(--focus-color);
+  }
+
+  &.checkbox input:checked + label {
+      background-color: var(--link-color);
+      background-image: url("../images/checked.svg");
+      background-repeat: no-repeat;
+      background-size: 22px;
+      background-position: center;
+  }
+
+  & label.checkmark {
+    display: block;
+    width: 30px;
+    height: 30px;
+    cursor: pointer;
+    background: white;
+    position: absolute;
+    border: 2px solid var(--text-color);
+  }
+`;
+
+function FormFieldConsentBox({
+  fieldName,
+  fieldId,
+  value,
+  required,
+  autofocus,
+  labelText,
+  errors
+}) {
+  return (
+    <FormFieldScaffolding
+      {...{
+        fieldName,
+        errors,
+        cols: "12",
+      }}
+      hideLabel
+      render={() => (
+        <ConsentBox className="form-row checkbox consent-box col-lg-10">
+          <input type="checkbox" id={fieldId} defaultValue={value} required={required} autoFocus={autofocus}/>
+          {/* TODO: there should be only one label for an input */}
+          {/* eslint-disable-next-line */}
+          <label htmlFor={fieldId} className="checkmark" />
+          <label htmlFor={fieldId} className="col-sm-10 col-form-label ml-3 pt-0">
+            {labelText}
+          </label>
+        </ConsentBox>
+      )}
+    />
+  );
+}
+
+FormFieldConsentBox.propTypes = {
+  fieldName: PropTypes.string.isRequired,
+  fieldId: PropTypes.string.isRequired,
+  labelText: PropTypes.string.isRequired,
+  value: PropTypes.arrayOf(PropTypes.string).isRequired,
+  errors: PropTypes.arrayOf(PropTypes.string).isRequired,
+  required: PropTypes.bool,
+  autofocus: PropTypes.bool,
+};
+
+FormFieldConsentBox.defaultProps = {
+  required: false,
+  autofocus: false,
+};
+
+export default FormFieldConsentBox;

--- a/webapp/client/src/components/FormFieldConsentBox.js
+++ b/webapp/client/src/components/FormFieldConsentBox.js
@@ -81,13 +81,14 @@ FormFieldConsentBox.propTypes = {
   fieldName: PropTypes.string.isRequired,
   fieldId: PropTypes.string.isRequired,
   labelText: PropTypes.oneOf(["element", "string"]).isRequired,
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
   errors: PropTypes.arrayOf(PropTypes.string).isRequired,
   required: PropTypes.bool,
   autofocus: PropTypes.bool,
 };
 
 FormFieldConsentBox.defaultProps = {
+  value: 'y',  // the default of WTForms BooleanField
   required: false,
   autofocus: false,
 };

--- a/webapp/client/src/components/FormFieldConsentBox.js
+++ b/webapp/client/src/components/FormFieldConsentBox.js
@@ -80,7 +80,7 @@ function FormFieldConsentBox({
 FormFieldConsentBox.propTypes = {
   fieldName: PropTypes.string.isRequired,
   fieldId: PropTypes.string.isRequired,
-  labelText: PropTypes.oneOf(["element", "string"]).isRequired,
+  labelText: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   value: PropTypes.string,
   errors: PropTypes.arrayOf(PropTypes.string).isRequired,
   required: PropTypes.bool,

--- a/webapp/client/src/components/FormFieldConsentBox.js
+++ b/webapp/client/src/components/FormFieldConsentBox.js
@@ -80,8 +80,8 @@ function FormFieldConsentBox({
 FormFieldConsentBox.propTypes = {
   fieldName: PropTypes.string.isRequired,
   fieldId: PropTypes.string.isRequired,
-  labelText: PropTypes.string.isRequired,
-  value: PropTypes.arrayOf(PropTypes.string).isRequired,
+  labelText: PropTypes.oneOf(["element", "string"]).isRequired,
+  value: PropTypes.string.isRequired,
   errors: PropTypes.arrayOf(PropTypes.string).isRequired,
   required: PropTypes.bool,
   autofocus: PropTypes.bool,

--- a/webapp/client/src/components/FormFieldDate.js
+++ b/webapp/client/src/components/FormFieldDate.js
@@ -24,9 +24,9 @@ function FormFieldDate({
 
   const labelWithDefaultExample = {
     // Use default example input if none is given
-    exampleInput: t('fields.dateField.exampleInput.text'),
+    exampleInput: t("fields.dateField.exampleInput.text"),
     ...label,
-  }
+  };
 
   const labelComponent = (
     <FieldLabelForSeparatedFields
@@ -64,7 +64,11 @@ function FormFieldDate({
           }}
           autofocus={autofocus || Boolean(errors.length)}
           inputFieldLengths={[2, 2, 4]}
-          inputFieldLabels={[t('dateField.day'), t('dateField.month'), t('dateField.year')]}
+          inputFieldLabels={[
+            t("dateField.day"),
+            t("dateField.month"),
+            t("dateField.year"),
+          ]}
         />
       )}
     />

--- a/webapp/client/src/components/FormFieldDate.js
+++ b/webapp/client/src/components/FormFieldDate.js
@@ -1,0 +1,92 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { useTranslation } from "react-i18next";
+import FormFieldScaffolding from "./FormFieldScaffolding";
+import FieldLabelForSeparatedFields from "./FieldLabelForSeparatedFields";
+import FormFieldSeparatedField from "./FormFieldSeparatedField";
+import {
+  baselineBugFix,
+  numericInputMask,
+  numericInputMode,
+} from "../lib/fieldUtils";
+
+function FormFieldDate({
+  fieldName,
+  fieldId,
+  values,
+  required,
+  autofocus,
+  label,
+  details,
+  errors,
+}) {
+  const { t } = useTranslation();
+
+  const labelWithDefaultExample = {
+    // Use default example input if none is given
+    exampleInput: t('fields.dateField.exampleInput.text'),
+    ...label,
+  }
+
+  const labelComponent = (
+    <FieldLabelForSeparatedFields
+      {...{ label: labelWithDefaultExample, fieldId, details }}
+    />
+  );
+
+  const extraFieldProps = {
+    ...numericInputMode,
+    ...numericInputMask,
+    ...baselineBugFix,
+  };
+
+  return (
+    <FormFieldScaffolding
+      {...{
+        fieldName,
+        errors,
+        labelComponent,
+      }}
+      hideLabel
+      hideErrors
+      render={() => (
+        // Separated fields ignore field class names
+        <FormFieldSeparatedField
+          {...{
+            fieldName,
+            labelComponent,
+            errors,
+            details,
+            extraFieldProps,
+            fieldId,
+            values,
+            required,
+          }}
+          autofocus={autofocus || Boolean(errors.length)}
+          inputFieldLengths={[2, 2, 4]}
+          inputFieldLabels={[t('dateField.day'), t('dateField.month'), t('dateField.year')]}
+        />
+      )}
+    />
+  );
+}
+
+FormFieldDate.propTypes = {
+  fieldId: PropTypes.string.isRequired,
+  fieldName: PropTypes.string.isRequired,
+  errors: PropTypes.arrayOf(PropTypes.string).isRequired,
+  autofocus: PropTypes.bool,
+  required: PropTypes.bool,
+  values: PropTypes.arrayOf(PropTypes.string).isRequired,
+  label: FieldLabelForSeparatedFields.propTypes.label,
+  details: FieldLabelForSeparatedFields.propTypes.details,
+};
+
+FormFieldDate.defaultProps = {
+  autofocus: FormFieldSeparatedField.defaultProps.autofocus,
+  required: FormFieldSeparatedField.defaultProps.required,
+  label: FieldLabelForSeparatedFields.defaultProps.label,
+  details: FieldLabelForSeparatedFields.defaultProps.details,
+};
+
+export default FormFieldDate;

--- a/webapp/client/src/components/FormFieldScaffolding.js
+++ b/webapp/client/src/components/FormFieldScaffolding.js
@@ -15,7 +15,6 @@ const FormField = styled.div`
 `;
 
 // TODO: implement concrete fields with this:
-// - ConfirmationField: cols="12" hideLabel=True
 // - BooleanField, YesNoField: hideLabel=True
 // - RadioField, SteuerlotseDateField: hideLabel=True hideErrors=True
 export default function FormFieldScaffolding({
@@ -58,16 +57,12 @@ export default function FormFieldScaffolding({
       <div className={classNames({ "d-block": displayBlock })}>
         {render(fieldClassNames)}
         {/* TODO: this goes into the concrete fields
-          {% if field.type == 'ConfirmationField' %}
-              {{ components.consent_box(field, classes=classes, position_details_after=position_details_after, first_field=first_field) }}
-          {% elif field.type == 'BooleanField' %}
+          {% if field.type == 'BooleanField' %}
               {{ components.checkbox(field, classes=classes, position_details_after=position_details_after, first_field=first_field) }}
           {% elif field.type == 'RadioField' %}
               {{ components.radio_field(field, position_details_after=position_details_after, first_field=first_field) }}
           {% elif field.type == 'YesNoField' %}
               {{ components.yes_no_field(field, position_details_after=position_details_after, first_field=first_field) }}
-          {% elif field.type == 'SteuerlotseDateField' %}
-              {{ components.separated_field(field, position_details_after=position_details_after, first_field=first_field) }}
           {% else %}
               {% if first_field or field.errors %}
                   {{ field(class=classes, autofocus=True) }}
@@ -92,7 +87,7 @@ export default function FormFieldScaffolding({
 FormFieldScaffolding.propTypes = {
   render: PropTypes.func.isRequired,
   fieldName: PropTypes.string.isRequired,
-  labelComponent: PropTypes.element.isRequired,
+  labelComponent: PropTypes.element,
   errors: PropTypes.arrayOf(PropTypes.string),
   cols: PropTypes.string,
   extraClassNames: PropTypes.string, // field.render_kw['class']
@@ -104,6 +99,7 @@ FormFieldScaffolding.propTypes = {
 };
 
 FormFieldScaffolding.defaultProps = {
+  labelComponent: undefined,
   errors: [],
   cols: "6",
   extraClassNames: "",

--- a/webapp/client/src/components/FormFieldSeparatedField.js
+++ b/webapp/client/src/components/FormFieldSeparatedField.js
@@ -115,7 +115,10 @@ function FormFieldSeparatedField({
             <React.Fragment key={index}>
               {inputFieldLabels.length > index ? (
                 <div>
-                  <SeparatedFieldLabel htmlFor={subFieldId} className="sub-field-label">
+                  <SeparatedFieldLabel
+                    htmlFor={subFieldId}
+                    className="sub-field-label"
+                  >
                     {inputFieldLabels[index]}
                   </SeparatedFieldLabel>
                   {inputElement}

--- a/webapp/client/src/components/FormFieldSeparatedField.js
+++ b/webapp/client/src/components/FormFieldSeparatedField.js
@@ -16,6 +16,14 @@ const SeparatedField = styled(FormRowCentered)`
   }
 `;
 
+const SeparatedFieldLabel = styled.label`
+  &.sub-field-label {
+    margin-bottom: 0 !important;
+    font-size: var(--text-sm);
+    font-weight: var(--font-bold);
+  }
+`;
+
 function FormFieldSeparatedField({
   fieldName,
   fieldId,
@@ -107,9 +115,9 @@ function FormFieldSeparatedField({
             <React.Fragment key={index}>
               {inputFieldLabels.length > index ? (
                 <div>
-                  <label htmlFor={subFieldId} className="sub-field-label">
+                  <SeparatedFieldLabel htmlFor={subFieldId} className="sub-field-label">
                     {inputFieldLabels[index]}
-                  </label>
+                  </SeparatedFieldLabel>
                   {inputElement}
                 </div>
               ) : (

--- a/webapp/client/src/components/FormFieldSeparatedField.test.js
+++ b/webapp/client/src/components/FormFieldSeparatedField.test.js
@@ -12,6 +12,7 @@ describe("FormFieldSeparatedField", () => {
       fieldId: "foo",
       values: ["bar", "baz"],
       inputFieldLengths: [3, 4],
+      inputFieldLabels: ["label1", "label2"],
       errors: [],
       labelComponent: <></>,
       subFieldSeparator: "SPLITTO",
@@ -40,6 +41,12 @@ describe("FormFieldSeparatedField", () => {
   it("should show field separators", () => {
     render(<FormFieldSeparatedField {...props} />);
     expect(screen.getByText("SPLITTO")).toBeInTheDocument();
+  });
+
+  it("should show sub field labels", () => {
+    render(<FormFieldSeparatedField {...props} />);
+    expect(screen.getByText("label1")).toBeInTheDocument();
+    expect(screen.getByText("label2")).toBeInTheDocument();
   });
 
   describe("when pasting content", () => {

--- a/webapp/client/src/components/FormFieldSeparatedField.test.js
+++ b/webapp/client/src/components/FormFieldSeparatedField.test.js
@@ -40,7 +40,7 @@ describe("FormFieldSeparatedField", () => {
     props.subFieldSeparator = "SPLITTO";
 
     render(<FormFieldSeparatedField {...props} />);
-    
+
     expect(screen.getByText("SPLITTO")).toBeInTheDocument();
   });
 
@@ -48,7 +48,7 @@ describe("FormFieldSeparatedField", () => {
     props.inputFieldLabels = ["label1", "label2"];
 
     render(<FormFieldSeparatedField {...props} />);
-    
+
     expect(screen.getByText("label1")).toBeInTheDocument();
     expect(screen.getByText("label2")).toBeInTheDocument();
   });

--- a/webapp/client/src/components/FormFieldSeparatedField.test.js
+++ b/webapp/client/src/components/FormFieldSeparatedField.test.js
@@ -12,10 +12,8 @@ describe("FormFieldSeparatedField", () => {
       fieldId: "foo",
       values: ["bar", "baz"],
       inputFieldLengths: [3, 4],
-      inputFieldLabels: ["label1", "label2"],
       errors: [],
       labelComponent: <></>,
-      subFieldSeparator: "SPLITTO",
     };
   });
 
@@ -39,12 +37,18 @@ describe("FormFieldSeparatedField", () => {
   });
 
   it("should show field separators", () => {
+    props.subFieldSeparator = "SPLITTO";
+
     render(<FormFieldSeparatedField {...props} />);
+    
     expect(screen.getByText("SPLITTO")).toBeInTheDocument();
   });
 
-  it("should show sub field labels", () => {
+  it("should show sub field labels if provided", () => {
+    props.inputFieldLabels = ["label1", "label2"];
+
     render(<FormFieldSeparatedField {...props} />);
+    
     expect(screen.getByText("label1")).toBeInTheDocument();
     expect(screen.getByText("label2")).toBeInTheDocument();
   });

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -42,22 +42,26 @@ const translations = {
       title: "Datenschutzerklärung und Nutzungsbedingungen",
     },
     fieldRegistrationConfirmDataPrivacy: {
-      labelText: "Ich habe die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> inklusive der <taxGdprLink>Allgemeinen Informationen zur Umsetzung der datenschutzrechtlichen Vorgaben der Artikel 12 bis 14 der Datenschutz-Grundverordnung in der Steuerverwaltung</taxGdprLink> zur Kenntnis genommen und akzeptiere diese.",
+      labelText:
+        "Ich habe die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> inklusive der <taxGdprLink>Allgemeinen Informationen zur Umsetzung der datenschutzrechtlichen Vorgaben der Artikel 12 bis 14 der Datenschutz-Grundverordnung in der Steuerverwaltung</taxGdprLink> zur Kenntnis genommen und akzeptiere diese.",
     },
     fieldRegistrationConfirmTermsOfService: {
-      labelText: "Ich habe die <termsOfServiceLink>Nutzungsbedingungen</termsOfServiceLink> gelesen und stimme ihnen zu.",
+      labelText:
+        "Ich habe die <termsOfServiceLink>Nutzungsbedingungen</termsOfServiceLink> gelesen und stimme ihnen zu.",
     },
     fieldRegistrationConfirmIncomes: {
-      labelText: "Ich habe unter <eligibilityLink>Nutzung prüfen</eligibilityLink> den Fragebogen ausgewertet und erfülle alle Voraussetzungen für die Nutzung des Steuerlotsen.",
+      labelText:
+        "Ich habe unter <eligibilityLink>Nutzung prüfen</eligibilityLink> den Fragebogen ausgewertet und erfülle alle Voraussetzungen für die Nutzung des Steuerlotsen.",
     },
     fieldRegistrationConfirmEData: {
-      labelText: "Ich bzw. wir sind damit einverstanden, dass die Festsetzung meiner / unserer Einkommensteuer anhand der elektronisch vorliegenden Daten erfolgt, die der Finanzbehörde vorliegen.",
+      labelText:
+        "Ich bzw. wir sind damit einverstanden, dass die Festsetzung meiner / unserer Einkommensteuer anhand der elektronisch vorliegenden Daten erfolgt, die der Finanzbehörde vorliegen.",
     },
     eData: {
       helpTitle: "Was bedeutet das?",
-      helpText: "Daten zu beispielsweise <bold>Renten, Pensionen oder Kranken- und Pflegeversicherungen</bold> erhält die Steuerverwaltung vom jeweiligen Träger elektronisch. Diese Daten werden vom Finanzamt automatisch übernommen und müssen von Ihnen nicht in diese Steuererklärung eingetragen werden. Welche Beträge über Sie übermittelt wurden, können Sie den Bescheiden entnehmen, die Sie von der jeweiligen Stelle per Post erhalten haben. Die Daten kommen aus der gleichen Quelle. Sollten Sie mit der Übernahme nicht einverstanden sein, können Sie die vereinfachte Steuererklärung leider nicht nutzen."
-    }
-    
+      helpText:
+        "Daten zu beispielsweise <bold>Renten, Pensionen oder Kranken- und Pflegeversicherungen</bold> erhält die Steuerverwaltung vom jeweiligen Träger elektronisch. Diese Daten werden vom Finanzamt automatisch übernommen und müssen von Ihnen nicht in diese Steuererklärung eingetragen werden. Welche Beträge über Sie übermittelt wurden, können Sie den Bescheiden entnehmen, die Sie von der jeweiligen Stelle per Post erhalten haben. Die Daten kommen aus der gleichen Quelle. Sollten Sie mit der Übernahme nicht einverstanden sein, können Sie die vereinfachte Steuererklärung leider nicht nutzen.",
+    },
   },
   dateField: {
     day: "Tag",
@@ -67,10 +71,10 @@ const translations = {
   fields: {
     dateField: {
       exampleInput: {
-        text: 'z.B. 29.2.1951'
-      }
-    }
-  }
+        text: "z.B. 29.2.1951",
+      },
+    },
+  },
 };
 
 export default translations;

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -38,6 +38,26 @@ const translations = {
     dob: {
       labelText: "Geburtsdatum",
     },
+    dataPrivacyAndAgb: {
+      title: "Datenschutzerklärung und Nutzungsbedingungen",
+    },
+    fieldRegistrationConfirmDataPrivacy: {
+      labelText: "Ich habe die <privacyPolicyLink>Datenschutzerklärung</privacyPolicyLink> inklusive der <taxGdprLink>Allgemeinen Informationen zur Umsetzung der datenschutzrechtlichen Vorgaben der Artikel 12 bis 14 der Datenschutz-Grundverordnung in der Steuerverwaltung</taxGdprLink> zur Kenntnis genommen und akzeptiere diese.",
+    },
+    fieldRegistrationConfirmTermsOfService: {
+      labelText: "Ich habe die <termsOfServiceLink>Nutzungsbedingungen</termsOfServiceLink> gelesen und stimme ihnen zu.",
+    },
+    fieldRegistrationConfirmIncomes: {
+      labelText: "Ich habe unter <eligibilityLink>Nutzung prüfen</eligibilityLink> den Fragebogen ausgewertet und erfülle alle Voraussetzungen für die Nutzung des Steuerlotsen.",
+    },
+    fieldRegistrationConfirmEData: {
+      labelText: "Ich bzw. wir sind damit einverstanden, dass die Festsetzung meiner / unserer Einkommensteuer anhand der elektronisch vorliegenden Daten erfolgt, die der Finanzbehörde vorliegen.",
+    },
+    eData: {
+      helpTitle: "Was bedeutet das?",
+      helpText: "Daten zu beispielsweise <bold>Renten, Pensionen oder Kranken- und Pflegeversicherungen</bold> erhält die Steuerverwaltung vom jeweiligen Träger elektronisch. Diese Daten werden vom Finanzamt automatisch übernommen und müssen von Ihnen nicht in diese Steuererklärung eingetragen werden. Welche Beträge über Sie übermittelt wurden, können Sie den Bescheiden entnehmen, die Sie von der jeweiligen Stelle per Post erhalten haben. Die Daten kommen aus der gleichen Quelle. Sollten Sie mit der Übernahme nicht einverstanden sein, können Sie die vereinfachte Steuererklärung leider nicht nutzen."
+    }
+    
   },
   dateField: {
     day: "Tag",

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -34,6 +34,18 @@ const translations = {
       },
     },
   },
+  dateField: {
+    day: "Tag",
+    month: "Monat",
+    year: "Jahr",
+  },
+  fields: {
+    dateField: {
+      exampleInput: {
+        text: 'z.B. 29.2.1951'
+      }
+    }
+  }
 };
 
 export default translations;

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -34,6 +34,11 @@ const translations = {
       },
     },
   },
+  unlockCodeRequest: {
+    dob: {
+      labelText: "Geburtsdatum",
+    },
+  },
   dateField: {
     day: "Tag",
     month: "Monat",

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -42,7 +42,7 @@ const translations = {
       title: "Datenschutzerklärung und Nutzungsbedingungen",
     },
     fieldRegistrationConfirmDataPrivacy: {
-      labelText: "Ich habe die <privacyPolicyLink>Datenschutzerklärung</privacyPolicyLink> inklusive der <taxGdprLink>Allgemeinen Informationen zur Umsetzung der datenschutzrechtlichen Vorgaben der Artikel 12 bis 14 der Datenschutz-Grundverordnung in der Steuerverwaltung</taxGdprLink> zur Kenntnis genommen und akzeptiere diese.",
+      labelText: "Ich habe die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> inklusive der <taxGdprLink>Allgemeinen Informationen zur Umsetzung der datenschutzrechtlichen Vorgaben der Artikel 12 bis 14 der Datenschutz-Grundverordnung in der Steuerverwaltung</taxGdprLink> zur Kenntnis genommen und akzeptiere diese.",
     },
     fieldRegistrationConfirmTermsOfService: {
       labelText: "Ich habe die <termsOfServiceLink>Nutzungsbedingungen</termsOfServiceLink> gelesen und stimme ihnen zu.",

--- a/webapp/client/src/pages/RegistrationPage.js
+++ b/webapp/client/src/pages/RegistrationPage.js
@@ -1,0 +1,179 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+import styled from "styled-components";
+import Details from "../components/Details";
+import FormFieldConsentBox from "../components/FormFieldConsentBox";
+import FormFieldDate from "../components/FormFieldDate";
+import FormFieldIdNr from "../components/FormFieldIdNr";
+import FormHeader from "../components/FormHeader";
+import FormRowCentered from "../components/FormRowCentered";
+import StepForm from "../components/StepForm";
+import StepHeaderButtons from "../components/StepHeaderButtons";
+
+const SubHeading = styled.h2`
+&.form-sub-heading-smaller {
+  font-size: var(--text-medium);
+  margin-top: var(--spacing-09);
+  margin-bottom: var(--spacing-03);
+}
+`;
+
+export default function RegistrationPage({ backLink, stepHeader, form, fields }) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <StepHeaderButtons {...backLink} />
+      <FormHeader {...stepHeader} />
+      <StepForm {...form}>
+      <FormRowCentered>
+          <FormFieldDate
+            autofocus
+            required
+            fieldName="dob"
+            fieldId="dob"
+            values={fields.dob.value}
+            label={{
+              text: t("unlockCodeRequest.dob.labelText"),
+            }}
+            errors={fields.dob.errors}
+          />
+        </FormRowCentered>
+        <FormRowCentered>
+          <FormFieldIdNr
+            required
+            fieldName="idnr"
+            fieldId="idnr"
+            values={fields.idnr.value}
+            label={{
+              text: t("unlockCodeActivation.idnr.labelText"),
+            }}
+            details={{
+              title: t("unlockCodeActivation.idnr.help.title"),
+              text: t("unlockCodeActivation.idnr.help.text"),
+            }}
+            errors={fields.idnr.errors}
+          />
+        </FormRowCentered> 
+        <SubHeading className="form-sub-heading-smaller">{ t("unlockCodeRequest.dataPrivacyAndAgb.title") }</SubHeading>
+        <FormFieldConsentBox
+          required
+          fieldName="registration_confirm_data_privacy"
+          fieldId="registration_confirm_data_privacy"
+          value={fields.registrationConfirmDataPrivacy.value}
+          labelText={
+            <Trans 
+              t={t}
+              i18nKey="unlockCodeRequest.fieldRegistrationConfirmDataPrivacy.labelText"
+              components={{
+                // The anchors get content in the translation file
+                // eslint-disable-next-line jsx-a11y/anchor-has-content
+                privacyPolicyLink: <a href="/TODO"/>,
+                // eslint-disable-next-line jsx-a11y/anchor-has-content
+                taxGdprLink: <a href="https://www.bundesfinanzministerium.de/Content/DE/Downloads/BMF_Schreiben/Weitere_Steuerthemen/Abgabenordnung/2020-07-01-Korrektur-Allgemeine-Informationen-Datenschutz-Grundverordnung-Steuerverwaltung-anlage-1.pdf?__blob=publicationFile&v=3" rel="noreferrer" target="_blank" />,
+              }}
+            />
+          }
+          errors={fields.registrationConfirmDataPrivacy.errors}
+        />
+        <FormFieldConsentBox
+          required
+          fieldName="registration_confirm_terms_of_service"
+          fieldId="registration_confirm_terms_of_service"
+          value={fields.registrationConfirmTermsOfService.value}
+          labelText={
+            <Trans 
+              t={t}
+              i18nKey="unlockCodeRequest.fieldRegistrationConfirmTermsOfService.labelText"
+              components={{
+                // The anchors get content in the translation file
+                // eslint-disable-next-line jsx-a11y/anchor-has-content
+                termsOfServiceLink: <a href="/TODO"/>,
+              }}
+            />
+          }
+          errors={fields.registrationConfirmTermsOfService.errors}
+        />
+        <FormFieldConsentBox
+          required
+          fieldName="registration_confirm_incomes"
+          fieldId="registration_confirm_incomes"
+          value={fields.registrationConfirmIncomes.value}
+          labelText={
+            <Trans 
+              t={t}
+              i18nKey="unlockCodeRequest.fieldRegistrationConfirmIncomes.labelText"
+              components={{
+                // The anchors get content in the translation file
+                // eslint-disable-next-line jsx-a11y/anchor-has-content
+                eligibilityLink: <a href="/TODO"/>,
+              }}
+            />
+          }
+          errors={fields.registrationConfirmIncomes.errors}
+        />
+        <SubHeading className="form-sub-heading-smaller">{ t("unlockCodeRequest.dataPrivacyAndAgb.title") }</SubHeading>
+        <Details title={t("unlockCodeRequest.eData.helpTitle")} detailsId='registration_confirm_e_data'>
+          {{
+            paragraphs: [
+              <Trans 
+              t={t}
+              i18nKey="unlockCodeRequest.eData.helpText"
+              components={{bold: <strong />}}
+            />
+            ]
+          }}
+        </Details>
+        <FormFieldConsentBox
+          required
+          fieldName="registration_confirm_e_data"
+          fieldId="registration_confirm_e_data"
+          value={fields.registrationConfirmEData.value}
+          labelText={t("unlockCodeRequest.fieldRegistrationConfirmEData.labelText")}
+          errors={fields.registrationConfirmEData.errors}
+        />
+      </StepForm>
+    </>
+  );
+}
+
+const fieldPropType = PropTypes.exact({
+  value: PropTypes.any,
+  errors: PropTypes.arrayOf(PropTypes.string),
+});
+
+RegistrationPage.propTypes = {
+  backLink: PropTypes.exact(StepHeaderButtons.propTypes),
+  stepHeader: PropTypes.exact({
+    // TODO: define these here, not in Python
+    // render_info.step_title
+    title: PropTypes.string,
+    // render_info.step_intro
+    intro: PropTypes.string,
+  }).isRequired,
+  form: PropTypes.exact({
+    // render_info.submit_url
+    action: PropTypes.string, // TODO: does this change? if not, define here, not in Python
+    // csrf_token()
+    csrfToken: PropTypes.string,
+    // !!render_info.overview_url
+    showOverviewButton: PropTypes.bool,
+    // explanatory_button_text
+    explanatoryButtonText: PropTypes.string, // TODO: define here, not in Python
+    // render_info.additional_info.next_button_label
+    nextButtonLabel: PropTypes.string, // TODO: define here, not in Python
+  }).isRequired,
+  fields: PropTypes.exact({
+    idnr: fieldPropType,
+    dob: fieldPropType,
+    registrationConfirmDataPrivacy: fieldPropType,
+    registrationConfirmTermsOfService: fieldPropType,
+    registrationConfirmIncomes: fieldPropType,
+    registrationConfirmEData: fieldPropType,
+  }).isRequired,
+};
+
+RegistrationPage.defaultProps = {
+  backLink: undefined,
+};

--- a/webapp/client/src/pages/RegistrationPage.js
+++ b/webapp/client/src/pages/RegistrationPage.js
@@ -19,7 +19,7 @@ const SubHeading = styled.h2`
 }
 `;
 
-export default function RegistrationPage({ backLink, stepHeader, form, fields }) {
+export default function RegistrationPage({ backLink, stepHeader, form, fields, eligibilityLink, termsOfServiceLink, dataPrivacyLink }) {
   const { t } = useTranslation();
 
   return (
@@ -69,7 +69,7 @@ export default function RegistrationPage({ backLink, stepHeader, form, fields })
               components={{
                 // The anchors get content in the translation file
                 // eslint-disable-next-line jsx-a11y/anchor-has-content
-                privacyPolicyLink: <a href="/TODO"/>,
+                dataPrivacyLink: <a href={dataPrivacyLink} />,
                 // eslint-disable-next-line jsx-a11y/anchor-has-content
                 taxGdprLink: <a href="https://www.bundesfinanzministerium.de/Content/DE/Downloads/BMF_Schreiben/Weitere_Steuerthemen/Abgabenordnung/2020-07-01-Korrektur-Allgemeine-Informationen-Datenschutz-Grundverordnung-Steuerverwaltung-anlage-1.pdf?__blob=publicationFile&v=3" rel="noreferrer" target="_blank" />,
               }}
@@ -89,7 +89,7 @@ export default function RegistrationPage({ backLink, stepHeader, form, fields })
               components={{
                 // The anchors get content in the translation file
                 // eslint-disable-next-line jsx-a11y/anchor-has-content
-                termsOfServiceLink: <a href="/TODO"/>,
+                termsOfServiceLink: <a href={termsOfServiceLink}/>,
               }}
             />
           }
@@ -107,7 +107,7 @@ export default function RegistrationPage({ backLink, stepHeader, form, fields })
               components={{
                 // The anchors get content in the translation file
                 // eslint-disable-next-line jsx-a11y/anchor-has-content
-                eligibilityLink: <a href="/TODO"/>,
+                eligibilityLink: <a href={eligibilityLink}/>,
               }}
             />
           }
@@ -172,6 +172,9 @@ RegistrationPage.propTypes = {
     registrationConfirmIncomes: fieldPropType,
     registrationConfirmEData: fieldPropType,
   }).isRequired,
+  eligibilityLink: PropTypes.string.isRequired,
+  termsOfServiceLink: PropTypes.string.isRequired,
+  dataPrivacyLink: PropTypes.string.isRequired,
 };
 
 RegistrationPage.defaultProps = {

--- a/webapp/client/src/pages/RegistrationPage.js
+++ b/webapp/client/src/pages/RegistrationPage.js
@@ -12,14 +12,22 @@ import StepForm from "../components/StepForm";
 import StepHeaderButtons from "../components/StepHeaderButtons";
 
 const SubHeading = styled.h2`
-&.form-sub-heading-smaller {
-  font-size: var(--text-medium);
-  margin-top: var(--spacing-09);
-  margin-bottom: var(--spacing-03);
-}
+  &.form-sub-heading-smaller {
+    font-size: var(--text-medium);
+    margin-top: var(--spacing-09);
+    margin-bottom: var(--spacing-03);
+  }
 `;
 
-export default function RegistrationPage({ backLink, stepHeader, form, fields, eligibilityLink, termsOfServiceLink, dataPrivacyLink }) {
+export default function RegistrationPage({
+  backLink,
+  stepHeader,
+  form,
+  fields,
+  eligibilityLink,
+  termsOfServiceLink,
+  dataPrivacyLink,
+}) {
   const { t } = useTranslation();
 
   return (
@@ -27,7 +35,7 @@ export default function RegistrationPage({ backLink, stepHeader, form, fields, e
       <StepHeaderButtons {...backLink} />
       <FormHeader {...stepHeader} />
       <StepForm {...form}>
-      <FormRowCentered>
+        <FormRowCentered>
           <FormFieldDate
             autofocus
             required
@@ -55,15 +63,17 @@ export default function RegistrationPage({ backLink, stepHeader, form, fields, e
             }}
             errors={fields.idnr.errors}
           />
-        </FormRowCentered> 
-        <SubHeading className="form-sub-heading-smaller">{ t("unlockCodeRequest.dataPrivacyAndAgb.title") }</SubHeading>
+        </FormRowCentered>
+        <SubHeading className="form-sub-heading-smaller">
+          {t("unlockCodeRequest.dataPrivacyAndAgb.title")}
+        </SubHeading>
         <FormFieldConsentBox
           required
           fieldName="registration_confirm_data_privacy"
           fieldId="registration_confirm_data_privacy"
           value={fields.registrationConfirmDataPrivacy.value}
           labelText={
-            <Trans 
+            <Trans
               t={t}
               i18nKey="unlockCodeRequest.fieldRegistrationConfirmDataPrivacy.labelText"
               components={{
@@ -71,7 +81,13 @@ export default function RegistrationPage({ backLink, stepHeader, form, fields, e
                 // eslint-disable-next-line jsx-a11y/anchor-has-content
                 dataPrivacyLink: <a href={dataPrivacyLink} />,
                 // eslint-disable-next-line jsx-a11y/anchor-has-content
-                taxGdprLink: <a href="https://www.bundesfinanzministerium.de/Content/DE/Downloads/BMF_Schreiben/Weitere_Steuerthemen/Abgabenordnung/2020-07-01-Korrektur-Allgemeine-Informationen-Datenschutz-Grundverordnung-Steuerverwaltung-anlage-1.pdf?__blob=publicationFile&v=3" rel="noreferrer" target="_blank" />,
+                taxGdprLink: (
+                  <a
+                    href="https://www.bundesfinanzministerium.de/Content/DE/Downloads/BMF_Schreiben/Weitere_Steuerthemen/Abgabenordnung/2020-07-01-Korrektur-Allgemeine-Informationen-Datenschutz-Grundverordnung-Steuerverwaltung-anlage-1.pdf?__blob=publicationFile&v=3"
+                    rel="noreferrer"
+                    target="_blank"
+                  />
+                ),
               }}
             />
           }
@@ -83,13 +99,13 @@ export default function RegistrationPage({ backLink, stepHeader, form, fields, e
           fieldId="registration_confirm_terms_of_service"
           value={fields.registrationConfirmTermsOfService.value}
           labelText={
-            <Trans 
+            <Trans
               t={t}
               i18nKey="unlockCodeRequest.fieldRegistrationConfirmTermsOfService.labelText"
               components={{
                 // The anchors get content in the translation file
                 // eslint-disable-next-line jsx-a11y/anchor-has-content
-                termsOfServiceLink: <a href={termsOfServiceLink}/>,
+                termsOfServiceLink: <a href={termsOfServiceLink} />,
               }}
             />
           }
@@ -101,28 +117,33 @@ export default function RegistrationPage({ backLink, stepHeader, form, fields, e
           fieldId="registration_confirm_incomes"
           value={fields.registrationConfirmIncomes.value}
           labelText={
-            <Trans 
+            <Trans
               t={t}
               i18nKey="unlockCodeRequest.fieldRegistrationConfirmIncomes.labelText"
               components={{
                 // The anchors get content in the translation file
                 // eslint-disable-next-line jsx-a11y/anchor-has-content
-                eligibilityLink: <a href={eligibilityLink}/>,
+                eligibilityLink: <a href={eligibilityLink} />,
               }}
             />
           }
           errors={fields.registrationConfirmIncomes.errors}
         />
-        <SubHeading className="form-sub-heading-smaller">{ t("unlockCodeRequest.dataPrivacyAndAgb.title") }</SubHeading>
-        <Details title={t("unlockCodeRequest.eData.helpTitle")} detailsId='registration_confirm_e_data'>
+        <SubHeading className="form-sub-heading-smaller">
+          {t("unlockCodeRequest.dataPrivacyAndAgb.title")}
+        </SubHeading>
+        <Details
+          title={t("unlockCodeRequest.eData.helpTitle")}
+          detailsId="registration_confirm_e_data"
+        >
           {{
             paragraphs: [
-              <Trans 
-              t={t}
-              i18nKey="unlockCodeRequest.eData.helpText"
-              components={{bold: <strong />}}
-            />
-            ]
+              <Trans
+                t={t}
+                i18nKey="unlockCodeRequest.eData.helpText"
+                components={{ bold: <strong /> }}
+              />,
+            ],
           }}
         </Details>
         <FormFieldConsentBox
@@ -130,7 +151,9 @@ export default function RegistrationPage({ backLink, stepHeader, form, fields, e
           fieldName="registration_confirm_e_data"
           fieldId="registration_confirm_e_data"
           value={fields.registrationConfirmEData.value}
-          labelText={t("unlockCodeRequest.fieldRegistrationConfirmEData.labelText")}
+          labelText={t(
+            "unlockCodeRequest.fieldRegistrationConfirmEData.labelText"
+          )}
           errors={fields.registrationConfirmEData.errors}
         />
       </StepForm>

--- a/webapp/client/src/stories/FormFieldConsentBox.stories.js
+++ b/webapp/client/src/stories/FormFieldConsentBox.stories.js
@@ -1,0 +1,25 @@
+import React from "react";
+
+import FormFieldConsentBox from "../components/FormFieldConsentBox";
+import StepForm from "../components/StepForm";
+import { Default as StepFormDefault } from "./StepForm.stories";
+
+export default {
+  title: "Form Fields/ConsentBox",
+  component: FormFieldConsentBox,
+};
+
+const Template = (args) => (
+  <StepForm {...StepFormDefault.args}>
+    <FormFieldConsentBox {...args} />
+  </StepForm>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  fieldId: "consentBox",
+  fieldName: "consentBox",
+  labelText: "This is a Consent Box. Please check if you consent.",
+  errors: [],
+  values: [],
+};

--- a/webapp/client/src/stories/FormFieldConsentBox.stories.js
+++ b/webapp/client/src/stories/FormFieldConsentBox.stories.js
@@ -19,7 +19,8 @@ export const Default = Template.bind({});
 Default.args = {
   fieldId: "consentBox",
   fieldName: "consentBox",
-  labelText: "This is a Consent Box. Please check if you consent.",
+  labelText:
+    "Ich mag Consent Boxen. Wenn du sie auch magst, klicke doch mal hier drauf.",
   errors: [],
   values: [],
 };

--- a/webapp/client/src/stories/FormFieldDate.stories.js
+++ b/webapp/client/src/stories/FormFieldDate.stories.js
@@ -1,0 +1,30 @@
+import React from "react";
+
+import FormFieldDate from "../components/FormFieldDate";
+import FormRowCentered from "../components/FormRowCentered";
+import StepForm from "../components/StepForm";
+import { Default as StepFormDefault } from "./StepForm.stories";
+
+export default {
+  title: "Form Fields/Date",
+  component: FormFieldDate,
+};
+
+const Template = (args) => (
+  <StepForm {...StepFormDefault.args}>
+    <FormRowCentered>
+      <FormFieldDate {...args} />
+    </FormRowCentered>
+  </StepForm>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  fieldId: "date",
+  fieldName: "date",
+  label: {
+    text: "Date",
+  },
+  errors: [],
+  values: [],
+};

--- a/webapp/client/src/stories/FormFieldDate.stories.js
+++ b/webapp/client/src/stories/FormFieldDate.stories.js
@@ -23,7 +23,7 @@ Default.args = {
   fieldId: "date",
   fieldName: "date",
   label: {
-    text: "Date",
+    text: "Datum",
   },
   errors: [],
   values: [],

--- a/webapp/client/src/stories/FormFieldDate.stories.js
+++ b/webapp/client/src/stories/FormFieldDate.stories.js
@@ -1,7 +1,6 @@
 import React from "react";
 
 import FormFieldDate from "../components/FormFieldDate";
-import FormRowCentered from "../components/FormRowCentered";
 import StepForm from "../components/StepForm";
 import { Default as StepFormDefault } from "./StepForm.stories";
 
@@ -12,9 +11,7 @@ export default {
 
 const Template = (args) => (
   <StepForm {...StepFormDefault.args}>
-    <FormRowCentered>
-      <FormFieldDate {...args} />
-    </FormRowCentered>
+    <FormFieldDate {...args} />
   </StepForm>
 );
 

--- a/webapp/client/src/stories/FormFieldIdNr.stories.js
+++ b/webapp/client/src/stories/FormFieldIdNr.stories.js
@@ -1,7 +1,6 @@
 import React from "react";
 
 import FormFieldIdNr from "../components/FormFieldIdNr";
-import FormRowCentered from "../components/FormRowCentered";
 import StepForm from "../components/StepForm";
 import { Default as StepFormDefault } from "./StepForm.stories";
 
@@ -12,9 +11,7 @@ export default {
 
 const Template = (args) => (
   <StepForm {...StepFormDefault.args}>
-    <FormRowCentered>
-      <FormFieldIdNr {...args} />
-    </FormRowCentered>
+    <FormFieldIdNr {...args} />
   </StepForm>
 );
 

--- a/webapp/client/src/stories/FormFieldUnlockCode.stories.js
+++ b/webapp/client/src/stories/FormFieldUnlockCode.stories.js
@@ -1,7 +1,6 @@
 import React from "react";
 
 import FormFieldUnlockCode from "../components/FormFieldUnlockCode";
-import FormRowCentered from "../components/FormRowCentered";
 import StepForm from "../components/StepForm";
 import * as StepFormStories from "./StepForm.stories";
 
@@ -12,9 +11,7 @@ export default {
 
 const Template = (args) => (
   <StepForm {...StepFormStories.Default.args}>
-    <FormRowCentered>
-      <FormFieldUnlockCode {...args} />
-    </FormRowCentered>
+    <FormFieldUnlockCode {...args} />
   </StepForm>
 );
 

--- a/webapp/client/src/stories/RegistrationPage.stories.js
+++ b/webapp/client/src/stories/RegistrationPage.stories.js
@@ -67,6 +67,6 @@ WithErrors.args = {
     registrationConfirmTermsOfService: {
       value: false,
       errors: [],
-    }
+    },
   },
 };

--- a/webapp/client/src/stories/RegistrationPage.stories.js
+++ b/webapp/client/src/stories/RegistrationPage.stories.js
@@ -1,0 +1,74 @@
+import React from "react";
+
+import RegistrationPage from "../pages/RegistrationPage";
+import { Default as StepFormDefault } from "./StepForm.stories";
+
+export default {
+  title: "Pages/Registration",
+  component: RegistrationPage,
+};
+
+const Template = (args) => <RegistrationPage {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  stepHeader: {
+    title: "Registrieren und persönlichen Freischaltcode beantragen",
+    intro:
+      "Mit Ihrer Registrierung beantragen Sie einen Freischaltcode bei Ihrer Finanzverwaltung. Sie erhalten diesen mit einem Brief wenige Tage nach erfolgreicher Beantragung. Wenn Sie die Zusammenveranlagung nutzen möchten, muss sich nur eine Person registrieren.",
+  },
+  form: {
+    ...StepFormDefault.args,
+  },
+  fields: {
+    idnr: {
+      value: ["04", "452", "397", "687"],
+      errors: [],
+    },
+    dob: {
+      value: ["01", "01", "1985"],
+      errors: [],
+    },
+    // TODO: understand how checked/non-checked is handled in WTForms
+    registrationConfirmDataPrivacy: {
+      value: "y",
+      errors: [],
+    },
+    registrationConfirmTermsOfService: {
+      value: "y",
+      errors: [],
+    },
+    registrationConfirmIncomes: {
+      value: "y",
+      errors: [],
+    },
+    registrationConfirmEData: {
+      value: "y",
+      errors: [],
+    },
+  },
+};
+
+export const WithErrors = Template.bind({});
+WithErrors.args = {
+  ...Default.args,
+  fields: {
+    ...Default.args.fields,
+    idnr: {
+      value: ["12", "345", "678", "90"],
+      errors: ["Geben Sie bitte eine gültige Steuer-Identifikationsnummer an."],
+    },
+    dob: {
+      value: ["40", "01", "1985"],
+      errors: ["Geben Sie ein gültiges Datum an."],
+    },
+    registrationConfirmDataPrivacy: {
+      value: false,
+      errors: [],
+    },
+    registrationConfirmTermsOfService: {
+      value: false,
+      errors: [],
+    }
+  },
+};

--- a/webapp/client/src/stories/RegistrationPage.stories.js
+++ b/webapp/client/src/stories/RegistrationPage.stories.js
@@ -42,6 +42,9 @@ Default.args = {
       errors: [],
     },
   },
+  eligibilityLink: "/eligibility/start",
+  termsOfServiceLink: "/agb",
+  dataPrivacyLink: "/datenschutz",
 };
 
 export const WithErrors = Template.bind({});

--- a/webapp/client/src/stories/RegistrationPage.stories.js
+++ b/webapp/client/src/stories/RegistrationPage.stories.js
@@ -29,21 +29,16 @@ Default.args = {
       value: ["01", "01", "1985"],
       errors: [],
     },
-    // TODO: understand how checked/non-checked is handled in WTForms
     registrationConfirmDataPrivacy: {
-      value: "y",
       errors: [],
     },
     registrationConfirmTermsOfService: {
-      value: "y",
       errors: [],
     },
     registrationConfirmIncomes: {
-      value: "y",
       errors: [],
     },
     registrationConfirmEData: {
-      value: "y",
       errors: [],
     },
   },

--- a/webapp/client/src/storybook-assets/base.css
+++ b/webapp/client/src/storybook-assets/base.css
@@ -369,12 +369,6 @@ h4 {
   margin-bottom: 0;
 }
 
-.form-sub-heading-smaller {
-  font-size: var(--text-medium);
-  margin-top: var(--spacing-09);
-  margin-bottom: var(--spacing-03);
-}
-
 ul.margin-only-between li {
   margin-top: var(--spacing-04);
 }


### PR DESCRIPTION
# Short Description
- Add all components needed for the registration page and the page itself

# Changes
- Add DateField as a component
- Add ConsentBox as a component
- Add RegistrationPage as a page
- Style subfield labels
- Add test to check for subfield labels

# Feedback
- I defined the labelText for the ConsentBox as `PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired` to be able to hand strings from `t()` calls as well as `<Trans>` components. Is that what you expected?
- Also, I made the internal links, e.g. to /eligibility/start parameters of the RegistrationPage that have to be passed to it. I imagined them being set by the template or the step so that we can still use Flasks `url_for`. WDYT?
- Do you see any meaningful tests that are missing?