### PR TITLE
Add specific version number because the actual version is broken.

### DIFF
--- a/.github/workflows/cicd-pipeline.yml
+++ b/.github/workflows/cicd-pipeline.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install build requirements
       run: |
         python -m pip install --upgrade pip
-        pip install pipenv invoke
+        pip install pipenv==2021.5.29 invoke
       shell: bash
 
     - name: Python dependencies - configure cache
@@ -110,7 +110,7 @@ jobs:
     - name: Install build requirements
       run: |
         python -m pip install --upgrade pip
-        pip install pipenv
+        pip install pipenv==2021.5.29
       shell: bash
 
     - name: Cache dependencies


### PR DESCRIPTION
# Short Description
- We need to specify the last version because the actual version is broken. Installed dependencies are lost when use invoke.

# Changes
- cicd-pipeline.yml -> Specify last version of pipenv
