### PR TITLE
Js disabled error page will not be displayed for specific static pages

### DIFF
--- a/webapp/app/routes.py
+++ b/webapp/app/routes.py
@@ -143,7 +143,8 @@ def register_request_handlers(app):
         if current_user.is_authenticated:
             return render_template('unlock_code/already_logged_in.html',
                                    title=_('unlock_code_request.logged_in.title'),
-                                   intro=_('unlock_code_request.logged_in.intro'))
+                                   intro=_('unlock_code_request.logged_in.intro'),
+                                   js_needed=False)
 
         flow = UnlockCodeRequestMultiStepFlow(endpoint='unlock_code_request')
         return flow.handle(step_name=step)
@@ -170,7 +171,8 @@ def register_request_handlers(app):
         if current_user.is_authenticated:
             return render_template('unlock_code/already_logged_in.html',
                                    title=_('unlock_code_revocation.logged_in.title'),
-                                   intro=_('unlock_code_revocation.logged_in.intro'))
+                                   intro=_('unlock_code_revocation.logged_in.intro'),
+                                   js_needed=False)
 
         flow = UnlockCodeRevocationMultiStepFlow(endpoint='unlock_code_revocation')
         return flow.handle(step_name=step)
@@ -181,7 +183,9 @@ def register_request_handlers(app):
     @limiter.limit('1000 per day')
     def download_pdf():
         if not current_user.has_completed_tax_return():
-            return render_template('error/pdf_not_found.html', header_title=_('404.header-title')), 404
+            return render_template('error/pdf_not_found.html',
+                                   header_title=_('404.header-title'),
+                                   js_needed=False), 404
 
         pdf_file = base64.b64decode(current_user.pdf)
         return send_file(io.BytesIO(pdf_file), mimetype='application/pdf',
@@ -199,52 +203,67 @@ def register_request_handlers(app):
     @app.route('/')
     @add_caching_headers
     def index():
-        return render_template('content/landing_page.html', header_title=_('page.title'))
+        return render_template('content/landing_page.html',
+                               header_title=_('page.title'),
+                               js_needed=False)
 
     @app.route('/sofunktionierts')
     @add_caching_headers
     def howitworks():
-        return render_template('content/howitworks.html', header_title=_('howitworks.header-title'))
+        return render_template('content/howitworks.html',
+                               header_title=_('howitworks.header-title'),
+                               js_needed=False)
 
     @app.route('/kontakt')
     @add_caching_headers
     def contact():
-        return render_template('content/contact.html', header_title=_('contact.header-title'))
+        return render_template('content/contact.html',
+                               header_title=_('contact.header-title'),
+                               js_needed=False)
 
     @app.route('/impressum')
     @add_caching_headers
     def imprint():
-        return render_template('content/imprint.html', header_title=_('imprint.header-title'))
+        return render_template('content/imprint.html',
+                               header_title=_('imprint.header-title'),
+                               js_needed=False)
 
     @app.route('/barrierefreiheit')
     @add_caching_headers
     def barrierefreiheit():
-        return render_template('content/barrierefreiheit.html', header_title=_('barrierefreiheit.header-title'))
+        return render_template('content/barrierefreiheit.html',
+                               header_title=_('barrierefreiheit.header-title'),
+                               js_needed=False)
 
     @app.route('/datenschutz')
     @add_caching_headers
     def data_privacy():
-        return render_template('content/data_privacy.html', header_title=_('data_privacy.header-title'))
+        return render_template('content/data_privacy.html',
+                               header_title=_('data_privacy.header-title'),
+                               js_needed=False)
 
     @app.route('/agb')
     @add_caching_headers
     def agb():
-        return render_template('content/agb.html', header_title=_('agb.header-title'))
+        return render_template('content/agb.html',
+                               header_title=_('agb.header-title'),
+                               js_needed=False)
 
     @app.route('/interviews')
     @add_caching_headers
     def interviews():
-        return render_template('content/interviews.html')
+        return render_template('content/interviews.html',
+                               js_needed=False)
 
     @app.route('/ueber')
     @add_caching_headers
     def about_steuerlotse():
-        return render_template('content/about_steuerlotse.html', header_title=_('about.header-title'))
+        return render_template('content/about_steuerlotse.html', header_title=_('about.header-title'), js_needed=False)
 
     @app.route('/digitalservice')
     @add_caching_headers
     def about_digitalservice():
-        return render_template('content/about_digitalservice.html', header_title=_('about_digitalservice.header-title'))
+        return render_template('content/about_digitalservice.html', header_title=_('about_digitalservice.header-title'), js_needed=False)
 
     @app.route('/download_preparation', methods=['GET'])
     @limiter.limit('15 per minute')
@@ -265,25 +284,26 @@ def register_error_handlers(app):
     @app.errorhandler(GeneralEricaError)
     def error_erica(error):
         current_app.logger.exception('A general erica error occurred')
-        return render_template('error/erica_error.html', header_title=_('erica-error.header-title')), 500
+        return render_template('error/erica_error.html', header_title=_('erica-error.header-title'), js_needed=False), 500
 
     @app.errorhandler(400)
     def error_400(error):
-        return render_template('error/400.html', header_title=_('400.header-title')), 400
+        return render_template('error/400.html', header_title=_('400.header-title'), js_needed=False), 400
 
     @app.errorhandler(404)
     def error_404(error):
-        return render_template('error/404.html', header_title=_('404.header-title')), 404
+        return render_template('error/404.html', header_title=_('404.header-title'), js_needed=False), 404
 
     @app.errorhandler(IncorrectEligibilityData)
     def handle_incorrect_eligibility_data(error):
-        return render_template('error/incorrect_eligiblity_data.html', header_title=_('400.header-title')), 400
+        return render_template('error/incorrect_eligiblity_data.html', header_title=_('400.header-title'), js_needed=False), 400
 
     @app.errorhandler(429)
     def error_429(error):
-        return render_template('error/429.html', header_title=_('429.header-title')), 429
+        return render_template('error/429.html', header_title=_('429.header-title'), js_needed=False), 429
 
     @app.errorhandler(InternalServerError)
     def error_500(error):
-        current_app.logger.error('An uncaught error occurred', exc_info=error.original_exception)
-        return render_template('error/500.html', header_title=_('500.header-title')), 500
+        current_app.logger.error(
+            'An uncaught error occurred', exc_info=error.original_exception)
+        return render_template('error/500.html', header_title=_('500.header-title'), js_needed=False), 500

--- a/webapp/app/templates/basis/base.html
+++ b/webapp/app/templates/basis/base.html
@@ -45,7 +45,7 @@
         {% include 'basis/mobile_nav.html' %}
         {% include 'basis/sidebar.html' %}
         <main id="main" class="main">
-            {% block js_required %}
+            {% if js_needed is not defined or js_needed %}
                 <noscript>
                     {% include 'error/js_disabled.html' %}
 
@@ -54,7 +54,7 @@
                             #main_content { display: none!important; }
                     </style>
                 </noscript>
-            {% endblock %}
+            {% endif %}
             <div id="main_content" class="container-fluid p-0 d-flex flex-column min-vh-100">
                 {% block flashed_messages %}
                     {% for category, message in get_flashed_messages(with_categories=True) %}

--- a/webapp/app/templates/basis/base.html
+++ b/webapp/app/templates/basis/base.html
@@ -45,14 +45,16 @@
         {% include 'basis/mobile_nav.html' %}
         {% include 'basis/sidebar.html' %}
         <main id="main" class="main">
-            <noscript>
-                {% include 'error/js_disabled.html' %}
+            {% block js_required %}
+                <noscript>
+                    {% include 'error/js_disabled.html' %}
 
-                <!-- If javascript is disabled, the main_content container is hidden. -->
-                <style type="text/css">
-                        #main_content { display: none!important; }
-                </style>
-            </noscript>
+                    <!-- If javascript is disabled, the main_content container is hidden. -->
+                    <style type="text/css">
+                            #main_content { display: none!important; }
+                    </style>
+                </noscript>
+            {% endblock %}
             <div id="main_content" class="container-fluid p-0 d-flex flex-column min-vh-100">
                 {% block flashed_messages %}
                     {% for category, message in get_flashed_messages(with_categories=True) %}

--- a/webapp/app/templates/content/about_digitalservice.html
+++ b/webapp/app/templates/content/about_digitalservice.html
@@ -9,7 +9,3 @@
         <p class="mt-3 pb-2">{{ _('about_digitalservice.aim-text') }}</p>
     </div>
 {% endblock %}
-
-<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
-{% block js_required %}
-{% endblock %}

--- a/webapp/app/templates/content/about_digitalservice.html
+++ b/webapp/app/templates/content/about_digitalservice.html
@@ -9,3 +9,7 @@
         <p class="mt-3 pb-2">{{ _('about_digitalservice.aim-text') }}</p>
     </div>
 {% endblock %}
+
+<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
+{% block js_required %}
+{% endblock %}

--- a/webapp/app/templates/content/about_steuerlotse.html
+++ b/webapp/app/templates/content/about_steuerlotse.html
@@ -28,7 +28,3 @@
         <p class="mt-3 pb-2">{{ _('about_digitalservice.creation-text') }}</p>
     </div>
 {% endblock %}
-
-<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
-{% block js_required %}
-{% endblock %}

--- a/webapp/app/templates/content/about_steuerlotse.html
+++ b/webapp/app/templates/content/about_steuerlotse.html
@@ -28,3 +28,7 @@
         <p class="mt-3 pb-2">{{ _('about_digitalservice.creation-text') }}</p>
     </div>
 {% endblock %}
+
+<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
+{% block js_required %}
+{% endblock %}

--- a/webapp/app/templates/content/agb.html
+++ b/webapp/app/templates/content/agb.html
@@ -123,7 +123,3 @@
         <p class="mb-2">{{ _('agb.schlussbestimmungen-p11') }}</p>
     </div>
 {% endblock %}
-
-<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
-{% block js_required %}
-{% endblock %}

--- a/webapp/app/templates/content/agb.html
+++ b/webapp/app/templates/content/agb.html
@@ -123,3 +123,7 @@
         <p class="mb-2">{{ _('agb.schlussbestimmungen-p11') }}</p>
     </div>
 {% endblock %}
+
+<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
+{% block js_required %}
+{% endblock %}

--- a/webapp/app/templates/content/barrierefreiheit.html
+++ b/webapp/app/templates/content/barrierefreiheit.html
@@ -30,7 +30,3 @@
         <p class="mt-3 pb-2">{{ _('accessibility.conciliation-text-p6') }}</p>
     </div>
 {% endblock %}
-
-<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
-{% block js_required %}
-{% endblock %}

--- a/webapp/app/templates/content/barrierefreiheit.html
+++ b/webapp/app/templates/content/barrierefreiheit.html
@@ -30,3 +30,7 @@
         <p class="mt-3 pb-2">{{ _('accessibility.conciliation-text-p6') }}</p>
     </div>
 {% endblock %}
+
+<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
+{% block js_required %}
+{% endblock %}

--- a/webapp/app/templates/content/contact.html
+++ b/webapp/app/templates/content/contact.html
@@ -24,3 +24,7 @@
         <p class="mt-2">{{ _('contact.security-text') }}</p>
     </div>
 {% endblock %}
+
+<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
+{% block js_required %}
+{% endblock %}

--- a/webapp/app/templates/content/contact.html
+++ b/webapp/app/templates/content/contact.html
@@ -24,7 +24,3 @@
         <p class="mt-2">{{ _('contact.security-text') }}</p>
     </div>
 {% endblock %}
-
-<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
-{% block js_required %}
-{% endblock %}

--- a/webapp/app/templates/content/data_privacy.html
+++ b/webapp/app/templates/content/data_privacy.html
@@ -86,3 +86,7 @@
         </div>
     </div>
 {% endblock %}
+
+<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
+{% block js_required %}
+{% endblock %}

--- a/webapp/app/templates/content/data_privacy.html
+++ b/webapp/app/templates/content/data_privacy.html
@@ -86,7 +86,3 @@
         </div>
     </div>
 {% endblock %}
-
-<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
-{% block js_required %}
-{% endblock %}

--- a/webapp/app/templates/content/howitworks.html
+++ b/webapp/app/templates/content/howitworks.html
@@ -234,3 +234,8 @@
         </div>
     </div>
 {% endblock %}
+
+
+<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
+{% block js_required %}
+{% endblock %}

--- a/webapp/app/templates/content/howitworks.html
+++ b/webapp/app/templates/content/howitworks.html
@@ -234,8 +234,3 @@
         </div>
     </div>
 {% endblock %}
-
-
-<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
-{% block js_required %}
-{% endblock %}

--- a/webapp/app/templates/content/landing_page.html
+++ b/webapp/app/templates/content/landing_page.html
@@ -121,7 +121,3 @@
         </div>
     </div>
 {% endblock %}
-
-<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
-{% block js_required %}
-{% endblock %}

--- a/webapp/app/templates/content/landing_page.html
+++ b/webapp/app/templates/content/landing_page.html
@@ -48,7 +48,6 @@
 
 {% set accordeons = [accordeon_home] %}
 
-
 {% block main_content %}
     <div class="main-content-home">
         <div class="container-fluid p-0">
@@ -121,4 +120,8 @@
             </div>
         </div>
     </div>
+{% endblock %}
+
+<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
+{% block js_required %}
 {% endblock %}

--- a/webapp/app/templates/error/js_disabled.html
+++ b/webapp/app/templates/error/js_disabled.html
@@ -1,4 +1,4 @@
-<div class="js-disabled-container main-content pt-5">
+<div class="js-disabled-container main-content pt-5 h-100">
     <h1 class="pt-5">{{ _('js_disabled.headline') }}</h1>
     <p class="mt-3 col-9 pl-0">
         {{ _('js_disabled.info-text') }}
@@ -7,3 +7,5 @@
         {{ _('js_disabled.info-link') }}
     </p>
 </div>
+
+{% include 'basis/footer.html' %}

--- a/webapp/app/templates/error/pdf_not_found.html
+++ b/webapp/app/templates/error/pdf_not_found.html
@@ -21,3 +21,7 @@
     <p>{{ _('pdf_not_found.reasons.not_activated.intro') }}</p>
     {{ components.primaryButton( text=_('login.input-code'), url=url_for('unlock_code_activation', step='data_input')) }}
 {% endblock %}
+
+<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
+{% block js_required %}
+{% endblock %}

--- a/webapp/app/templates/error/pdf_not_found.html
+++ b/webapp/app/templates/error/pdf_not_found.html
@@ -21,7 +21,3 @@
     <p>{{ _('pdf_not_found.reasons.not_activated.intro') }}</p>
     {{ components.primaryButton( text=_('login.input-code'), url=url_for('unlock_code_activation', step='data_input')) }}
 {% endblock %}
-
-<!-- Override "js_required" block in the base.html - javascript is not required for this page -->
-{% block js_required %}
-{% endblock %}

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -4992,7 +4992,7 @@ msgstr ""
 #: app/templates/error/js_disabled.html:7
 msgid "js_disabled.info-link"
 msgstr ""
-"Wie Sie Javascrip aktivieren können, erfahren Sie zum Beispiel "
+"Wie Sie JavaScript aktivieren können, erfahren Sie zum Beispiel "
 "hier:<br><a class=\"font-weight-bold\" "
 "href=\"http://www.enablejavascript.io\" "
 "target=\"_blank\">enablejavascript.io</a>"


### PR DESCRIPTION
# Short Description
- Carolyn noted a typo in QA and wished that certain static pages did not display the error message with JavaScript.

# Changes
- Correct the js disabled text message from Javascrip -> JavaScript
- Wrapped js_disabled with a block
- Every static page (where JS is not needed) overrides the js_disabled block in the base.html

# Feedback
- Do you think, the JS check should be checked on every page by default? 
- Is it a good solution if a page doesn't need JavaScript that it then overwrites the parent js_disabled block with an empty block? (I tried namespace to store a variable and propagate it to the parent template, but that didn't work)
