### PR TITLE
Adapt order of Steuerminderung pages and correctly use form

### DIFF
--- a/webapp/app/forms/flows/lotse_flow.py
+++ b/webapp/app/forms/flows/lotse_flow.py
@@ -144,8 +144,9 @@ class LotseMultiStepFlow(MultiStepFlow):
                 StepAussergBela,
                 StepHaushaltsnaheHandwerker,
                 StepGemeinsamerHaushalt,
-                StepReligion,
                 StepSpenden,
+                StepReligion,
+
 
                 StepSummary,
                 StepConfirmation,

--- a/webapp/app/forms/steps/lotse/steuerminderungen.py
+++ b/webapp/app/forms/steps/lotse/steuerminderungen.py
@@ -68,7 +68,7 @@ class StepSelectStmind(LotseFormSteuerlotseStep):
                                component='StmindSelectionPage',
                                props=props_dict,
                                # TODO: These are still required by base.html to set the page title.
-                               form=self.form,
+                               form=self.render_info.form,
                                header_title=self.header_title)
 
 

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-11-08 10:57+0100\n"
+"POT-Creation-Date: 2021-11-10 15:11+0100\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -68,58 +68,7 @@ msgstr ""
 "wenn Sie mit Ihrer Steuererklärung fortfahren möchten. Wenn Sie Ihren "
 "Freischaltcode stornieren möchten, müssen Sie sich zuerst abmelden."
 
-#: app/routes.py:187 app/routes.py:295
-msgid "404.header-title"
-msgstr "Fehler 404 - Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:207 app/templates/basis/base.html:36
-msgid "page.title"
-msgstr "Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:214
-msgid "howitworks.header-title"
-msgstr "Informieren - Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:221
-msgid "contact.header-title"
-msgstr "Kontakt - Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:228
-msgid "imprint.header-title"
-msgstr "Impressum - Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:235
-msgid "barrierefreiheit.header-title"
-msgstr "Barrierefreiheit - Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:242
-msgid "data_privacy.header-title"
-msgstr "Datenschutz - Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:249
-msgid "agb.header-title"
-msgstr "Nutzungsbedingungen - Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:261
-msgid "about.header-title"
-msgstr "Projektinfos - Der Steuerlotse für Rente und Pension"
-
-msgid "about_digitalservice.header-title"
-msgstr "Digital Service - Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:287
-msgid "erica-error.header-title"
-msgstr "Übermittlungsfehler - Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:291 app/routes.py:299
-msgid "400.header-title"
-msgstr "Fehler 400 - Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:303
-msgid "429.header-title"
-msgstr "Fehler 429 - Der Steuerlotse für Rente und Pension"
-
-#: app/routes.py:199 app/routes.py:307
+#: app/routes.py:196 app/routes.py:304
 msgid "404.header-title"
 msgstr "Fehler 404 - Der Steuerlotse für Rente und Pension"
 
@@ -318,16 +267,16 @@ msgstr "Sie haben sich erfolgreich abgemeldet."
 msgid "form.lotse.title"
 msgstr "Ihre Steuererklärung"
 
-#: app/forms/flows/lotse_flow.py:184
+#: app/forms/flows/lotse_flow.py:185
 #: app/templates/unlock_code/already_logged_in.html:11
 msgid "form.logout"
 msgstr "Abmelden"
 
-#: app/forms/flows/lotse_flow.py:319
+#: app/forms/flows/lotse_flow.py:320
 msgid "form.lotse.no_answer"
 msgstr "Keine Angabe"
 
-#: app/forms/flows/lotse_flow.py:371
+#: app/forms/flows/lotse_flow.py:372
 msgid "form.lotse.missing_mandatory_field"
 msgstr "Dieses Feld müssen Sie noch angeben."
 
@@ -1117,8 +1066,8 @@ msgstr ""
 msgid "form.logout.header-title"
 msgstr "Infos zur Abmeldung - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:199
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:319
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:198
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:318
 #: app/forms/steps/unlock_code_activation_steps.py:19
 #: app/forms/steps/unlock_code_request_steps.py:22
 #: app/forms/steps/unlock_code_revocation_steps.py:17
@@ -1151,7 +1100,6 @@ msgstr "Anmeldung fehlgeschlagen"
 #: app/forms/steps/unlock_code_request_steps.py:23
 msgid "validation-date-of-birth-missing"
 msgstr "Geben Sie Ihr Geburtsdatum ein."
-
 
 #: app/forms/steps/unlock_code_request_steps.py:25
 msgid "form.unlock-code-request.confirm_data_privacy.required"
@@ -1295,10 +1243,10 @@ msgstr ""
 "Veranlagungsart sein."
 
 #: app/forms/steps/lotse/personal_data.py:24
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:152
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:275
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:400
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:449
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:151
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:274
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:399
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:448
 msgid "form.lotse.mandatory_data.header-title"
 msgstr "Steuerformular - Pflichtangaben - Der Steuerlotse für Rente und Pension"
 
@@ -1310,9 +1258,9 @@ msgstr "Steuernummer"
 #: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:20
 #: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:61
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:22
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:194
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:303
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:414
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:193
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:302
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:413
 msgid "form.lotse.mandatory_data.label"
 msgstr "Pflichtangaben"
 
@@ -1594,7 +1542,7 @@ msgstr ""
 
 #: app/forms/steps/lotse/steuerminderungen.py:189
 msgid "form.lotse.ausserg_bela-title"
-msgstr "Außergewöhnliche Belastungen"
+msgstr "Krankheitskosten und weitere außergewöhnliche Belastungen"
 
 #: app/forms/steps/lotse/steuerminderungen.py:190
 msgid "form.lotse.ausserg_bela-intro"
@@ -1613,7 +1561,7 @@ msgstr ""
 
 #: app/forms/steps/lotse/steuerminderungen.py:195
 msgid "form.lotse.step_ausserg_bela.label"
-msgstr "Außergewöhnliche Belastungen"
+msgstr "Krankheitskosten und weitere außergewöhnliche Belastungen"
 
 #: app/forms/steps/lotse/steuerminderungen.py:201
 msgid "form.lotse.field_krankheitskosten_summe"
@@ -1805,7 +1753,7 @@ msgstr ""
 
 #: app/forms/steps/lotse/steuerminderungen.py:268
 msgid "form.lotse.step_haushaltsnahe_handwerker.label"
-msgstr " Handwerker, Tätigkeiten und Dienstleistungen im Haushalt"
+msgstr "Haushaltsnahe Dienstleistungen und Handwerkerleistungen"
 
 #: app/forms/steps/lotse/steuerminderungen.py:274
 msgid "form.lotse.field_haushaltsnahe_entries"
@@ -2379,7 +2327,7 @@ msgid "validate.date-of-marriage-missing"
 msgstr "Geben Sie Ihr Geburtsdatum ein."
 
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:75
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:103
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:102
 #: app/forms/validations/date_validations.py:67
 msgid "validate.date-of-death-missing"
 msgstr "Geben Sie Ihr Geburtsdatum ein."
@@ -2394,131 +2342,131 @@ msgstr "Geben Sie Ihr Geburtsdatum ein."
 msgid "form.lotse.validation-familienstand-married-lived-separated"
 msgstr "Wählen Sie “Ja” oder “Nein” aus."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:96
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:95
 msgid "form.lotse.validation.married-after-separated"
 msgstr "Dieses Datum darf nicht vor Ihrem Hochzeitsdatum liegen."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:109
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:108
 msgid "form.lotse.validation-familienstand-widowed-lived-separated-since"
 msgstr "Geben Sie ein Datum an."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:116
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:115
 msgid "form.lotse.validation.widowed-before-separated"
 msgstr ""
 "Dieses Datum darf nicht nach dem Todestag Ihres Partners/Ihrer Partnerin "
 "liegen."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:129
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:128
 msgid "form.lotse.validation-familienstand-zusammenveranlagung"
 msgstr "Geben Sie an ob die eine Zusammenveranlagung wünschen."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:142
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:141
 msgid "form.lotse.validation-familienstand-confirm-zusammenveranlagung"
 msgstr ""
 "Aufgrund Ihres Familienstandes müssen Sie gemeinsam veranlagen. Bitte "
 "bestätigen Sie dies."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:149
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:148
 msgid "form.lotse.familienstand-title"
 msgstr "Familienstand"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:159
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:158
 msgid "form.lotse.field_person_religion"
 msgstr "Religionszugehörigkeit"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:161
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:160
 msgid "form.lotse.field_person_religion.none"
 msgstr "nicht kirchensteuerpflichtig"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:162
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:161
 msgid "form.lotse.field_person_religion.ak"
 msgstr "Altkatholisch"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:163
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:162
 msgid "form.lotse.field_person_religion.ev"
 msgstr "Evangelisch"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:164
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:163
 msgid "form.lotse.field_person_religion.er"
 msgstr "Evangelisch-reformiert"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:165
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:164
 msgid "form.lotse.field_person_religion.erb"
 msgstr "Evangelisch-reformierte Kirche Bückeburg"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:166
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:165
 msgid "form.lotse.field_person_religion.ers"
 msgstr "Evangelisch-reformierte Kirche Stadthagen"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:167
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:166
 msgid "form.lotse.field_person_religion.fr"
 msgstr "Französisch-reformiert"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:168
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:167
 msgid "form.lotse.field_person_religion.fra"
 msgstr "Freie Religionsgemeinschaft Alzey"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:169
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:168
 msgid "form.lotse.field_person_religion.fgm"
 msgstr "Freireligiöse Gemeinde Mainz"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:170
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:169
 msgid "form.lotse.field_person_religion.fgo"
 msgstr "Freireligiöse Gemeinde Offenbach"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:171
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:170
 msgid "form.lotse.field_person_religion.flb"
 msgstr "Freireligiöse Landesgemeinde Baden"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:172
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:171
 msgid "form.lotse.field_person_religion.flp"
 msgstr "Freireligiöse Landesgemeinde Pfalz"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:173
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:172
 msgid "form.lotse.field_person_religion.is"
 msgstr "Israelitisch (Saarland)"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:174
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:173
 msgid "form.lotse.field_person_religion.irb"
 msgstr "Israelitische Religionsgemeinschaft Baden"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:175
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:174
 msgid "form.lotse.field_person_religion.iw"
 msgstr "Israelitische Religionsgemeinschaft Württemberg"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:176
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:175
 msgid "form.lotse.field_person_religion.ikb"
 msgstr "Landesverband der israelitischen Kultusgemeinden in Bayern"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:177
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:176
 msgid "form.lotse.field_person_religion.inw"
 msgstr "Nordrhein-Westfalen: Israelitisch (jüdisch)"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:178
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:177
 msgid "form.lotse.field_person_religion.jgf"
 msgstr "Jüdische Gemeinde Frankfurt (Hessen)"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:179
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:178
 msgid "form.lotse.field_person_religion.jh"
 msgstr "Jüdische Gemeinde Hamburg"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:180
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:179
 msgid "form.lotse.field_person_religion.jgh"
 msgstr "Jüdische Gemeinden im Landesverband Hessen"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:181
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:180
 msgid "form.lotse.field_person_religion.jkk"
 msgstr "Jüdische Kultusgemeinden Bad Kreuznach und Koblenz"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:182
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:181
 msgid "form.lotse.field_person_religion.rk"
 msgstr "Römisch-katholisch"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:183
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:182
 msgid "form.lotse.field_person_religion.other"
 msgstr "Sonstige"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:186
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:185
 msgid "form.lotse.field_person_religion-help"
 msgstr ""
 "Wenn Sie keiner Religionsgemeinschaft angehören, wählen Sie »nicht "
@@ -2526,122 +2474,122 @@ msgstr ""
 "kirchensteuerhebeberechtigten Religionsgemeinschaft an, wählen Sie "
 "»Sonstige« aus."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:187
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:186
 msgid "form.lotse.field_person_religion.data_label"
 msgstr "Religionszugehörigkeit"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:198
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:319
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:197
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:318
 msgid "form.lotse.field_person_idnr"
 msgstr "Steuer-Identifikationsnummer"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:200
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:320
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:199
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:319
 msgid "form.lotse.field_person_idnr.data_label"
 msgstr "Steuer-Identifikationsnummer"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:202
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:322
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:201
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:321
 msgid "form.lotse.field_person_dob"
 msgstr "Geburtsdatum"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:203
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:323
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:202
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:322
 msgid "form.lotse.field_person_dob.data_label"
 msgstr "Geburtsdatum"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:203
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:324
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:202
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:323
 msgid "form.lotse.validation-dob-missing"
 msgstr "Bitte erteilen Sie alle notwendigen Einwilligungen um fortzufahren."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:205
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:326
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:204
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:325
 msgid "form.lotse.field_person_first_name"
 msgstr "Vorname"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:206
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:327
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:205
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:326
 msgid "form.lotse.field_person_first_name.data_label"
 msgstr "Vorname"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:210
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:331
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:209
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:330
 msgid "form.lotse.field_person_last_name"
 msgstr "Nachname"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:211
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:332
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:210
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:331
 msgid "form.lotse.field_person_last_name.data_label"
 msgstr "Nachname"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:215
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:344
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:214
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:343
 msgid "form.lotse.field_person_street"
 msgstr "Straße"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:216
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:345
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:215
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:344
 msgid "form.lotse.field_person_street.data_label"
 msgstr "Straße"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:220
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:350
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:219
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:349
 msgid "form.lotse.field_person_street_number"
 msgstr "Hausnummer"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:221
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:351
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:220
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:350
 msgid "form.lotse.field_person_street_number.data_label"
 msgstr "Hausnummer"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:225
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:357
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:224
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:356
 msgid "form.lotse.field_person_street_number_ext"
 msgstr "Hausnummerzusatz"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:226
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:358
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:225
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:357
 msgid "form.lotse.field_person_street_number_ext.data_label"
 msgstr "Hausnummerzusatz"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:230
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:362
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:229
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:361
 msgid "form.lotse.field_person_address_ext"
 msgstr "Adressergänzung"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:231
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:363
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:230
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:362
 msgid "form.lotse.field_person_address_ext.data_label"
 msgstr "Adressergänzung"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:235
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:367
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:234
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:366
 msgid "form.lotse.field_person_plz"
 msgstr "Postleitzahl"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:236
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:368
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:235
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:367
 msgid "form.lotse.field_person_plz.data_label"
 msgstr "Postleitzahl"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:240
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:373
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:239
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:372
 msgid "form.lotse.field_person_town"
 msgstr "Wohnort"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:241
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:374
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:240
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:373
 msgid "form.lotse.field_person_town.data_label"
 msgstr "Wohnort"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:247
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:381
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:246
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:380
 msgid "form.lotse.field_person_beh_grad"
 msgstr "Grad der Behinderung"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:250
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:383
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:249
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:382
 msgid "form.lotse.field_person_beh_grad-help"
 msgstr ""
 "Tragen Sie bitte hier den Grad der Behinderung ein. Der Grad der "
@@ -2655,143 +2603,143 @@ msgstr ""
 "Einbuße der körperlichen Beweglichkeit geführt hat oder auf einer "
 "typischen Berufskrankheit beruht.</li><ul>"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:251
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:384
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:250
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:383
 msgid "form.lotse.field_person_beh_grad.data_label"
 msgstr "Grad der Behinderung"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:252
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:385
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:251
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:384
 msgid "form.lotse.field_person_beh_grad.example_input"
 msgstr "z.B. 25, 30, 35 etc. "
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:255
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:388
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:254
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:387
 msgid "form.lotse.field_person_blind"
 msgstr "blind / ständig hilflos oder Pflegegrad 4 oder 5"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:256
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:389
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:255
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:388
 msgid "form.lotse.field_person_blind.data_label"
 msgstr "blind / ständig hilflos oder Pflegegrad 4 oder 5"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:258
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:391
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:257
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:390
 msgid "form.lotse.field_person_gehbeh"
 msgstr "geh- und stehbehindert"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:259
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:392
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:258
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:391
 msgid "form.lotse.field_person_gehbeh.data_label"
 msgstr "geh- und stehbehindert"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:263
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:314
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:262
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:313
 msgid "form.lotse.validation-person-beh-grad"
 msgstr ""
 "Sie haben eine Geh- oder Stehbehinderung angegeben. Bitte geben Sie hier "
 "den Grad der Behinderung an."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:282
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:281
 msgid "form.lotse.step_person_a.label"
 msgid_plural "form.lotse.step_person_a.label"
 msgstr[0] "Ihre Angaben"
 msgstr[1] "Person A"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:286
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:285
 msgid "form.lotse.person-a-title"
 msgid_plural "form.lotse.person-a-title"
 msgstr[0] "Ihre Angaben"
 msgstr[1] "Angaben für Person A"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:288
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:287
 msgid "form.lotse.person-a-intro"
 msgstr ""
 "Geben Sie bitte zunächst die Informationen des Ehemannes an. Wenn Sie in "
 "einer gleichgeschlechtlichen Partnerschaft leben, geben Sie bitte "
 "zunächst die Person an, deren Name im Alphabet zuerst kommt."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:302
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:301
 msgid "form.lotse.step_person_b.label"
 msgstr "Person B"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:338
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:337
 msgid "form.lotse.field_person_b_same_address.data_label"
 msgstr "Mein Partner / Meine Partnerin und ich wohnen zusammen."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:340
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:339
 msgid "form.lotse.field_person_b_same_address-yes"
 msgstr "Mein Partner / Meine Partnerin und ich wohnen zusammen."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:341
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:340
 msgid "form.lotse.field_person_b_same_address-no"
 msgstr ""
 "Mein Partner / Meine Partnerin und ich wohnen nicht zusammen. Er / Sie "
 "ist wohnhaft in:"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:396
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:395
 msgid "form.lotse.person-b-title"
 msgstr "Angaben für Person B"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:397
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:396
 msgid "form.lotse.person-b-intro"
 msgstr ""
 "Geben Sie hier bitte die Daten der Ehefrau an. Wenn Sie in einer "
 "gleichgeschlechtlichen Partnerschaft leben, geben Sie bitte die Person "
 "an, deren Name im Alphabet zuletzt kommt."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:408
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:407
 msgid "form.lotse.skip_reason.familienstand_single"
 msgstr "Sie haben als Familienstand ledig angegeben."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:413
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:412
 msgid "form.lotse.step_iban.label"
 msgstr "Bankverbindung"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:418
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:417
 msgid "form.lotse.iban.account-holder"
 msgstr "Wer ist Kontoinhaber:in?"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:419
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:418
 msgid "form.lotse.iban.account-holder.data_label"
 msgstr "Kontoinhaber:in"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:420
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:419
 msgid "form.lotse.iban.account-holder-person-a"
 msgstr "Person A"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:421
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:420
 msgid "form.lotse.iban.account-holder-person-b"
 msgstr "Person B"
 
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:423
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:435
+msgid "form.lotse.field_iban"
+msgstr "IBAN "
+
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:424
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:436
-msgid "form.lotse.field_iban"
+msgid "form.lotse.field_iban.data_label"
 msgstr "IBAN "
 
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:425
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:437
-msgid "form.lotse.field_iban.data_label"
-msgstr "IBAN "
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:426
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:438
 msgid "form.lotse.field_iban.example_input"
 msgstr "inländisches Geldinstitut"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:433
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:432
 msgid "form.lotse.field_is_user_account_holder"
 msgstr "Ja, ich bin Kontoinhaber:in."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:434
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:433
 msgid "form.lotse.field_is_user_account_holder.data_label"
 msgstr "Das angegebene Konto gehört Ihnen"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:445
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:444
 msgid "form.lotse.iban-title"
 msgstr "Bankverbindung"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:446
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:445
 msgid "form.lotse.iban-intro"
 msgstr ""
 "Falls Sie Vorauszahlungen getätigt haben, werden eventuelle Erstattungen "

--- a/webapp/tests/forms/flows/test_lotse_flow.py
+++ b/webapp/tests/forms/flows/test_lotse_flow.py
@@ -175,8 +175,8 @@ class TestLotseInit(unittest.TestCase):
             StepAussergBela,
             StepHaushaltsnaheHandwerker,
             StepGemeinsamerHaushalt,
-            StepReligion,
             StepSpenden,
+            StepReligion,
 
             StepSummary,
             StepConfirmation,


### PR DESCRIPTION
# Short Description
QA found the following problems:
- The summary page lists our two Steuerminderung sections in the wrong order. This can be fixed by changing the order of the steps in the Steuerlotsemultistep. I guess that the order was incorrect there and I can not see anything that should break by changing the order.
- The title showed "Fehler". This was because we did not set the form object (stored in the `render_info`) but the form class. For the class `form.errors` evaluates to true and "Fehler" is shown because of this. We do not want to use the class but the object anyway. 

# Changes
- See above
- Use the texts for gemeinsamer Haushalt and außergewöhnliche Belastungen also on the summary page

# Feedback
- Can you see any problems with these changes?
