### PR TITLE
Webapp registration styling fix

### DIFF
--- a/webapp/client/src/components/FormNavButtons.js
+++ b/webapp/client/src/components/FormNavButtons.js
@@ -4,12 +4,15 @@ import styled from "styled-components";
 
 const Row = styled.div`
   margin-top: var(--spacing-09);
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: var(--spacing-06);
 `;
 
 // TODO: tidy this up (turn into a proper Button component as per Nadine's designs?)
 const Button = styled.button`
   padding: 1rem 1.25rem calc(1rem - 4px) 1.25rem;
-
+  margin-right: var(--spacing-06);
   font-size: var(--text-base);
   letter-spacing: var(--tracking-wide);
   text-decoration: none;
@@ -83,7 +86,6 @@ const OutlineButton = styled.button`
 
 const ExplanatoryText = styled.small`
   margin-bottom: 0;
-  margin-left: var(--spacing-02);
 
   & a {
     color: var(--text-color);

--- a/webapp/client/src/components/FormNavButtons.js
+++ b/webapp/client/src/components/FormNavButtons.js
@@ -6,13 +6,13 @@ const Row = styled.div`
   margin-top: var(--spacing-09);
   display: flex;
   flex-wrap: wrap;
-  row-gap: var(--spacing-06);
+  row-gap: var(--spacing-05);
 `;
 
 // TODO: tidy this up (turn into a proper Button component as per Nadine's designs?)
 const Button = styled.button`
   padding: 1rem 1.25rem calc(1rem - 4px) 1.25rem;
-  margin-right: var(--spacing-06);
+  margin-right: var(--spacing-05);
   font-size: var(--text-base);
   letter-spacing: var(--tracking-wide);
   text-decoration: none;

--- a/webapp/client/src/setupProxy.js
+++ b/webapp/client/src/setupProxy.js
@@ -14,7 +14,7 @@ function setupProxy(app) {
         "!/*.hot-update.json", // HMR requests
       ],
       {
-        target: "http://localhost:5000",
+        target: "http://127.0.0.1:5000",
         changeOrigin: true,
         autoRewrite: true,
       }

--- a/webapp/client/src/stories/FormNavButtons.stories.js
+++ b/webapp/client/src/stories/FormNavButtons.stories.js
@@ -21,6 +21,11 @@ WithOverviewLink.args = {
 export const WithExplanatoryText = Template.bind({});
 WithExplanatoryText.args = {
   ...Default.args,
-  explanatoryButtonText:
-    'Sie haben Ihren Freischaltcode bereits erhalten? <br><a href="#">Dann können Sie sich anmelden</a>',
+  explanatoryButtonText: (
+    <>
+      Sie haben Ihren Freischaltcode bereits erhalten?
+      <br />
+      <a href="/">Dann können Sie sich anmelden</a>
+    </>
+  ),
 };


### PR DESCRIPTION
# Short Description
- The vertical spacing around the registration button was wrong on small viewports (see https://steuerlotse.atlassian.net/browse/STL-1398 for images).
- The horizontal spacing between button and explanatory text was also different from the designs, so I changed that, too.

# Changes
- FormNavButtons CSS
- I also changed the `http-proxy-middleware` proxy target host from `localhost` to `127.0.0.1` because that fixes a problem for me.
 
# Feedback
- Could you please test if proxying from react dev server (`yarn start`) to the Flask app still works for you with the changed setting?