### PR TITLE
Add workaround for boto3 downloading file

### DIFF
--- a/erica_app/scripts/load_eric_binaries.py
+++ b/erica_app/scripts/load_eric_binaries.py
@@ -73,13 +73,17 @@ def download_file(bucket_name, object_name, file_name, s3client=None):
     if not s3client:
         s3client = get_connected_client()
 
-    s3client.download_file(bucket_name, object_name, file_name)
+    object = s3client.get_object(Bucket=bucket_name, Key="{0}".format(object_name))
+    raw_data = object['Body']._raw_stream.data
+
+    with open(file_name, "wb") as file:
+        file.write(raw_data)
 
 
 @cli.command()
-@click.option('--bucket_name', help='Name of the bucket you want to list of which you want to list the files.')
+@click.option('--bucket', help='Name of the bucket you want to list of which you want to list the files.')
 def list_objects_in_bucket(bucket):
-    if isinstance(str, bucket):
+    if isinstance(bucket, str):
         bucket = get_connected_session().Bucket(bucket)
     for bucket_object in bucket.objects.all():
         print(bucket_object)


### PR DESCRIPTION
# Short Description
We encountered a problem with boto3 when we were downloading the Eric binaries from our object storage. Boto3 opens multiple connections to download the file. However, one of the connections returns a false 200 status code instead of a 206 (range-request) and the download fails with the error MAX RETRIES.

This is a workaround to open only one connection and we will roll back to the old version once the object storage problem is fixed.

# Changes
- Change the download_file function of the Eric_binaries_script

# Feedback
- Do you see any problems?