### PR TITLE
Refactor determine prev and next step

### DIFF
--- a/webapp/app/forms/flows/lotse_step_chooser.py
+++ b/webapp/app/forms/flows/lotse_step_chooser.py
@@ -26,3 +26,15 @@ class LotseStepChooser(StepChooser):
             endpoint=endpoint,
             overview_step=StepSummary
         )
+
+    # TODO remove this once all steps are converted to steuerlotse steps
+    def determine_prev_step(self, current_step_name, stored_data):
+        if hasattr(self.steps[current_step_name], 'prev_step'):
+            return self.steps[current_step_name].prev_step
+        super().determine_prev_step(current_step_name, stored_data)
+
+    # TODO remove this once all steps are converted to steuerlotse steps
+    def determine_next_step(self, current_step_name, stored_data):
+        if hasattr(self.steps[current_step_name], 'next_step'):
+            return self.steps[current_step_name].next_step
+        super().determine_next_step(current_step_name, stored_data)

--- a/webapp/app/forms/flows/lotse_step_chooser.py
+++ b/webapp/app/forms/flows/lotse_step_chooser.py
@@ -29,12 +29,18 @@ class LotseStepChooser(StepChooser):
 
     # TODO remove this once all steps are converted to steuerlotse steps
     def determine_prev_step(self, current_step_name, stored_data):
+        # As we mix Mutlistepflow Steps and SteuerlotseSteps for the lotse, we need to handle leaving the
+        # "steuerlotse-step-context" and therefore directly set the prev_step in the SteuerlotseSteps that are
+        # adjacent to Mutlistepflow Steps.
         if hasattr(self.steps[current_step_name], 'prev_step'):
             return self.steps[current_step_name].prev_step
         super().determine_prev_step(current_step_name, stored_data)
 
     # TODO remove this once all steps are converted to steuerlotse steps
     def determine_next_step(self, current_step_name, stored_data):
+        # As we mix Mutlistepflow Steps and SteuerlotseSteps for the lotse, we need to handle leaving the
+        # "steuerlotse-step-context" and therefore directly set the next_step in the SteuerlotseSteps that are
+        # adjacent to Mutlistepflow Steps.
         if hasattr(self.steps[current_step_name], 'next_step'):
             return self.steps[current_step_name].next_step
         super().determine_next_step(current_step_name, stored_data)

--- a/webapp/app/forms/flows/step_chooser.py
+++ b/webapp/app/forms/flows/step_chooser.py
@@ -61,6 +61,16 @@ class StepChooser:
         )
 
     def determine_prev_step(self, current_step_name, stored_data):
+        """
+        This method searches the correct previous step for the given @current_step_name on the basis of the
+        @stored_data.
+        It loops through the list of steps starting from the current_step (i) upwards. Each step is then asked if they
+        could be the previous step (via checking their own precondition). If the answer of i-1 is yes, that step is
+        returned. Otherwise, the step i-2 is asked and so on until a fitting step is found.
+
+        :param current_step_name: The name of the step to get the previous step for
+        :param stored_data: The data currently in the session
+        """
         idx = self.step_order.index(current_step_name)
         for possible_prev_step_idx in range(idx - 1, -1, -1):
             possible_prev_step = self.steps[self.step_order[possible_prev_step_idx]]
@@ -69,6 +79,16 @@ class StepChooser:
         return None
 
     def determine_next_step(self, current_step_name, stored_data):
+        """
+        This method searches the correct next step for the given @current_step_name on the basis of the
+        @stored_data.
+        It loops through the list of steps starting from the current_step (i) downwards. Each step is then asked if they
+        could be the next step (via checking their own precondition). If the answer of i+1 is yes, that step is
+        returned. Otherwise, the step i+2 is asked and so on until a fitting step is found.
+
+        :param current_step_name: The name of the step to get the next step for
+        :param stored_data: The data currently in the session
+        """
         idx = self.step_order.index(current_step_name)
         for possible_next_step_idx in range(idx + 1, len(self.steps)):
             possible_next_step = self.steps[self.step_order[possible_next_step_idx]]

--- a/webapp/app/forms/flows/step_chooser.py
+++ b/webapp/app/forms/flows/step_chooser.py
@@ -62,11 +62,19 @@ class StepChooser:
 
     def determine_prev_step(self, current_step_name, stored_data):
         idx = self.step_order.index(current_step_name)
-        return self.steps[self.step_order[idx - 1]] if idx > 0 else None
+        for possible_prev_step_idx in range(idx - 1, -1, -1):
+            possible_prev_step = self.steps[self.step_order[possible_prev_step_idx]]
+            if possible_prev_step.check_precondition(stored_data):
+                return possible_prev_step
+        return None
 
     def determine_next_step(self, current_step_name, stored_data):
         idx = self.step_order.index(current_step_name)
-        return self.steps[self.step_order[idx + 1]] if idx < len(self.step_order) - 1 else None
+        for possible_next_step_idx in range(idx + 1, len(self.steps)):
+            possible_next_step = self.steps[self.step_order[possible_next_step_idx]]
+            if possible_next_step.check_precondition(stored_data):
+                return possible_next_step
+        return None
 
     def default_data(self):
         if Config.DEBUG_DATA:

--- a/webapp/app/forms/steps/lotse/personal_data.py
+++ b/webapp/app/forms/steps/lotse/personal_data.py
@@ -39,6 +39,7 @@ class StepSteuernummer(LotseFormSteuerlotseStep):
     intro = _l('form.lotse.steuernummer-intro')
     header_title = _l('form.lotse.mandatory_data.header-title')
     template = 'lotse/form_steuernummer.html'
+    # TODO remove this once all steps are converted to steuerlotse steps
     prev_step_name = StepFamilienstand.name
     next_step_name = StepPersonA.name
 

--- a/webapp/app/forms/steps/lotse/personal_data.py
+++ b/webapp/app/forms/steps/lotse/personal_data.py
@@ -19,16 +19,14 @@ from app.model.form_data import FamilienstandModel
 class LotseFormSteuerlotseStep(FormSteuerlotseStep):
     template = 'basis/form_standard.html'
     header_title = None
-    prev_step_name = None
-    next_step_name = None
+    prev_step = StepFamilienstand
+    next_step = StepPersonA
 
     def __init__(self, endpoint, **kwargs):
         super().__init__(endpoint=endpoint, header_title=self.header_title, **kwargs)
 
     def _main_handle(self):
         super()._main_handle()
-        self.render_info.prev_url = self.url_for_step(self.prev_step_name)
-        self.render_info.next_url = self.url_for_step(self.next_step_name)
 
         # redirect in any case if overview button pressed
         if 'overview_button' in request.form:

--- a/webapp/app/forms/steps/steuerlotse_step.py
+++ b/webapp/app/forms/steps/steuerlotse_step.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from flask import request, session, url_for, render_template
 from flask_babel import ngettext
+from pydantic import ValidationError
 from werkzeug.utils import redirect
 
 from app.forms import SteuerlotseBaseForm
@@ -20,6 +21,7 @@ class SteuerlotseStep(object):
     intro = None
     intro_multiple = None
     template = None
+    precondition = None
 
     def __init__(self, endpoint, header_title, stored_data, overview_step, default_data, prev_step, next_step,
                  session_data_identifier='form_data'):
@@ -77,6 +79,19 @@ class SteuerlotseStep(object):
     @classmethod
     def number_of_users(cls, input_data=None):
         return 1
+
+    @classmethod
+    def check_precondition(cls, stored_data):
+        if cls.precondition:
+            try:
+                cls.precondition.parse_obj(stored_data)
+            except ValidationError:
+                return False
+        return True
+
+    @classmethod
+    def get_redirection_step(cls, stored_data):
+        return None
 
     def render(self, **kwargs):
         raise NotImplementedError

--- a/webapp/tests/forms/flows/test_lotse_step_chooser.py
+++ b/webapp/tests/forms/flows/test_lotse_step_chooser.py
@@ -8,11 +8,11 @@ from tests.forms.mock_steuerlotse_steps import MockMiddleStep
 
 # TODO remove this once all steps are converted to steuerlotse steps
 class TestDeterminePrevStep:
-    def test_if_prev_step_set_in_step_return_this_set_step(self):
+    def test_if_prev_step_set_in_step_then_return_the_set_step(self):
         returned_prev_step = LotseStepChooser(endpoint="lotse").determine_prev_step(StepSteuernummer.name, {})
         assert returned_prev_step == StepFamilienstand
 
-    def test_if_prev_step_not_set_in_step_call_super_method(self):
+    def test_if_prev_step_not_set_in_step_then_call_super_method(self):
         step_chooser = LotseStepChooser(endpoint="lotse")
         step_chooser.steps['step_without_set_prev_step'] = MockMiddleStep
         with patch('app.forms.flows.step_chooser.StepChooser.determine_prev_step') as super_method:
@@ -22,11 +22,11 @@ class TestDeterminePrevStep:
 
 # TODO remove this once all steps are converted to steuerlotse steps
 class TestDetermineNextStep:
-    def test_if_next_step_set_in_step_return_this_set_step(self):
+    def test_if_next_step_set_in_step_then_return_the_set_step(self):
         returned_prev_step = LotseStepChooser(endpoint="lotse").determine_next_step(StepSteuernummer.name, {})
         assert returned_prev_step == StepPersonA
 
-    def test_if_next_step_not_set_in_step_call_super_method(self):
+    def test_if_next_step_not_set_in_step_then_call_super_method(self):
         step_chooser = LotseStepChooser(endpoint="lotse")
         step_chooser.steps['step_without_set_next_step'] = MockMiddleStep
         with patch('app.forms.flows.step_chooser.StepChooser.determine_next_step') as super_method:

--- a/webapp/tests/forms/flows/test_lotse_step_chooser.py
+++ b/webapp/tests/forms/flows/test_lotse_step_chooser.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+
+from app.forms.flows.lotse_step_chooser import LotseStepChooser
+from app.forms.steps.lotse.personal_data import StepSteuernummer
+from app.forms.steps.lotse_multistep_flow_steps.personal_data_steps import StepFamilienstand, StepPersonA
+from tests.forms.mock_steuerlotse_steps import MockMiddleStep
+
+
+# TODO remove this once all steps are converted to steuerlotse steps
+class TestDeterminePrevStep:
+    def test_if_prev_step_set_in_step_return_this_set_step(self):
+        returned_prev_step = LotseStepChooser(endpoint="lotse").determine_prev_step(StepSteuernummer.name, {})
+        assert returned_prev_step == StepFamilienstand
+
+    def test_if_prev_step_not_set_in_step_call_super_method(self):
+        step_chooser = LotseStepChooser(endpoint="lotse")
+        step_chooser.steps['step_without_set_prev_step'] = MockMiddleStep
+        with patch('app.forms.flows.step_chooser.StepChooser.determine_prev_step') as super_method:
+            step_chooser.determine_prev_step('step_without_set_prev_step', {})
+            super_method.assert_called_once()
+
+
+# TODO remove this once all steps are converted to steuerlotse steps
+class TestDetermineNextStep:
+    def test_if_next_step_set_in_step_return_this_set_step(self):
+        returned_prev_step = LotseStepChooser(endpoint="lotse").determine_next_step(StepSteuernummer.name, {})
+        assert returned_prev_step == StepPersonA
+
+    def test_if_next_step_not_set_in_step_call_super_method(self):
+        step_chooser = LotseStepChooser(endpoint="lotse")
+        step_chooser.steps['step_without_set_next_step'] = MockMiddleStep
+        with patch('app.forms.flows.step_chooser.StepChooser.determine_next_step') as super_method:
+            step_chooser.determine_next_step('step_without_set_next_step', {})
+            super_method.assert_called_once()

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -145,12 +145,12 @@ class TestDeterminePrevStep:
         yield StepChooser(title="Testing StepChooser", steps=testing_steps,
                           endpoint="lotse", overview_step=MockFormWithInputStep)
 
-    def test_if_previous_steps_have_no_precondition_then_return_direct_predecessor(self, step_chooser_without_preconditions):
+    def test_if_previous_step_has_no_precondition_then_return_direct_predecessor(self, step_chooser_without_preconditions):
         expected_prev_step = MockMiddleStep
         actual_prev_step = step_chooser_without_preconditions.determine_prev_step(MockFormWithInputStep.name, {})
         assert actual_prev_step == expected_prev_step
 
-    def test_if_previous_steps_have_no_precondition_then_request_only_direct_predecessor(self, step_chooser_without_preconditions):
+    def test_if_previous_step_has_no_precondition_then_request_only_direct_predecessor(self, step_chooser_without_preconditions):
         with patch('tests.forms.mock_steuerlotse_steps.MockStartStep.check_precondition') as start_step_check, \
              patch('tests.forms.mock_steuerlotse_steps.MockMiddleStep.check_precondition') as middle_step_check, \
              patch('tests.forms.mock_steuerlotse_steps.MockFormWithInputStep.check_precondition') as input_step_check, \
@@ -161,19 +161,19 @@ class TestDeterminePrevStep:
             input_step_check.assert_not_called()
             final_step_check.assert_not_called()
 
-    def test_if_previous_steps_have_met_precondition_then_return_direct_predecessor(self, step_chooser_with_preconditions):
+    def test_if_previous_step_meets_precondition_then_return_direct_predecessor(self, step_chooser_with_preconditions):
         expected_prev_step = MockStepWithPrecondition
         actual_prev_step = step_chooser_with_preconditions.determine_prev_step(MockFormWithInputStep.name,
                                                                                {'precondition_met': True})
         assert actual_prev_step == expected_prev_step
 
-    def test_if_previous_steps_have_but_dont_meet_precondition_then_return_step_before(self, step_chooser_with_preconditions):
+    def test_if_previous_step_have_but_does_not_meet_precondition_then_return_step_before(self, step_chooser_with_preconditions):
         expected_prev_step = MockStartStep
         actual_prev_step = step_chooser_with_preconditions.determine_prev_step(MockFormWithInputStep.name,
                                                                                {'precondition_met': False})
         assert actual_prev_step == expected_prev_step
 
-    def test_if_previous_steps_have_but_dont_meet_precondition_then_request_direct_predecessors(self, step_chooser_with_preconditions):
+    def test_if_previous_step_has_but_does_not_meet_precondition_then_request_direct_predecessors(self, step_chooser_with_preconditions):
         with patch('tests.forms.mock_steuerlotse_steps.MockStartStep.check_precondition') as start_step_check, \
                 patch('tests.forms.mock_steuerlotse_steps.MockStepWithPrecondition.check_precondition',
                       MagicMock(return_value=False)) as precondition_step_check, \
@@ -204,12 +204,12 @@ class TestDetermineNextStep:
         yield StepChooser(title="Testing StepChooser", steps=testing_steps,
                           endpoint="lotse", overview_step=MockFormWithInputStep)
 
-    def test_if_next_steps_have_no_precondition_then_return_direct_successor(self, step_chooser_without_preconditions):
+    def test_if_next_step_has_no_precondition_then_return_direct_successor(self, step_chooser_without_preconditions):
         expected_next_step = MockMiddleStep
         actual_next_step = step_chooser_without_preconditions.determine_next_step(MockFormWithInputStep.name, {})
         assert actual_next_step == expected_next_step
 
-    def test_if_next_steps_have_no_precondition_then_request_only_direct_successor(self, step_chooser_without_preconditions):
+    def test_if_next_step_has_no_precondition_then_request_only_direct_successor(self, step_chooser_without_preconditions):
         with patch('tests.forms.mock_steuerlotse_steps.MockStartStep.check_precondition') as start_step_check, \
              patch('tests.forms.mock_steuerlotse_steps.MockFormWithInputStep.check_precondition') as input_step_check, \
              patch('tests.forms.mock_steuerlotse_steps.MockMiddleStep.check_precondition') as middle_step_check, \
@@ -220,19 +220,19 @@ class TestDetermineNextStep:
             middle_step_check.assert_called_once()
             final_step_check.assert_not_called()
 
-    def test_if_next_steps_have_met_precondition_then_return_direct_successor(self, step_chooser_with_preconditions):
+    def test_if_next_step_meets_precondition_then_return_direct_successor(self, step_chooser_with_preconditions):
         expected_next_step = MockStepWithPrecondition
         actual_next_step = step_chooser_with_preconditions.determine_next_step(MockFormWithInputStep.name,
                                                                                {'precondition_met': True})
         assert actual_next_step == expected_next_step
 
-    def test_if_next_steps_have_but_dont_meet_precondition_then_return_step_after(self, step_chooser_with_preconditions):
+    def test_if_next_step_has_but_does_not_meet_precondition_then_return_step_after(self, step_chooser_with_preconditions):
         expected_next_step = MockFinalStep
         actual_next_step = step_chooser_with_preconditions.determine_next_step(MockFormWithInputStep.name,
                                                                                {'precondition_met': False})
         assert actual_next_step == expected_next_step
 
-    def test_if_next_steps_have_but_dont_meet_precondition_then_request_direct_successors(self, step_chooser_with_preconditions):
+    def test_if_next_step_has_but_does_not_meet_precondition_then_request_direct_successors(self, step_chooser_with_preconditions):
         with patch('tests.forms.mock_steuerlotse_steps.MockStartStep.check_precondition') as start_step_check, \
                 patch(
                     'tests.forms.mock_steuerlotse_steps.MockFormWithInputStep.check_precondition') as input_step_check, \

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -42,7 +42,7 @@ class TestGetPossibleRedirect:
         yield StepChooser(title="Testing StepChooser", steps=testing_steps,
                           endpoint=self.endpoint_correct, overview_step=MockFormWithInputStep)
 
-    def test_if_step_not_in_step_list_return_404(self, step_chooser):
+    def test_if_step_not_in_step_list_then_return_404(self, step_chooser):
         with pytest.raises(NotFound):
             step_chooser._get_possible_redirect('INVALID_STEP_NAME', {})
 
@@ -95,7 +95,7 @@ class TestStepChooserGetCorrectStep(unittest.TestCase):
         self.assertIsInstance(chosen_step, RedirectSteuerlotseStep)
         self.assertEqual(chosen_step.redirection_step_name, self.step_chooser.first_step.name)
 
-    def test_if_step_in_list_of_steps_return_correct_steps(self):
+    def test_if_step_in_list_of_steps_then_return_correct_steps(self):
         simple_step_chooser = StepChooser(title="Testing StepChooser",
                                             steps=[MockStartStep, MockMiddleStep, MockFinalStep],
                                             endpoint=self.endpoint_correct)
@@ -145,12 +145,12 @@ class TestDeterminePrevStep:
         yield StepChooser(title="Testing StepChooser", steps=testing_steps,
                           endpoint="lotse", overview_step=MockFormWithInputStep)
 
-    def test_if_previous_steps_have_no_precondition_return_direct_predecessor(self, step_chooser_without_preconditions):
+    def test_if_previous_steps_have_no_precondition_then_return_direct_predecessor(self, step_chooser_without_preconditions):
         expected_prev_step = MockMiddleStep
         actual_prev_step = step_chooser_without_preconditions.determine_prev_step(MockFormWithInputStep.name, {})
         assert actual_prev_step == expected_prev_step
 
-    def test_if_previous_steps_have_no_precondition_request_only_direct_predecessor(self, step_chooser_without_preconditions):
+    def test_if_previous_steps_have_no_precondition_then_request_only_direct_predecessor(self, step_chooser_without_preconditions):
         with patch('tests.forms.mock_steuerlotse_steps.MockStartStep.check_precondition') as start_step_check, \
              patch('tests.forms.mock_steuerlotse_steps.MockMiddleStep.check_precondition') as middle_step_check, \
              patch('tests.forms.mock_steuerlotse_steps.MockFormWithInputStep.check_precondition') as input_step_check, \
@@ -161,19 +161,19 @@ class TestDeterminePrevStep:
             input_step_check.assert_not_called()
             final_step_check.assert_not_called()
 
-    def test_if_previous_steps_have_met_precondition_return_direct_predecessor(self, step_chooser_with_preconditions):
+    def test_if_previous_steps_have_met_precondition_then_return_direct_predecessor(self, step_chooser_with_preconditions):
         expected_prev_step = MockStepWithPrecondition
         actual_prev_step = step_chooser_with_preconditions.determine_prev_step(MockFormWithInputStep.name,
                                                                                {'precondition_met': True})
         assert actual_prev_step == expected_prev_step
 
-    def test_if_previous_steps_have_but_dont_meet_precondition_return_step_before(self, step_chooser_with_preconditions):
+    def test_if_previous_steps_have_but_dont_meet_precondition_then_return_step_before(self, step_chooser_with_preconditions):
         expected_prev_step = MockStartStep
         actual_prev_step = step_chooser_with_preconditions.determine_prev_step(MockFormWithInputStep.name,
                                                                                {'precondition_met': False})
         assert actual_prev_step == expected_prev_step
 
-    def test_if_previous_steps_have_but_dont_meet_precondition_request_correct_steps(self, step_chooser_with_preconditions):
+    def test_if_previous_steps_have_but_dont_meet_precondition_then_request_correct_steps(self, step_chooser_with_preconditions):
         with patch('tests.forms.mock_steuerlotse_steps.MockStartStep.check_precondition') as start_step_check, \
                 patch('tests.forms.mock_steuerlotse_steps.MockStepWithPrecondition.check_precondition',
                       MagicMock(return_value=False)) as precondition_step_check, \
@@ -186,7 +186,7 @@ class TestDeterminePrevStep:
             input_step_check.assert_not_called()
             final_step_check.assert_not_called()
 
-    def test_if_no_step_is_valid_prev_step_return_none(self, step_chooser_without_preconditions):
+    def test_if_no_step_is_valid_prev_step_then_return_none(self, step_chooser_without_preconditions):
         returned_prev_step = step_chooser_without_preconditions.determine_prev_step(MockStartStep.name, {})
         assert returned_prev_step is None
 
@@ -204,12 +204,12 @@ class TestDetermineNextStep:
         yield StepChooser(title="Testing StepChooser", steps=testing_steps,
                           endpoint="lotse", overview_step=MockFormWithInputStep)
 
-    def test_if_next_steps_have_no_precondition_return_direct_successor(self, step_chooser_without_preconditions):
+    def test_if_next_steps_have_no_precondition_then_return_direct_successor(self, step_chooser_without_preconditions):
         expected_next_step = MockMiddleStep
         actual_next_step = step_chooser_without_preconditions.determine_next_step(MockFormWithInputStep.name, {})
         assert actual_next_step == expected_next_step
 
-    def test_if_next_steps_have_no_precondition_request_only_direct_successor(self, step_chooser_without_preconditions):
+    def test_if_next_steps_have_no_precondition_then_request_only_direct_successor(self, step_chooser_without_preconditions):
         with patch('tests.forms.mock_steuerlotse_steps.MockStartStep.check_precondition') as start_step_check, \
              patch('tests.forms.mock_steuerlotse_steps.MockFormWithInputStep.check_precondition') as input_step_check, \
              patch('tests.forms.mock_steuerlotse_steps.MockMiddleStep.check_precondition') as middle_step_check, \
@@ -220,19 +220,19 @@ class TestDetermineNextStep:
             middle_step_check.assert_called_once()
             final_step_check.assert_not_called()
 
-    def test_if_next_steps_have_met_precondition_return_direct_successor(self, step_chooser_with_preconditions):
+    def test_if_next_steps_have_met_precondition_then_return_direct_successor(self, step_chooser_with_preconditions):
         expected_next_step = MockStepWithPrecondition
         actual_next_step = step_chooser_with_preconditions.determine_next_step(MockFormWithInputStep.name,
                                                                                {'precondition_met': True})
         assert actual_next_step == expected_next_step
 
-    def test_if_next_steps_have_but_dont_meet_precondition_return_step_after(self, step_chooser_with_preconditions):
+    def test_if_next_steps_have_but_dont_meet_precondition_then_return_step_after(self, step_chooser_with_preconditions):
         expected_next_step = MockFinalStep
         actual_next_step = step_chooser_with_preconditions.determine_next_step(MockFormWithInputStep.name,
                                                                                {'precondition_met': False})
         assert actual_next_step == expected_next_step
 
-    def test_if_next_steps_have_but_dont_meet_precondition_request_correct_steps(self, step_chooser_with_preconditions):
+    def test_if_next_steps_have_but_dont_meet_precondition_then_request_correct_steps(self, step_chooser_with_preconditions):
         with patch('tests.forms.mock_steuerlotse_steps.MockStartStep.check_precondition') as start_step_check, \
                 patch(
                     'tests.forms.mock_steuerlotse_steps.MockFormWithInputStep.check_precondition') as input_step_check, \
@@ -245,7 +245,7 @@ class TestDetermineNextStep:
             precondition_step_check.assert_called_once()
             final_step_check.assert_called_once()
 
-    def test_if_no_step_is_valid_next_step_return_none(self, step_chooser_without_preconditions):
+    def test_if_no_step_is_valid_next_step_then_return_none(self, step_chooser_without_preconditions):
         returned_next_step = step_chooser_without_preconditions.determine_next_step(MockFinalStep.name, {})
         assert returned_next_step is None
 

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -173,7 +173,7 @@ class TestDeterminePrevStep:
                                                                                {'precondition_met': False})
         assert actual_prev_step == expected_prev_step
 
-    def test_if_previous_steps_have_but_dont_meet_precondition_then_request_correct_steps(self, step_chooser_with_preconditions):
+    def test_if_previous_steps_have_but_dont_meet_precondition_then_request_direct_predecessors(self, step_chooser_with_preconditions):
         with patch('tests.forms.mock_steuerlotse_steps.MockStartStep.check_precondition') as start_step_check, \
                 patch('tests.forms.mock_steuerlotse_steps.MockStepWithPrecondition.check_precondition',
                       MagicMock(return_value=False)) as precondition_step_check, \
@@ -232,7 +232,7 @@ class TestDetermineNextStep:
                                                                                {'precondition_met': False})
         assert actual_next_step == expected_next_step
 
-    def test_if_next_steps_have_but_dont_meet_precondition_then_request_correct_steps(self, step_chooser_with_preconditions):
+    def test_if_next_steps_have_but_dont_meet_precondition_then_request_direct_successors(self, step_chooser_with_preconditions):
         with patch('tests.forms.mock_steuerlotse_steps.MockStartStep.check_precondition') as start_step_check, \
                 patch(
                     'tests.forms.mock_steuerlotse_steps.MockFormWithInputStep.check_precondition') as input_step_check, \

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -60,6 +60,10 @@ class TestGetPossibleRedirect:
                                                                   {'precondition_met': True})
         assert step_to_redirect_to is None
 
+    def test_if_step_in_list_and_has_no_redirection_set_then_return_none(self, step_chooser):
+        step_to_redirect_to = step_chooser._get_possible_redirect(MockRenderStep.name, {})
+        assert step_to_redirect_to is None
+
 
 class TestStepChooserGetCorrectStep(unittest.TestCase):
     @pytest.fixture(autouse=True)

--- a/webapp/tests/forms/steps/lotse/test_personal_data_steps.py
+++ b/webapp/tests/forms/steps/lotse/test_personal_data_steps.py
@@ -23,24 +23,6 @@ def step_with_bufa_choices(app, test_request_context):
     yield step
 
 
-@pytest.mark.usefixtures("app", "test_request_context")
-class TestLotseFormSteuerlotseStep:
-
-    def test_if_prev_and_next_step_name_set_then_set_correct_urls(self):
-        step = LotseFormSteuerlotseStep(endpoint="lotse")
-        step.create_form = lambda *a, **k: None
-        step.render = lambda *a, **k: None
-        step.name = "TESTING_STEP"
-        step.overview_step = SummaryStep
-        step.prev_step_name = "iban"
-        step.next_step_name = "person_a"
-
-        step.handle()
-
-        assert step.render_info.prev_url == step.url_for_step("iban")
-        assert step.render_info.next_url == step.url_for_step("person_a")
-
-
 class TestStepSteuernummer:
 
     def test_if_steuernummer_exists_missing_then_fail_validation(self, step_with_bufa_choices):

--- a/webapp/tests/forms/steps/test_steuerlotse_step.py
+++ b/webapp/tests/forms/steps/test_steuerlotse_step.py
@@ -413,8 +413,8 @@ class TestCheckPrecondition:
 
 class TestGetRedirectionStep:
     def test_by_default_return_none(self):
-        precondition_checked = MockRenderStep.get_redirection_step({})
-        assert precondition_checked is None
+        redirection_step = MockRenderStep.get_redirection_step({})
+        assert redirection_step is None
 
 
 class TestSteuerlotseFormStepHandle(unittest.TestCase):

--- a/webapp/tests/forms/steps/test_steuerlotse_step.py
+++ b/webapp/tests/forms/steps/test_steuerlotse_step.py
@@ -15,7 +15,7 @@ from app.forms.flows.multistep_flow import RenderInfo
 from app.forms.steps.steuerlotse_step import SteuerlotseStep, \
     RedirectSteuerlotseStep, FormSteuerlotseStep
 from tests.forms.mock_steuerlotse_steps import MockStartStep, MockMiddleStep, MockFinalStep, MockFormStep, \
-    MockRenderStep, MockYesNoStep, MockFormWithInputStep
+    MockRenderStep, MockYesNoStep, MockFormWithInputStep, MockStepWithPrecondition
 from tests.utils import create_session_form_data
 
 
@@ -395,6 +395,26 @@ class TestRedirectSteuerlotseStep(unittest.TestCase):
             redirect(url_for(endpoint="lotse", step="RedirectToThis",
                                 link_overview=redirection_step.has_link_overview)).location,
             returned_redirect.location)
+
+
+class TestCheckPrecondition:
+    def test_if_no_precondition_set_then_return_true(self, app):
+        precondition_checked = MockRenderStep.check_precondition({})
+        assert precondition_checked == True
+
+    def test_if_precondition_set_and_met_then_return_true(self):
+        precondition_checked = MockStepWithPrecondition.check_precondition({'precondition_met': True})
+        assert precondition_checked == True
+
+    def test_if_precondition_set_but_not_met_then_return_false(self):
+        precondition_checked = MockStepWithPrecondition.check_precondition({'precondition_met': False})
+        assert precondition_checked == False
+
+
+class TestGetRedirectionStep:
+    def test_by_default_return_none(self):
+        precondition_checked = MockRenderStep.get_redirection_step({})
+        assert precondition_checked is None
 
 
 class TestSteuerlotseFormStepHandle(unittest.TestCase):


### PR DESCRIPTION
# Short Description
- This introduces the new logic how previous and next steps are determined.
- I did not change the eligibility logic though.

# Changes
- Introduce new method to determine prev and next steps
- Move the prev and next step logic of the lotse steps from the steps up to the step_chooser. This way we can use the logic in the lotse once we have more than one consecutive step as SteuerlotseStep
- Add `check_precondition? and `get_redirection_step` to the SteuerlotseStep
- Redirect in step_chooser if `get_redirection_step` of the step returns something

# Feedback
- Do you think we need a log/error message in case we return None as the prev/next step *and* the current step is not the first/last step (or is not in a defined list of accepted first/last steps)?
- What do you think of the way I handled the prev/next step logic for the lotse_step_chooser? Does that make sense to you? This way, we only have to set prev_step and next_step directly for the steps that direct to old multistepflow-steps.
- Do you see any missing tests?