### PR TITLE
Storybook deployment workflow

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,21 @@
+name: Deploy Storybook
+
+on:
+  push:
+    branches: [main]
+    paths: ["webapp/client/**"]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build storybook
+        run: cd webapp/client && yarn install && yarn build-storybook
+
+      - name: Deploy storybook to github pages
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          branch: gh-pages
+          folder: webapp/client/storybook-static


### PR DESCRIPTION
# Short Description
- Host storybook on github pages
- I'm merging it immediately because new workflows can only be tested once they've been merged to main (subsequent modifications can be tested from a branch, but Github Actions won't know about it beforehand).
- Post-merge todos:
  - [ ] Make workflow work :)
  - [ ] Enable Github pages and set branch to gh-pages
  - [ ] Test making a change to a story on main and see that it updates on Github Pages
  - [ ] Test making a change to a story on a different branch and see that it doesn't update on Github Pages
  - [ ] Make a change elsewhere in the code and verify that the workflow didn't run

# Changes
- Adds a github actions workflow to run `yarn build-storybook` and deploy the result to github pages (by pushing the folder to the configured branch).
- This should only run for main and only if the webapp client files have changed.

# Feedback
- Does that path spec on L6 look right to you?
- There's no caching of node dependencies here, but I felt it wasn't so important for this workflow (and still a bit of a pain to set up)… WDYT?
