### PR TITLE
Sqlachemy pool tweaks

### DIFF
--- a/webapp/app/config.py
+++ b/webapp/app/config.py
@@ -19,9 +19,22 @@ class BaseConfig(object):
     SESSION_COOKIE_SAMESITE = 'Lax'
     SESSION_COOKIE_SECURE = True
     PERMANENT_SESSION_LIFETIME = 10800
-    SQLALCHEMY_TRACK_MODIFICATIONS = False
     PLAUSIBLE_DOMAIN = None
     REACT_BUNDLE_NAME = 'runtime-main.js'
+
+    SQLALCHEMY_ENGINE_OPTIONS = {
+        # pool_pre_ping and pool_recycle both attempt to fix problems stemming from this:
+        # https://docs.syseleven.de/syseleven-stack/de/reference/network/known-issues#idle-tcp-sessions-being-closed
+        'pool_pre_ping': True,
+        'pool_recycle': 45,
+        # ensure we get a connection error before gunicorn kills our process after 30s
+        'pool_timeout': 20,
+        # don't log any parameters with errors or when logging SQL statements
+        # https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.hide_parameters
+        'hide_parameters': True,
+    }
+
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     USE_LRU_CACHE = True
 
@@ -73,6 +86,7 @@ class DevelopmentConfig(BaseConfig):
     ERICA_BASE_URL = environ.get('ERICA_BASE_URL') or 'http://0.0.0.0:8000/01'
     RATELIMIT_STORAGE_URL = environ.get('RATELIMIT_STORAGE_URL') or "memory://"
     SQLALCHEMY_DATABASE_URI = environ.get('SQLALCHEMY_DATABASE_URI') or "sqlite:///dev.db"
+    SQLALCHEMY_ENGINE_OPTIONS = {}  # Some of our settings don't work with sqlite.
 
     ENCRYPTION_KEY = b'DZq_fTImMfOUsZr74Fy278GJ1Zva5j24lUJeZ-OWXxE='  # Generate a new random key for production
     # Find the according private key in tests/crypto/test_encryption
@@ -105,6 +119,7 @@ class TestingConfig(BaseConfig):
     ERICA_BASE_URL = 'ERICA'
     RATELIMIT_STORAGE_URL = "memory://"
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    SQLALCHEMY_ENGINE_OPTIONS = {}  # Some of our settings don't work with sqlite.
 
     ENCRYPTION_KEY = b'DZq_fTImMfOUsZr74Fy278GJ1Zva5j24lUJeZ-OWXxE='  # Generate a new random key for production
     RSA_ENCRYPT_PUBLIC_KEY = b'rsa encrypt public key'

--- a/webapp/app/extensions.py
+++ b/webapp/app/extensions.py
@@ -44,6 +44,7 @@ csrf = CSRFProtect()
 #   https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.hide_parameters)
 db = SQLAlchemy(engine_options={
     'pool_pre_ping': True,
+    'pool_recycle': 45,
     'pool_timeout': 20,
     'hide_parameters': True,
 })

--- a/webapp/app/extensions.py
+++ b/webapp/app/extensions.py
@@ -42,7 +42,11 @@ csrf = CSRFProtect()
 #   https://docs.syseleven.de/syseleven-stack/de/reference/network/known-issues#idle-tcp-sessions-being-closed).
 # - hide_parameters: don't log any parameters with errors or when logging SQL statements (
 #   https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.hide_parameters)
-db = SQLAlchemy(engine_options={'pool_pre_ping': True, 'hide_parameters': True})
+db = SQLAlchemy(engine_options={
+    'pool_pre_ping': True,
+    'pool_timeout': 20,
+    'hide_parameters': True,
+})
 
 flask_static_digest = FlaskStaticDigest()
 

--- a/webapp/app/extensions.py
+++ b/webapp/app/extensions.py
@@ -36,19 +36,7 @@ class PrometheusExporterWrapper:
 
 babel = Babel()
 csrf = CSRFProtect()
-
-# SQLAlchemy options
-# - pool_pre_ping: fix problems with stale connection we've been seeing (see also:
-#   https://docs.syseleven.de/syseleven-stack/de/reference/network/known-issues#idle-tcp-sessions-being-closed).
-# - hide_parameters: don't log any parameters with errors or when logging SQL statements (
-#   https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.hide_parameters)
-db = SQLAlchemy(engine_options={
-    'pool_pre_ping': True,
-    'pool_recycle': 45,
-    'pool_timeout': 20,
-    'hide_parameters': True,
-})
-
+db = SQLAlchemy()
 flask_static_digest = FlaskStaticDigest()
 
 limiter = Limiter(


### PR DESCRIPTION
# Short Description
- Two tweaks to help with worker timeouts

# Changes
- Set [pool_timeout](https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.pool_timeout) to 20s. Desired effect: DB connection issues result in a SQLAlchemy exception rather than a worker timeout; the process remains alive.
- Set [pool_recycle](https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.pool_recycle) to 45s. Desired effect: fewer issues with closed connections due to https://docs.syseleven.de/syseleven-stack/de/reference/network/known-issues#idle-tcp-sessions-being-closed.
- Both those options cannot be set on a sqlite DB, so I made use of a flask-sqlalchemy configuration key to only set them for prod-like envs (staging & production).

# Feedback
- any :)
