### PR TITLE
Reactify confirmation step correctly

### DIFF
--- a/webapp/app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py
+++ b/webapp/app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py
@@ -17,10 +17,8 @@ class StepConfirmation(FormStep):
     name = 'confirmation'
 
     class Form(SteuerlotseBaseForm):
-        confirm_data_privacy = ConfirmationField(label=_l('form.lotse.field_confirm_data_privacy'),
-                                                 validators=[InputRequired(message=_l('form.lotse.confirm_data_privacy.required'))])
-        confirm_terms_of_service = ConfirmationField(label=_l('form.lotse.field_confirm_terms_of_service'),
-                                                     validators=[InputRequired(message=_l('form.lotse.confirm_terms_of_service.required'))])
+        confirm_data_privacy = ConfirmationField(validators=[InputRequired(message=_l('form.lotse.confirm_data_privacy.required'))])
+        confirm_terms_of_service = ConfirmationField(validators=[InputRequired(message=_l('form.lotse.confirm_terms_of_service.required'))])
 
     def __init__(self, **kwargs):
         super(StepConfirmation, self).__init__(

--- a/webapp/app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py
+++ b/webapp/app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py
@@ -38,7 +38,6 @@ class StepConfirmation(FormStep):
                 'action': render_info.submit_url,
                 'csrf_token': generate_csrf(),
                 'show_overview_button': bool(render_info.overview_url),
-                'next_button_label': _('form.finish'),
             },
             fields=form_fields_dict(render_info.form),
             terms_of_service_link=url_for('agb'),

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-11-04 17:27+0100\n"
+"POT-Creation-Date: 2021-11-04 17:36+0100\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -2077,36 +2077,32 @@ msgstr ""
 "(EStG). Die mit der Erklärung angeforderten Daten werden aufgrund der §§ "
 "149 und 150 AO und der §§ 25 und 46 EStG erhoben."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:41
-msgid "form.finish"
-msgstr "Steuererklärung abgeben"
-
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:53
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:52
 msgid "form.lotse.confirmation.header-title"
 msgstr "Steuerformular - Versand - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:60
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:59
 msgid "form.lotse.filing.title"
 msgstr ""
 "Ihre Informationen wurden erfolgreich verschickt. Speichern Sie Ihre "
 "Nachweise für Ihre Unterlagen."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:61
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:60
 msgid "form.lotse.filing.intro"
 msgstr ""
 "Ihre Informationen wurden erfolgreich an Ihre Finanzverwaltung "
 "übermittelt. Bewahren Sie Ihre Nachweise für Nachfragen gut auf."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:68
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:85
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:67
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:84
 msgid "form.lotse.filing.header-title"
 msgstr "Steuerformular - Abgabebestätigung - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:74
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:73
 msgid "form.lotse.filing.failure.header-title"
 msgstr "Steuerformular - Abgabebefehler - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:81
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:80
 msgid "form.lotse.ack.alert.title"
 msgstr "Herzlichen Glückwunsch! Sie sind mit Ihrer Steuererklärung fertig!"
 

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-11-04 16:01+0100\n"
+"POT-Creation-Date: 2021-11-04 17:27+0100\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -2052,43 +2052,24 @@ msgid "form.lotse.spenden-inland-parteien.data_label}"
 msgstr "an inländische politische Parteien"
 
 #: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:20
-msgid "form.lotse.field_confirm_data_privacy"
-msgstr ""
-"Ich habe die <a href=%(link)s target=\"_blank\">Datenschutzerklärung</a> "
-"inklusive der <a "
-"href=\"https://www.bundesfinanzministerium.de/Content/DE/Downloads/BMF_Schreiben/Weitere_Steuerthemen/Abgabenordnung/2020-07-01"
-"-Korrektur-Allgemeine-Informationen-Datenschutz-Grundverordnung-"
-"Steuerverwaltung-anlage-1.pdf?__blob=publicationFile&v=3\" "
-"target=\"_blank\">Allgemeinen Informationen zur Umsetzung der "
-"datenschutzrechtlichen Vorgaben der Artikel 12 bis 14 der Datenschutz-"
-"Grundverordnung in der Steuerverwaltung</a> zur Kenntnis genommen und "
-"akzeptiere diese."
-
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:21
 msgid "form.lotse.confirm_data_privacy.required"
 msgstr ""
 "Bestätigen Sie, dass Sie mit den Datenschutzrichtlinien einverstanden "
 "sind, um fortfahren zu können."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:22
-msgid "form.lotse.field_confirm_terms_of_service"
-msgstr ""
-"Ich habe die <a href=%(link)s target=\"_blank\">Nutzungsbedingungen</a> "
-"gelesen und stimme ihnen zu. "
-
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:23
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:21
 msgid "form.lotse.confirm_terms_of_service.required"
 msgstr ""
 "Bestätigen Sie, dass Sie den Nutzungbedingungen zustimmen, um fortfahren "
 "zu können."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:27
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:36
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:25
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:34
 msgid "form.lotse.confirmation-title"
 msgstr "Bestätigung und Versand an Ihre Finanzverwaltung"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:28
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:37
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:26
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:35
 msgid "form.lotse.confirmation-intro"
 msgstr ""
 "Diese Erklärung ist eine Einkommensteuererklärung im Sinne des § 150 Abs."
@@ -2096,36 +2077,36 @@ msgstr ""
 "(EStG). Die mit der Erklärung angeforderten Daten werden aufgrund der §§ "
 "149 und 150 AO und der §§ 25 und 46 EStG erhoben."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:43
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:41
 msgid "form.finish"
 msgstr "Steuererklärung abgeben"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:55
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:53
 msgid "form.lotse.confirmation.header-title"
 msgstr "Steuerformular - Versand - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:62
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:60
 msgid "form.lotse.filing.title"
 msgstr ""
 "Ihre Informationen wurden erfolgreich verschickt. Speichern Sie Ihre "
 "Nachweise für Ihre Unterlagen."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:63
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:61
 msgid "form.lotse.filing.intro"
 msgstr ""
 "Ihre Informationen wurden erfolgreich an Ihre Finanzverwaltung "
 "übermittelt. Bewahren Sie Ihre Nachweise für Nachfragen gut auf."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:70
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:87
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:68
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:85
 msgid "form.lotse.filing.header-title"
 msgstr "Steuerformular - Abgabebestätigung - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:76
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:74
 msgid "form.lotse.filing.failure.header-title"
 msgstr "Steuerformular - Abgabebefehler - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:83
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:81
 msgid "form.lotse.ack.alert.title"
 msgstr "Herzlichen Glückwunsch! Sie sind mit Ihrer Steuererklärung fertig!"
 

--- a/webapp/client/cypress/integration/confirmation.spec.js
+++ b/webapp/client/cypress/integration/confirmation.spec.js
@@ -31,8 +31,4 @@ describe("Confirmation", () => {
       cy.url().should("include", "/lotse/step/summary");
     });
   });
-
-  it("submitting a complete form with full data", () => {
-    // TODO implement this once route to set data for functional tests is implemented
-  });
 });

--- a/webapp/client/src/lib/propTypes.js
+++ b/webapp/client/src/lib/propTypes.js
@@ -1,0 +1,11 @@
+import PropTypes from "prop-types";
+
+export const checkboxPropType = PropTypes.exact({
+  errors: PropTypes.arrayOf(PropTypes.string),
+  checked: PropTypes.bool,
+});
+
+export const fieldPropType = PropTypes.exact({
+  value: PropTypes.any,
+  errors: PropTypes.arrayOf(PropTypes.string),
+});

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -32,6 +32,14 @@ const translations = {
         "pauschal besteuerte Einkünfte aus geringfügigen Beschäftigungen (Mini-Jobs) bis zu einer Höhe von insgesamt 450 Euro monatlich",
     },
     confirmation: {
+      fieldRegistrationConfirmDataPrivacy: {
+        labelText:
+          "Ich habe die <dataPrivacyLink>Datenschutzerklärung</dataPrivacyLink> inklusive der <taxGdprLink>Allgemeinen Informationen zur Umsetzung der datenschutzrechtlichen Vorgaben der Artikel 12 bis 14 der Datenschutz-Grundverordnung in der Steuerverwaltung</taxGdprLink> zur Kenntnis genommen und akzeptiere diese.",
+      },
+      fieldRegistrationConfirmTermsOfService: {
+        labelText:
+          "Ich habe die <termsOfServiceLink>Nutzungsbedingungen</termsOfServiceLink> gelesen und stimme ihnen zu.",
+      },
       finish: "Steuererklärung abgeben",
     },
   },

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -31,6 +31,9 @@ const translations = {
       listItem3:
         "pauschal besteuerte Einkünfte aus geringfügigen Beschäftigungen (Mini-Jobs) bis zu einer Höhe von insgesamt 450 Euro monatlich",
     },
+    confirmation: {
+      finish: "Steuererklärung abgeben",
+    },
   },
   unlockCodeActivation: {
     idnr: {

--- a/webapp/client/src/pages/ConfirmationPage.js
+++ b/webapp/client/src/pages/ConfirmationPage.js
@@ -20,7 +20,7 @@ export default function ConfirmationPage({
     <>
       <StepHeaderButtons />
       <FormHeader {...stepHeader} />
-      <StepForm {...form}>
+      <StepForm {...form} nextButtonLabel={t("lotse.confirmation.finish")}>
         <FormFieldConsentBox
           required
           fieldName="confirm_data_privacy"

--- a/webapp/client/src/pages/ConfirmationPage.js
+++ b/webapp/client/src/pages/ConfirmationPage.js
@@ -29,7 +29,7 @@ export default function ConfirmationPage({
           labelText={
             <Trans
               t={t}
-              i18nKey="unlockCodeRequest.fieldRegistrationConfirmDataPrivacy.labelText"
+              i18nKey="lotse.confirmation.fieldRegistrationConfirmDataPrivacy.labelText"
               components={{
                 // The anchors get content in the translation file
                 // eslint-disable-next-line jsx-a11y/anchor-has-content
@@ -55,7 +55,7 @@ export default function ConfirmationPage({
           labelText={
             <Trans
               t={t}
-              i18nKey="unlockCodeRequest.fieldRegistrationConfirmTermsOfService.labelText"
+              i18nKey="lotse.confirmation.fieldRegistrationConfirmTermsOfService.labelText"
               components={{
                 // The anchors get content in the translation file
                 // eslint-disable-next-line jsx-a11y/anchor-has-content

--- a/webapp/client/src/pages/ConfirmationPage.js
+++ b/webapp/client/src/pages/ConfirmationPage.js
@@ -5,6 +5,7 @@ import FormFieldConsentBox from "../components/FormFieldConsentBox";
 import FormHeader from "../components/FormHeader";
 import StepForm from "../components/StepForm";
 import StepHeaderButtons from "../components/StepHeaderButtons";
+import { checkboxPropType } from "../lib/propTypes";
 
 export default function ConfirmationPage({
   stepHeader,
@@ -68,11 +69,6 @@ export default function ConfirmationPage({
     </>
   );
 }
-
-const checkboxPropType = PropTypes.exact({
-  errors: PropTypes.arrayOf(PropTypes.string),
-  checked: PropTypes.bool,
-});
 
 ConfirmationPage.propTypes = {
   stepHeader: PropTypes.exact({

--- a/webapp/client/src/pages/DeclarationIncomesPage.js
+++ b/webapp/client/src/pages/DeclarationIncomesPage.js
@@ -7,6 +7,7 @@ import FormHeader from "../components/FormHeader";
 import StepForm from "../components/StepForm";
 import StepHeaderButtons from "../components/StepHeaderButtons";
 import listMarker from "../assets/icons/list_marker.svg";
+import { checkboxPropType } from "../lib/propTypes";
 
 const IntroList = styled.ul`
   margin-bottom: var(--spacing-06);
@@ -51,11 +52,6 @@ export default function DeclarationIncomesPage({ stepHeader, form, fields }) {
     </>
   );
 }
-
-const checkboxPropType = PropTypes.exact({
-  errors: PropTypes.arrayOf(PropTypes.string),
-  checked: PropTypes.bool,
-});
 
 DeclarationIncomesPage.propTypes = {
   stepHeader: PropTypes.exact({

--- a/webapp/client/src/pages/LoginPage.js
+++ b/webapp/client/src/pages/LoginPage.js
@@ -7,6 +7,7 @@ import FormHeader from "../components/FormHeader";
 import FormRowCentered from "../components/FormRowCentered";
 import StepForm from "../components/StepForm";
 import StepHeaderButtons from "../components/StepHeaderButtons";
+import { fieldPropType } from "../lib/propTypes";
 
 export default function LoginPage({ stepHeader, form, fields }) {
   const { t } = useTranslation();
@@ -54,11 +55,6 @@ export default function LoginPage({ stepHeader, form, fields }) {
     </>
   );
 }
-
-const fieldPropType = PropTypes.exact({
-  value: PropTypes.any,
-  errors: PropTypes.arrayOf(PropTypes.string),
-});
 
 LoginPage.propTypes = {
   stepHeader: PropTypes.exact({

--- a/webapp/client/src/pages/RegistrationPage.js
+++ b/webapp/client/src/pages/RegistrationPage.js
@@ -10,6 +10,7 @@ import FormHeader from "../components/FormHeader";
 import FormRowCentered from "../components/FormRowCentered";
 import StepForm from "../components/StepForm";
 import StepHeaderButtons from "../components/StepHeaderButtons";
+import { checkboxPropType, fieldPropType } from "../lib/propTypes";
 
 const SubHeading = styled.h2`
   &.form-sub-heading-smaller {
@@ -182,16 +183,6 @@ export default function RegistrationPage({
     </>
   );
 }
-
-const fieldPropType = PropTypes.exact({
-  value: PropTypes.any,
-  errors: PropTypes.arrayOf(PropTypes.string),
-});
-
-const checkboxPropType = PropTypes.exact({
-  errors: PropTypes.arrayOf(PropTypes.string),
-  checked: PropTypes.bool,
-});
 
 RegistrationPage.propTypes = {
   stepHeader: PropTypes.exact({

--- a/webapp/client/src/pages/StmindSelectionPage.js
+++ b/webapp/client/src/pages/StmindSelectionPage.js
@@ -10,6 +10,7 @@ import aussergBelaIcon from "../assets/icons/ausserg_bela_icon.svg";
 import handwerkerIcon from "../assets/icons/handwerker_icon.svg";
 import spendenIcon from "../assets/icons/spenden_icon.svg";
 import religionIcon from "../assets/icons/religion_icon.svg";
+import { checkboxPropType } from "../lib/propTypes";
 
 export default function StmindSelectionPage({ stepHeader, form, fields }) {
   const { t } = useTranslation();
@@ -69,11 +70,6 @@ export default function StmindSelectionPage({ stepHeader, form, fields }) {
     </>
   );
 }
-
-const checkboxPropType = PropTypes.exact({
-  errors: PropTypes.arrayOf(PropTypes.string),
-  checked: PropTypes.bool,
-});
 
 StmindSelectionPage.propTypes = {
   stepHeader: PropTypes.exact({


### PR DESCRIPTION
# Short Description
- @nfelger  made some very good comments on my PR  #319 after I merged it: https://github.com/digitalservice4germany/steuerlotse/pull/319#pullrequestreview-797838781
- This PR addresses these requested changes

# Changes
- The field prop types were used in multiple files. I took the freedom to also move fieldPropType into the specified file
- Removed todo comment for test and instead created a [ticket](https://steuerlotse.atlassian.net/browse/STL-1584)
- Removed unnecessary messages
- Moved the finish-button-text setting into the react component, away from flask
- I also noticed that the messages in `translations.js` were still wired to the registration page, instead of the confirmation page. Fixed that too.

# Feedback
- Was that the place you had in mind when moving the `form.finish` text? Or would you have set it as a default for the props?