### PR TITLE
Set tax office choices directly on the form

### DIFF
--- a/webapp/app/forms/steps/lotse/personal_data.py
+++ b/webapp/app/forms/steps/lotse/personal_data.py
@@ -100,6 +100,16 @@ class StepSteuernummer(LotseFormSteuerlotseStep):
             label=_l('form.lotse.steuernummer.request_new_tax_number'),
             render_kw={'data_label': _l('form.lotse.steuernummer.request_new_tax_number.data_label')})
 
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            tax_offices = request_tax_offices()
+            self.tax_offices = tax_offices
+            choices = []
+            for county in tax_offices:
+                choices += [(tax_office.get('bufa_nr'), tax_office.get('name')) for tax_office in
+                            county.get('tax_offices')]
+            self.bufa_nr.choices = choices
+
         def validate_bundesland(form, field):
             if form.steuernummer_exists.data == 'yes' or form.steuernummer_exists.data == 'no':
                 validators.InputRequired()(form, field)
@@ -139,19 +149,8 @@ class StepSteuernummer(LotseFormSteuerlotseStep):
             return all_fields_are_valid
 
     def _pre_handle(self):
-        tax_offices = request_tax_offices()
-
-        # Set bufa choices here because WTForms will otherwise not accept choices because they are invalid
-        self._set_bufa_choices(tax_offices)
         self._set_multiple_texts()
         super()._pre_handle()
-        self.render_info.additional_info['tax_offices'] = tax_offices
-
-    def _set_bufa_choices(self, tax_offices):
-        choices = []
-        for county in tax_offices:
-            choices += [(tax_office.get('bufa_nr'), tax_office.get('name')) for tax_office in county.get('tax_offices')]
-        self.render_info.form.bufa_nr.choices = choices
 
     def _set_multiple_texts(self):
         num_of_users = 2 if show_person_b(self.stored_data) else 1

--- a/webapp/app/templates/lotse/form_steuernummer.html
+++ b/webapp/app/templates/lotse/form_steuernummer.html
@@ -30,7 +30,7 @@
     {{ super() }}
     <script src="{{ url_for('static', filename='js/field_utils.js') }}" type=text/javascript></script>
     <script>
-        const taxOffices = JSON.parse('{{ render_info.additional_info['tax_offices']|tojson }}');
+        const taxOffices = JSON.parse('{{ form.tax_offices|tojson }}');
         const TAX_NUMBER_FORM_STATES = {
             'NothingSelected': 'NothingSelected',
             'StateSelectionTaxNumberExists': 'StateSelectionTaxNumberExists',

--- a/webapp/tests/forms/steps/lotse/test_personal_data_steps.py
+++ b/webapp/tests/forms/steps/lotse/test_personal_data_steps.py
@@ -19,9 +19,6 @@ class SummaryStep:
 
 def new_step_with_bufa_choices(form_data):
     step = LotseStepChooser().get_correct_step(StepSteuernummer.name, True, ImmutableMultiDict(form_data))
-    tax_offices = request_tax_offices()
-    step._set_bufa_choices(tax_offices)
-
     return step
 
 

--- a/webapp/tests/forms/steps/lotse/test_personal_data_steps.py
+++ b/webapp/tests/forms/steps/lotse/test_personal_data_steps.py
@@ -1,5 +1,5 @@
 import datetime
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 from flask.sessions import SecureCookieSession
@@ -127,6 +127,48 @@ class TestStepSteuernummer:
 
         assert expected_steuernummer_exists_label == step.render_info.form.steuernummer_exists.label.text
         assert expected_request_new_tax_number_label == step.render_info.form.request_new_tax_number.label.text
+
+
+class TestStepSteuernummerInputFormInit:
+
+    def test_if_init_called_then_set_tax_offices_attribute_correctly(self):
+        expected_tax_offices = [
+            {"state_abbreviation": "vu",
+             "name": "Vulcan",
+             "tax_offices": [{"name": "Finanzamt Ni'Var", "bufa_nr": "2801"}]
+             },
+            {"state_abbreviation": "tr",
+             "name": "Terra",
+             "tax_offices": [{"name": "Finanzamt Klingon Arbeitnehmerbereich (101)", "bufa_nr": "9101"},
+                             {"name": "Finanzamt Klingon Arbeitgeberbereich (102)", "bufa_nr": "9102"}]
+             }
+        ]
+
+        with patch('app.forms.steps.lotse.personal_data.request_tax_offices', MagicMock(return_value=expected_tax_offices)):
+            created_form = StepSteuernummer.InputForm()
+
+        assert created_form.tax_offices == expected_tax_offices
+
+    def test_if_init_called_then_set_bufa_nr_choices_correctly(self):
+        tax_offices = [
+            {"state_abbreviation": "vu",
+             "name": "Vulcan",
+             "tax_offices": [{"name": "Finanzamt Ni'Var", "bufa_nr": "2801"}]
+             },
+            {"state_abbreviation": "tr",
+             "name": "Terra",
+             "tax_offices": [{"name": "Finanzamt Klingon Arbeitnehmerbereich (101)", "bufa_nr": "9101"},
+                             {"name": "Finanzamt Klingon Arbeitgeberbereich (102)", "bufa_nr": "9102"}]
+             }
+        ]
+
+        with patch('app.forms.steps.lotse.personal_data.request_tax_offices', MagicMock(return_value=tax_offices)):
+            created_form = StepSteuernummer.InputForm()
+
+        assert created_form.bufa_nr.choices == [("2801", "Finanzamt Ni'Var"),
+                                                ("9101", "Finanzamt Klingon Arbeitnehmerbereich (101)"),
+                                                ("9102", "Finanzamt Klingon Arbeitgeberbereich (102)")
+                                                ]
 
 
 class TestStepSteuernummerValidate:


### PR DESCRIPTION
# Short Description
- The main branch is currently broken because the bufa_nr choices are not set correctly. This was caused by #277 when attempting to fix an error caused by #227.
- in #227 the bufa_nr choices were set on the class-level in the pre_handle() method - *after* the validation. When you put in a (valid) bufa_nr from the dropdown and POSTed it, this caused  a validation error as the Form did not know the proper choices yet (default is '--') - as this happened *after* the validation. (However, because we always GET and then POST, the choices were still set correctly once you POSTed - as they were set on a class level)
- in #277 I shifted the setting of the bufa_nr to be on an instance level (via render_info.form) - still *after* the validation. Meaning, that the correct bufa_nr are not stored across multiple requests anymore (as they are instance-based) and the validation fails.
- This fixes both issues by setting the bufa_nr *before* the validation *on an instance level* in the form

# Changes
- Set the choices of bufa_nr in the form's __init__
- Set the bufa_nr as an attribute on the form to transfer them to the template like that

# Feedback
- Let me know if you don't like it that the tax_offices are set directly on the form and then queried from there by the template. - This was my way of making sure we do not query the tax_offices twice.