### PR TITLE
Fix familienstand iban bug

### DIFF
--- a/acceptance_tests/cypress/integration/lotse_flow.spec.js
+++ b/acceptance_tests/cypress/integration/lotse_flow.spec.js
@@ -299,7 +299,7 @@ context('Acceptance tests', () => {
                 cy.get('#person_a_town').type(taxReturnData.personA.town)
                 cy.get(submitBtnSelector).click()
 
-                cy.get('label[for=is_person_a_account_holder]').first().click()
+                cy.get('label[for=is_user_account_holder]').first().click()
                 cy.get('#iban').type(taxReturnData.iban)
                 cy.get(submitBtnSelector).click()
 
@@ -349,7 +349,7 @@ context('Acceptance tests', () => {
                 cy.get('#person_a_town').type(taxReturnData.personA.town)
                 cy.get(submitBtnSelector).click()
 
-                cy.get('label[for=is_person_a_account_holder]').first().click()
+                cy.get('label[for=is_user_account_holder]').first().click()
                 cy.get('#iban').type(taxReturnData.iban)
                 cy.get(submitBtnSelector).click()
 
@@ -428,7 +428,7 @@ context('Acceptance tests', () => {
                 cy.get('select[id=person_b_religion]').select('ev')
                 cy.get(submitBtnSelector).click()
 
-                cy.get('label[for=is_person_a_account_holder-0]').first().click()
+                cy.get('label[for=account_holder-0]').first().click()
                 cy.get('#iban').type(taxReturnData.iban)
                 cy.get(submitBtnSelector).click()
 

--- a/erica_app/erica/elster_xml/est_mapping.py
+++ b/erica_app/erica/elster_xml/est_mapping.py
@@ -223,9 +223,9 @@ def check_and_generate_entries(est_data, year=2019):
     enriched_est_data = est_data
     enriched_est_data['is_einkommensteuererklaerung'] = 'X'
     enriched_est_data['is_digitally_signed'] = 'X'
-    if est_data.get('is_person_a_account_holder') is True:
+    if est_data.get('account_holder') == 'person_a':
         enriched_est_data['is_person_a_account_holder'] = 'X'
-    elif est_data.get('is_person_a_account_holder') is False:
+    elif est_data.get('account_holder') == 'person_b':
         enriched_est_data['is_person_b_account_holder'] = 'X'
 
     # Lebenssituation

--- a/erica_app/erica/request_processing/erica_input.py
+++ b/erica_app/erica/request_processing/erica_input.py
@@ -14,7 +14,7 @@ class FormDataEst(BaseModel):
     bufa_nr: Optional[str]
     bundesland: str
     iban: Optional[str]
-    is_person_a_account_holder: bool
+    account_holder: str
 
     familienstand: str  # potentially enum
     familienstand_date: Optional[date]
@@ -82,6 +82,12 @@ class FormDataEst(BaseModel):
 
     stmind_gem_haushalt_count: Optional[int]
     stmind_gem_haushalt_entries: Optional[List[str]]
+
+    @validator('account_holder')
+    def account_holder_is_person_a_or_b(cls, v):
+        if v not in ['person_a', 'person_b']:
+            raise ValueError('Account holder should be person a or person b')
+        return v
 
     @validator('submission_without_tax_nr', always=True)
     def if_no_tax_number_must_be_submission_without_tax_nr(cls, v, values):

--- a/erica_app/tests/elster_xml/test_est_mapping.py
+++ b/erica_app/tests/elster_xml/test_est_mapping.py
@@ -374,7 +374,7 @@ class TestEstMapping(unittest.TestCase):
 
     def test_if_person_a_is_kontoinhaber_then_set_correct_field(self):
         form_data = {
-            'is_person_a_account_holder': True,
+            'account_holder': 'person_a',
         }
 
         results = check_and_generate_entries(form_data)
@@ -382,9 +382,9 @@ class TestEstMapping(unittest.TestCase):
         self.assertNotIn('E0102402', results.keys())
         self.assertEqual('X', results['E0101601'])
 
-    def test_if_person_a_is_not_kontoinhaber_then_set_correct_field(self):
+    def test_if_person_b_is_kontoinhaber_then_set_correct_field(self):
         form_data = {
-            'is_person_a_account_holder': False,
+            'account_holder': 'person_b',
         }
 
         results = check_and_generate_entries(form_data)

--- a/erica_app/tests/request_processing/test_erica_input.py
+++ b/erica_app/tests/request_processing/test_erica_input.py
@@ -3,14 +3,16 @@ from datetime import date
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
+import pytest
 from pydantic import ValidationError
 
 from erica.pyeric.eric_errors import InvalidBufaNumberError
 from erica.request_processing.erica_input import FormDataEst, MetaDataEst
 
 
+@pytest.fixture
 def standard_est_data():
-    return {
+    yield {
             'steuernummer': '19811310010',
             'bundesland': 'BY',
             'familienstand': 'married',
@@ -38,7 +40,7 @@ def standard_est_data():
             'person_b_gehbeh': False,
 
             'iban': 'DE35133713370000012345',
-            'is_person_a_account_holder': True,
+            'account_holder': 'person_a',
 
             'steuerminderung': True,
 
@@ -53,152 +55,173 @@ def standard_est_data():
             'confirm_send': True}
 
 
-class TestFormDataEstNewAdmission(unittest.TestCase):
+class TestFormDataEstAccountHolder:
 
-    def test_if_steuernummer_given_and_submission_without_tax_nr_set_then_raise_exception(self):
-        est_data = standard_est_data()
-        est_data['submission_without_tax_nr'] = True
+    def test_if_account_holder_not_person_a_or_b_then_raise_exception(self, standard_est_data):
+        standard_est_data['account_holder'] = 'Robin Hood'
 
-        self.assertRaises(ValidationError, FormDataEst.parse_obj, est_data)
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
 
-    def test_if_steuernummer_none_and_no_submission_without_tax_nr_set_then_raise_exception(self):
-        est_data = standard_est_data()
-        est_data['steuernummer'] = None
-        est_data.pop('submission_without_tax_nr', None)
+    def test_if_account_holder_person_a_then_raise_no_exception(self, standard_est_data):
+        standard_est_data['account_holder'] = 'person_a'
 
-        self.assertRaises(ValidationError, FormDataEst.parse_obj, est_data)
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-    def test_if_no_steuernummer_and_no_submission_without_tax_nr_set_then_raise_exception(self):
-        est_data = standard_est_data()
-        est_data.pop('steuernummer', None)
-        est_data.pop('submission_without_tax_nr', None)
+    def test_if_account_holder_person_b_then_raise_no_exception(self, standard_est_data):
+        standard_est_data['account_holder'] = 'person_b'
 
-        self.assertRaises(ValidationError, FormDataEst.parse_obj, est_data)
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-    def test_if_no_steuernummer_and_submission_without_tax_nr_false_then_raise_exception(self):
-        est_data = standard_est_data()
-        est_data.pop('steuernummer', None)
-        est_data['submission_without_tax_nr'] = False
 
-        self.assertRaises(ValidationError, FormDataEst.parse_obj, est_data)
+class TestFormDataEstNewAdmission:
 
-    def test_if_submission_without_tax_nr_and_no_bufa_nr_then_raise_exception(self):
-        est_data = standard_est_data()
-        est_data.pop('steuernummer', None)
-        est_data['submission_without_tax_nr'] = True
-        est_data.pop('bufa_nr', None)
+    def test_if_steuernummer_given_and_submission_without_tax_nr_set_then_raise_exception(self, standard_est_data):
+        standard_est_data['submission_without_tax_nr'] = True
 
-        self.assertRaises(ValidationError, FormDataEst.parse_obj, est_data)
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
 
-    def test_if_submission_without_tax_nr_and_bufa_nr_too_short_then_raise_exception(self):
-        est_data = standard_est_data()
-        est_data.pop('steuernummer', None)
-        est_data['submission_without_tax_nr'] = True
-        est_data['bufa_nr'] = '91'
+    def test_if_steuernummer_none_and_no_submission_without_tax_nr_set_then_raise_exception(self, standard_est_data):
+        standard_est_data['steuernummer'] = None
+        standard_est_data.pop('submission_without_tax_nr', None)
 
-        self.assertRaises(ValidationError, FormDataEst.parse_obj, est_data)
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
 
-    def test_if_submission_without_tax_nr_and_bufa_nr_then_raise_no_exception(self):
-        est_data = standard_est_data()
-        est_data.pop('steuernummer', None)
-        est_data['submission_without_tax_nr'] = True
-        est_data['bufa_nr'] = '9198'
+    def test_if_no_steuernummer_and_no_submission_without_tax_nr_set_then_raise_exception(self, standard_est_data):
+        standard_est_data.pop('steuernummer', None)
+        standard_est_data.pop('submission_without_tax_nr', None)
+
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
+
+    def test_if_no_steuernummer_and_submission_without_tax_nr_false_then_raise_exception(self, standard_est_data):
+        standard_est_data.pop('steuernummer', None)
+        standard_est_data['submission_without_tax_nr'] = False
+
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
+
+    def test_if_submission_without_tax_nr_and_no_bufa_nr_then_raise_exception(self, standard_est_data):
+        standard_est_data.pop('steuernummer', None)
+        standard_est_data['submission_without_tax_nr'] = True
+        standard_est_data.pop('bufa_nr', None)
+
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
+
+    def test_if_submission_without_tax_nr_and_bufa_nr_too_short_then_raise_exception(self, standard_est_data):
+        standard_est_data.pop('steuernummer', None)
+        standard_est_data['submission_without_tax_nr'] = True
+        standard_est_data['bufa_nr'] = '91'
+
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
+
+    def test_if_submission_without_tax_nr_and_bufa_nr_then_raise_no_exception(self, standard_est_data):
+        standard_est_data.pop('steuernummer', None)
+        standard_est_data['submission_without_tax_nr'] = True
+        standard_est_data['bufa_nr'] = '9198'
 
 
         try:
-            FormDataEst.parse_obj(est_data)
+            FormDataEst.parse_obj(standard_est_data)
         except ValidationError as e:
-            self.fail("parse_obj failed with unexpected ValidationError " + str(e))
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-    def test_if_steuernummer_given_and_no_submission_without_tax_nr_then_raise_no_exception(self):
-        est_data = standard_est_data()
-        est_data.pop('submission_without_tax_nr', None)
-        est_data.pop('bufa_nr', None)
+    def test_if_steuernummer_given_and_no_submission_without_tax_nr_then_raise_no_exception(self, standard_est_data):
+        standard_est_data.pop('submission_without_tax_nr', None)
+        standard_est_data.pop('bufa_nr', None)
 
         try:
-            FormDataEst.parse_obj(est_data)
+            FormDataEst.parse_obj(standard_est_data)
         except ValidationError as e:
-            self.fail("parse_obj failed with unexpected ValidationError " + str(e))
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-    def test_if_not_valid_bufa_then_raise_exception(self):
-        est_data = standard_est_data()
-        est_data.pop('steuernummer', None)
-        est_data['submission_without_tax_nr'] = True
-        est_data['bufa_nr'] = '1981'
+    def test_if_not_valid_bufa_then_raise_exception(self, standard_est_data):
+        standard_est_data.pop('steuernummer', None)
+        standard_est_data['submission_without_tax_nr'] = True
+        standard_est_data['bufa_nr'] = '1981'
 
         with patch('erica.request_processing.erica_input.is_valid_bufa', MagicMock(return_value=False)):
-            self.assertRaises(InvalidBufaNumberError, FormDataEst.parse_obj, est_data)
+            with pytest.raises(InvalidBufaNumberError):
+                FormDataEst.parse_obj(standard_est_data)
 
 
-class TestFormDataEstSteuernummer(unittest.TestCase):
+class TestFormDataEstSteuernummer:
 
-    def setUp(self) -> None:
-        self.est_data = standard_est_data()
+    def test_if_steuernummer_len_9_then_raise_exception(self, standard_est_data):
+        standard_est_data['steuernummer'] = '123456789'
 
-    def test_if_steuernummer_len_9_then_raise_exception(self):
-        self.est_data['steuernummer'] = '123456789'
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
 
-        self.assertRaises(ValidationError, FormDataEst.parse_obj, self.est_data)
+    def test_if_steuernummer_len_12_then_raise_exception(self, standard_est_data):
+        standard_est_data['steuernummer'] = '123456789012'
 
-    def test_if_steuernummer_len_12_then_raise_exception(self):
-        self.est_data['steuernummer'] = '123456789012'
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
 
-        self.assertRaises(ValidationError, FormDataEst.parse_obj, self.est_data)
-
-    def test_if_steuernummer_len_10_then_raise_no_exception(self):
-        self.est_data['steuernummer'] = '1234567890'
-
-        try:
-            FormDataEst.parse_obj(self.est_data)
-        except ValidationError as e:
-            self.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_steuernummer_len_11_then_raise_no_exception(self):
-        self.est_data['steuernummer'] = '12345678901'
+    def test_if_steuernummer_len_10_then_raise_no_exception(self, standard_est_data):
+        standard_est_data['steuernummer'] = '1234567890'
 
         try:
-            FormDataEst.parse_obj(self.est_data)
+            FormDataEst.parse_obj(standard_est_data)
         except ValidationError as e:
-            self.fail("parse_obj failed with unexpected ValidationError " + str(e))
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-
-class TestFormDataEstFamilienstand(unittest.TestCase):
-
-    def setUp(self) -> None:
-        self.est_data = standard_est_data()
-
-    def test_if_married_lived_separated_and_no_corresponding_date_then_raise_exception(self):
-        self.est_data['familienstand_married_lived_separated'] = True
-        self.est_data.pop('familienstand_married_lived_separated_since', None)
-
-        self.assertRaises(ValidationError, FormDataEst.parse_obj, self.est_data)
-
-    def test_if_married_lived_separated_and_corresponding_date_then_raise_no_exception(self):
-        self.est_data['familienstand_married_lived_separated'] = True
-        self.est_data['familienstand_married_lived_separated_since'] = date(1950, 8, 16)
+    def test_if_steuernummer_len_11_then_raise_no_exception(self, standard_est_data):
+        standard_est_data['steuernummer'] = '12345678901'
 
         try:
-            FormDataEst.parse_obj(self.est_data)
+            FormDataEst.parse_obj(standard_est_data)
         except ValidationError as e:
-            self.fail("parse_obj failed with unexpected ValidationError " + str(e))
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-    def test_if_widowed_lived_separated_and_no_corresponding_date_then_raise_exception(self):
-        self.est_data['familienstand_widowed_lived_separated'] = True
-        self.est_data.pop('familienstand_widowed_lived_separated_since', None)
 
-        self.assertRaises(ValidationError, FormDataEst.parse_obj, self.est_data)
+class TestFormDataEstFamilienstand:
 
-    def test_if_widowed_lived_separated_and_corresponding_date_then_raise_no_exception(self):
-        self.est_data['familienstand_widowed_lived_separated'] = True
-        self.est_data['familienstand_widowed_lived_separated_since'] = date(1950, 8, 16)
+    def test_if_married_lived_separated_and_no_corresponding_date_then_raise_exception(self, standard_est_data):
+        standard_est_data['familienstand_married_lived_separated'] = True
+        standard_est_data.pop('familienstand_married_lived_separated_since', None)
+
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
+
+    def test_if_married_lived_separated_and_corresponding_date_then_raise_no_exception(self, standard_est_data):
+        standard_est_data['familienstand_married_lived_separated'] = True
+        standard_est_data['familienstand_married_lived_separated_since'] = date(1950, 8, 16)
 
         try:
-            FormDataEst.parse_obj(self.est_data)
+            FormDataEst.parse_obj(standard_est_data)
         except ValidationError as e:
-            self.fail("parse_obj failed with unexpected ValidationError " + str(e))
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_widowed_lived_separated_and_no_corresponding_date_then_raise_exception(self, standard_est_data):
+        standard_est_data['familienstand_widowed_lived_separated'] = True
+        standard_est_data.pop('familienstand_widowed_lived_separated_since', None)
+
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
+
+    def test_if_widowed_lived_separated_and_corresponding_date_then_raise_no_exception(self, standard_est_data):
+        standard_est_data['familienstand_widowed_lived_separated'] = True
+        standard_est_data['familienstand_widowed_lived_separated_since'] = date(1950, 8, 16)
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
 
-class TestMetaDataEstDigitallySigned(unittest.TestCase):
+class TestMetaDataEstDigitallySigned:
 
     def test_if_not_digitally_signed_raise_exception(self):
         meta_data = {
@@ -206,7 +229,8 @@ class TestMetaDataEstDigitallySigned(unittest.TestCase):
             'is_digitally_signed': False
         }
 
-        self.assertRaises(ValidationError, MetaDataEst.parse_obj, meta_data)
+        with pytest.raises(ValidationError):
+            MetaDataEst.parse_obj(meta_data)
 
     def test_if_digitally_signed_raise_no_exception(self):
         meta_data = {
@@ -217,5 +241,5 @@ class TestMetaDataEstDigitallySigned(unittest.TestCase):
         try:
             MetaDataEst.parse_obj(meta_data)
         except ValidationError as e:
-            self.fail("parse_obj failed with unexpected ValidationError " + str(e))
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 

--- a/erica_app/tests/utils.py
+++ b/erica_app/tests/utils.py
@@ -79,7 +79,7 @@ def create_form_data(correct=True, with_tax_number=True):
             person_b_gehbeh=False,
 
             iban='DE35133713370000012345',
-            is_person_a_account_holder=True,
+            account_holder='person_a',
 
             steuerminderung=True,
 
@@ -99,7 +99,7 @@ def create_form_data(correct=True, with_tax_number=True):
             submission_without_tax_nr= False if not with_tax_number else None,
             bufa_nr='9198' if not with_tax_number else None,
             iban="DE35133713370000012345",
-            is_person_a_account_holder=True,
+            account_holder='person_a',
             familienstand="single",
             person_a_idnr="09952417688",
             person_a_dob="1999-12-14",
@@ -142,7 +142,7 @@ def create_form_data_single(correct=True, with_tax_number=True):
             person_a_gehbeh=False,
 
             iban='DE35133713370000012345',
-            is_person_a_account_holder=True,
+            account_holder='person_a',
             steuerminderung=False,
 
             confirm_complete_correct=True,

--- a/webapp/app/elster_client/elster_client.py
+++ b/webapp/app/elster_client/elster_client.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 _PYERIC_API_BASE_URL = Config.ERICA_BASE_URL
 
 _BOOL_KEYS = ['familienstand_married_lived_separated', 'familienstand_widowed_lived_separated',
-              'is_person_a_account_holder', 'person_a_blind', 'person_a_gehbeh',
+              'person_a_blind', 'person_a_gehbeh',
               'person_b_same_address', 'person_b_blind', 'person_b_gehbeh', 'steuerminderung',
               'is_digitally_signed', 'request_new_tax_number', 'steuernummer_exists']
 _DECIMAL_KEYS = ['stmind_haushaltsnahe_summe', 'stmind_handwerker_summe', 'stmind_handwerker_lohn_etc_summe',
@@ -179,6 +179,9 @@ def _generate_est_request_data(form_data, year=2020):
     :param year: The year in which the taxes are declared
     """
     adapted_form_data = form_data.copy()
+
+    if adapted_form_data.pop('is_user_account_holder', None):
+        adapted_form_data['account_holder'] = 'person_a'
 
     for key in list(set(_BOOL_KEYS) & set(adapted_form_data.keys())):
         if isinstance(adapted_form_data[key], str):

--- a/webapp/app/forms/flows/lotse_flow.py
+++ b/webapp/app/forms/flows/lotse_flow.py
@@ -77,7 +77,8 @@ class LotseMultiStepFlow(MultiStepFlow):
             'person_b_blind': False,
             'person_b_gehbeh': False,
 
-            'is_person_a_account_holder': 'yes',
+            #'is_user_account_holder': 'yes', use for single user
+            'account_holder': 'person_a',
             'iban': 'DE35133713370000012345',
 
             'steuerminderung': 'yes',
@@ -250,7 +251,9 @@ class LotseMultiStepFlow(MultiStepFlow):
         elif isinstance(step, StepFamilienstand):
             if request.method == 'POST' and render_info.form.validate():
                 if not show_person_b(stored_data):
-                    stored_data = self._delete_dependent_data(['person_b', 'is_person_a_account_holder'], stored_data)
+                    stored_data = self._delete_dependent_data(['person_b', 'account_holder'], stored_data)
+                else:
+                    stored_data = self._delete_dependent_data(['is_user_account_holder'], stored_data)
                 if stored_data['familienstand'] == 'single':
                     stored_data = self._delete_dependent_data(['familienstand_date'], stored_data)
                 if stored_data['familienstand'] == 'married':

--- a/webapp/app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py
+++ b/webapp/app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py
@@ -411,11 +411,11 @@ class StepIban(FormStep):
     section_link = SectionLink('mandatory_data', StepFamilienstand.name, _l('form.lotse.mandatory_data.label'))
 
     class Form(SteuerlotseBaseForm):
-        is_person_a_account_holder = RadioField(
+        account_holder = RadioField(
             label=_l('form.lotse.field_is_person_a_account_holder'),
             render_kw={'data_label': _l('form.lotse.field_is_person_a_account_holder.data_label')},
-            choices=[('yes', _l('form.lotse.field_is_person_a_account_holder-person-a')),
-                     ('no', _l('form.lotse.field_is_person_a_account_holder-person-b')),
+            choices=[('person_a', _l('form.lotse.field_is_person_a_account_holder-person-a')),
+                     ('person_b', _l('form.lotse.field_is_person_a_account_holder-person-b')),
                      ])
         iban = SteuerlotseIbanField(
             label=_l('form.lotse.field_iban'),
@@ -426,7 +426,7 @@ class StepIban(FormStep):
             filters=[lambda value: value.replace(' ', '') if value else value])
 
     class FormSingle(SteuerlotseBaseForm):
-        is_person_a_account_holder = ConfirmationField(
+        is_user_account_holder = ConfirmationField(
             label=_l('form.lotse.field_is_person_a_account_holder_single'),
             render_kw={'data_label': _l('form.lotse.field_is_person_a_account_holder_single.data_label')})
         iban = SteuerlotseIbanField(

--- a/webapp/tests/elster_client/mock_erica.py
+++ b/webapp/tests/elster_client/mock_erica.py
@@ -13,7 +13,7 @@ _REQUIRED_FORM_KEYS_WITH_STEUERNUMMER = ["steuernummer", "bundesland", "familien
                                          "person_a_last_name", "person_a_first_name", "person_a_religion",
                                          "person_a_street", "person_a_street_number", "person_a_plz", "person_a_town",
                                          "person_a_blind", "steuerminderung",
-                                         "is_person_a_account_holder"]
+                                         "account_holder"]
 _REQUIRED_FORM_KEYS_WITHOUT_STEUERNUMMER = ["submission_without_tax_nr", "bufa_nr", "bundesland", "familienstand",
                                             "person_a_idnr", "person_a_dob", "person_a_last_name",
                                             "person_a_first_name", "person_a_religion", "person_a_street",

--- a/webapp/tests/forms/flows/test_lotse_flow.py
+++ b/webapp/tests/forms/flows/test_lotse_flow.py
@@ -989,7 +989,7 @@ class TestLotseHandleSpecificsForStep(unittest.TestCase):
                            'person_b_religion', 'person_b_street', 'person_b_street_number', 'person_b_idnr',
                            'person_b_street_number_ext', 'person_b_address_ext', 'person_b_plz',
                            'person_b_town', 'person_b_beh_grad', 'person_b_blind', 'person_b_gehbeh',
-                           'is_person_a_account_holder']
+                           'account_holder']
         with self.app.test_request_context(method='POST',
                                            data={'familienstand': 'married',
                                                  'familienstand_date': '1985-01-01'}):
@@ -998,7 +998,7 @@ class TestLotseHandleSpecificsForStep(unittest.TestCase):
                 copy.deepcopy(LotseMultiStepFlow._DEBUG_DATA[1]))
 
             self.assertIn('person_b_idnr', returned_data)
-            self.assertIn('is_person_a_account_holder', returned_data)
+            self.assertIn('account_holder', returned_data)
 
         with self.app.test_request_context(method='POST',
                                            data={'familienstand': 'single'}):
@@ -1341,8 +1341,8 @@ class TestLotseGetOverviewData(unittest.TestCase):
                             StepIban.label,
                             flow.url_for_step(StepIban.name, _has_link_overview=True),
                             {str(debug_data['iban']): debug_data['iban'],
-                                str(debug_data['is_person_a_account_holder']): debug_data[
-                                    'is_person_a_account_holder']}
+                                str(debug_data['account_holder']): debug_data[
+                                    'account_holder']}
                         )
                 }
             ),
@@ -1377,7 +1377,7 @@ class TestLotseGetOverviewData(unittest.TestCase):
         flow = LotseMultiStepFlow(endpoint='lotse')
         flow.steps = {s.name: s for s in [StepIban, StepHaushaltsnaheHandwerker, StepAck]}
         debug_data = copy.deepcopy(flow.default_data()[1])
-        missing_fields = ['iban', 'is_person_a_account_holder']
+        missing_fields = ['iban', 'account_holder']
         for missing_field in missing_fields:
             debug_data.pop(missing_field)
         mandatory_data_missing_value = _l('form.lotse.missing_mandatory_field')
@@ -1466,7 +1466,7 @@ class TestLotseValidateInput(unittest.TestCase):
             'person_a_blind': True,
             'person_a_gehbeh': True,
 
-            'is_person_a_account_holder': 'yes',
+            'is_user_account_holder': 'yes',
             'iban': 'DE35133713370000012345',
 
             'steuerminderung': 'yes', }
@@ -1552,6 +1552,7 @@ class TestLotseValidateInput(unittest.TestCase):
                         'confirm_data_privacy': True,
                         'confirm_complete_correct': True,
                         'confirm_terms_of_service': True,
+                        'account_holder': 'person_b'
                         }}
 
         try:
@@ -1647,7 +1648,7 @@ class TestLotseValidateInput(unittest.TestCase):
         expected_missing_fields = ['steuernummer_exists', 'bundesland', 'bufa_nr', 'request_new_tax_number', 'familienstand', 'person_a_dob',
                                    'person_a_last_name', 'person_a_first_name', 'person_a_religion', 'person_a_street',
                                    'person_a_street_number', 'person_a_plz', 'person_a_town', 'person_a_blind',
-                                   'person_a_gehbeh', 'steuerminderung', 'iban', 'is_person_a_account_holder', ]
+                                   'person_a_gehbeh', 'steuerminderung', 'iban', 'is_user_account_holder', ]
         existing_idnr = '04452397610'
         self._create_logged_in_user(existing_idnr)
         form_data = {'person_a_idnr': existing_idnr,

--- a/webapp/tests/model/test_form_data.py
+++ b/webapp/tests/model/test_form_data.py
@@ -127,7 +127,6 @@ class TestMandatoryFormData(unittest.TestCase):
             'person_a_blind': True,
             'person_a_gehbeh': True,
 
-            'is_person_a_account_holder': 'yes',
             'iban': 'DE35133713370000012345',
 
             'steuerminderung': 'yes',
@@ -142,6 +141,7 @@ class TestMandatoryFormData(unittest.TestCase):
             'person_b_religion': 'rk',
             'person_b_blind': False,
             'person_b_gehbeh': False,
+            'account_holder': 'person_a'
         }
 
         self.valid_steuernummer = {
@@ -208,11 +208,11 @@ class TestMandatoryFormData(unittest.TestCase):
 
     def test_if_show_person_b_false_then_raise_no_error_if_person_b_fields_missing(self):
         with patch('app.model.form_data.FamilienstandModel.show_person_b', MagicMock(return_value=False)):
-            MandatoryFormData.parse_obj({**self.valid_data_person_a, **self.married_familienstand, **self.valid_steuernummer})
+            MandatoryFormData.parse_obj({**self.valid_data_person_a, **self.married_familienstand, **self.valid_steuernummer, **{'is_user_account_holder': 'yes'}})
 
     def test_if_show_person_b_true_then_raise_error_if_person_b_fields_missing(self):
         expected_missing_fields = ['person_b_same_address', 'person_b_idnr', 'person_b_dob', 'person_b_last_name',
-                                   'person_b_first_name', 'person_b_religion', 'person_b_blind', 'person_b_gehbeh']
+                                   'person_b_first_name', 'person_b_religion', 'person_b_blind', 'person_b_gehbeh', 'account_holder']
         with patch('app.model.form_data.FamilienstandModel.show_person_b', MagicMock(return_value=True)):
             with self.assertRaises(ValidationError) as validation_error:
                 MandatoryFormData.parse_obj({**self.valid_data_person_a, **self.valid_steuernummer, **self.married_familienstand})


### PR DESCRIPTION
# Short Description
We had a bug that would remove the selection of the account holder on StepIban whenever the StepFamilienstand got a post. That was because for a single user we delete all person b fields and the account holder field was named the same for single and multiple users. This changes that and does some refactoring

# Changes
- Rename the account holder selection (`is_user_account_holder` for single users and `account_holder`for multiple users)
- Delete `is_user_account_holder` on StepFamilienstand for Zusammenveranlagung and `account_holder` if it is a single user
- Adapt the selections for multiple users -> 'person_a' and 'person_b' instead of yes and no
- Adapt Erica to receive `account_holder` with 'person_a' and 'person_b' instead of a boolean `is_person_a_account_holder` (as this PR changes the webapp,
- Are there any additional changes (e. g. refactoring) that are part of this pull request?

# Feedback
- Do you see any missing tests?
- Do you see anything else?
