### PR TITLE
Add TaxNumber React component

### DIFF
--- a/webapp/client/src/components/FormFieldSeparatedField.test.js
+++ b/webapp/client/src/components/FormFieldSeparatedField.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { fireEvent } from "@testing-library/dom";
 import FormFieldSeparatedField from "./FormFieldSeparatedField";
 
 describe("FormFieldSeparatedField", () => {

--- a/webapp/client/src/components/FormFieldSeparatedField.test.js
+++ b/webapp/client/src/components/FormFieldSeparatedField.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import { fireEvent } from "@testing-library/dom";
 import FormFieldSeparatedField from "./FormFieldSeparatedField";
 
 describe("FormFieldSeparatedField", () => {

--- a/webapp/client/src/components/FormFieldTaxNumber.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import PropTypes from "prop-types";
 import FormFieldScaffolding from "./FormFieldScaffolding";
 import FieldLabelForSeparatedFields from "./FieldLabelForSeparatedFields";
@@ -15,13 +16,25 @@ function FormFieldTaxNumber({
   values,
   required,
   autofocus,
-  label,
   details,
   errors,
   isSplit,
 }) {
-  const labelComponent = (
-    <FieldLabelForSeparatedFields {...{ label, fieldId, details }} />
+  const { t } = useTranslation();
+
+  const notSplitLabel = {
+    text: t("lotseFlow.taxNumber.taxNumberInput.label.labelText"),
+    exampleInput: t("lotseFlow.taxNumber.taxNumberInput.label.exampleInput"),
+  };
+  const notSplitLabelComponent = (
+    <FieldLabelForSeparatedFields {...{ notSplitLabel, fieldId, details }} />
+  );
+
+  const splitLabel = {
+    text: t("lotseFlow.taxNumber.taxNumberInput.label.labelText"),
+  };
+  const splitLabelComponent = (
+    <FieldLabelForSeparatedFields {...{ splitLabel, fieldId, details }} />
   );
 
   const extraFieldProps = {
@@ -31,6 +44,9 @@ function FormFieldTaxNumber({
   };
 
   const inputFieldLengths = isSplit ? [3, 4, 4] : [11];
+  const labelComponent = isSplit ? splitLabelComponent : notSplitLabelComponent;
+
+  console.log(labelComponent);
 
   return (
     <FormFieldScaffolding
@@ -69,7 +85,6 @@ FormFieldTaxNumber.propTypes = {
   autofocus: PropTypes.bool,
   required: PropTypes.bool,
   values: PropTypes.arrayOf(PropTypes.string).isRequired,
-  label: FieldLabelForSeparatedFields.propTypes.label,
   details: FieldLabelForSeparatedFields.propTypes.details,
   isSplit: PropTypes.bool.isRequired,
 };
@@ -77,7 +92,6 @@ FormFieldTaxNumber.propTypes = {
 FormFieldTaxNumber.defaultProps = {
   autofocus: FormFieldSeparatedField.defaultProps.autofocus,
   required: FormFieldSeparatedField.defaultProps.required,
-  label: FieldLabelForSeparatedFields.defaultProps.label,
   details: FieldLabelForSeparatedFields.defaultProps.details,
 };
 

--- a/webapp/client/src/components/FormFieldTaxNumber.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.js
@@ -50,6 +50,7 @@ function FormFieldTaxNumber({
   };
 
   const inputFieldLengths = isSplit ? [3, 4, 4] : [11];
+  const concatValues = isSplit ? values : [values.join()];
 
   return (
     <FormFieldScaffolding
@@ -70,7 +71,7 @@ function FormFieldTaxNumber({
             details,
             extraFieldProps,
             fieldId,
-            values,
+            values: concatValues,
             required,
           }}
           autoFocus={autofocus || Boolean(errors.length)}

--- a/webapp/client/src/components/FormFieldTaxNumber.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.js
@@ -26,16 +26,22 @@ function FormFieldTaxNumber({
     text: t("lotseFlow.taxNumber.taxNumberInput.label.labelText"),
     exampleInput: t("lotseFlow.taxNumber.taxNumberInput.label.exampleInput"),
   };
-  const notSplitLabelComponent = (
-    <FieldLabelForSeparatedFields {...{ notSplitLabel, fieldId, details }} />
-  );
 
   const splitLabel = {
     text: t("lotseFlow.taxNumber.taxNumberInput.label.labelText"),
   };
-  const splitLabelComponent = (
-    <FieldLabelForSeparatedFields {...{ splitLabel, fieldId, details }} />
-  );
+
+  const fieldLabelProps = {
+    label: notSplitLabel,
+    fieldId,
+    details,
+  };
+
+  if (isSplit) {
+    fieldLabelProps.label = splitLabel;
+  }
+
+  const labelComponent = <FieldLabelForSeparatedFields {...fieldLabelProps} />;
 
   const extraFieldProps = {
     ...numericInputMode,
@@ -44,7 +50,6 @@ function FormFieldTaxNumber({
   };
 
   const inputFieldLengths = isSplit ? [3, 4, 4] : [11];
-  const labelComponent = isSplit ? splitLabelComponent : notSplitLabelComponent;
 
   return (
     <FormFieldScaffolding

--- a/webapp/client/src/components/FormFieldTaxNumber.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.js
@@ -1,0 +1,84 @@
+import React from "react";
+import PropTypes from "prop-types";
+import FormFieldScaffolding from "./FormFieldScaffolding";
+import FieldLabelForSeparatedFields from "./FieldLabelForSeparatedFields";
+import FormFieldSeparatedField from "./FormFieldSeparatedField";
+import {
+  baselineBugFix,
+  numericInputMask,
+  numericInputMode,
+} from "../lib/fieldUtils";
+
+function FormFieldTaxNumber({
+  fieldName,
+  fieldId,
+  values,
+  required,
+  autofocus,
+  label,
+  details,
+  errors,
+  isSplit,
+}) {
+  const labelComponent = (
+    <FieldLabelForSeparatedFields {...{ label, fieldId, details }} />
+  );
+
+  const extraFieldProps = {
+    ...numericInputMode,
+    ...numericInputMask,
+    ...baselineBugFix,
+  };
+
+  const inputFieldLengths = isSplit ? [3, 4, 4] : [11];
+
+  return (
+    <FormFieldScaffolding
+      {...{
+        fieldName,
+        errors,
+        labelComponent,
+      }}
+      hideLabel
+      hideErrors
+      render={() => (
+        // Separated fields ignore field class names
+        <FormFieldSeparatedField
+          {...{
+            fieldName,
+            labelComponent,
+            errors,
+            details,
+            extraFieldProps,
+            fieldId,
+            values,
+            required,
+          }}
+          autoFocus={autofocus || Boolean(errors.length)}
+          inputFieldLengths={inputFieldLengths}
+        />
+      )}
+    />
+  );
+}
+
+FormFieldTaxNumber.propTypes = {
+  fieldId: PropTypes.string.isRequired,
+  fieldName: PropTypes.string.isRequired,
+  errors: PropTypes.arrayOf(PropTypes.string).isRequired,
+  autofocus: PropTypes.bool,
+  required: PropTypes.bool,
+  values: PropTypes.arrayOf(PropTypes.string).isRequired,
+  label: FieldLabelForSeparatedFields.propTypes.label,
+  details: FieldLabelForSeparatedFields.propTypes.details,
+  isSplit: PropTypes.bool.isRequired,
+};
+
+FormFieldTaxNumber.defaultProps = {
+  autofocus: FormFieldSeparatedField.defaultProps.autofocus,
+  required: FormFieldSeparatedField.defaultProps.required,
+  label: FieldLabelForSeparatedFields.defaultProps.label,
+  details: FieldLabelForSeparatedFields.defaultProps.details,
+};
+
+export default FormFieldTaxNumber;

--- a/webapp/client/src/components/FormFieldTaxNumber.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.js
@@ -22,24 +22,17 @@ function FormFieldTaxNumber({
 }) {
   const { t } = useTranslation();
 
-  const notSplitLabel = {
+  const label = {
     text: t("lotseFlow.taxNumber.taxNumberInput.label.labelText"),
-    exampleInput: t("lotseFlow.taxNumber.taxNumberInput.label.exampleInput"),
-  };
-
-  const splitLabel = {
-    text: t("lotseFlow.taxNumber.taxNumberInput.label.labelText"),
-  };
-
-  const fieldLabelProps = {
-    label: notSplitLabel,
-    fieldId,
-    details,
   };
 
   if (isSplit) {
-    fieldLabelProps.label = splitLabel;
+    label.exampleInput = t(
+      "lotseFlow.taxNumber.taxNumberInput.label.exampleInput"
+    );
   }
+
+  const fieldLabelProps = { label, fieldId, details };
 
   const labelComponent = <FieldLabelForSeparatedFields {...fieldLabelProps} />;
 

--- a/webapp/client/src/components/FormFieldTaxNumber.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.js
@@ -46,8 +46,6 @@ function FormFieldTaxNumber({
   const inputFieldLengths = isSplit ? [3, 4, 4] : [11];
   const labelComponent = isSplit ? splitLabelComponent : notSplitLabelComponent;
 
-  console.log(labelComponent);
-
   return (
     <FormFieldScaffolding
       {...{

--- a/webapp/client/src/components/FormFieldTaxNumber.test.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.test.js
@@ -52,6 +52,41 @@ describe("FormFieldTaxNumber is split", () => {
       );
     });
   });
+
+  describe("When pressing tab", () => {
+    beforeEach(() => {
+      userEvent.tab();
+    });
+
+    it("Set focus on first input field", () => {
+      expect(screen.getAllByRole("textbox")[0]).toHaveFocus();
+    });
+
+    describe("When typing", () => {
+      const input_characters = "123456789012";
+
+      beforeEach(() => {
+        userEvent.keyboard(input_characters);
+      });
+
+      it("Enter letters into first input field", () => {
+        expect(screen.getAllByRole("textbox")[0]).toHaveValue(
+          input_characters.slice(0, 3)
+        );
+      });
+    });
+
+    it("Set focus on second input field after second tab", () => {
+      userEvent.tab();
+      expect(screen.getAllByRole("textbox")[1]).toHaveFocus();
+    });
+
+    it("Set focus on third input field after third tab", () => {
+      userEvent.tab();
+      userEvent.tab();
+      expect(screen.getAllByRole("textbox")[2]).toHaveFocus();
+    });
+  });
 });
 
 describe("FormFieldTaxNumber is not split", () => {
@@ -86,6 +121,30 @@ describe("FormFieldTaxNumber is not split", () => {
       expect(screen.getByRole("textbox")).toHaveValue(
         input_characters.slice(0, 11)
       );
+    });
+  });
+
+  describe("When pressing tab", () => {
+    beforeEach(() => {
+      userEvent.tab();
+    });
+
+    it("Set focus on input field", () => {
+      expect(screen.getByRole("textbox")).toHaveFocus();
+    });
+
+    describe("When typing", () => {
+      const input_characters = "123456789012";
+
+      beforeEach(() => {
+        userEvent.keyboard(input_characters);
+      });
+
+      it("Enter letters into input field", () => {
+        expect(screen.getByRole("textbox")).toHaveValue(
+          input_characters.slice(0, 11)
+        );
+      });
     });
   });
 });

--- a/webapp/client/src/components/FormFieldTaxNumber.test.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.test.js
@@ -6,6 +6,7 @@ import FormFieldTaxNumber from "./FormFieldTaxNumber";
 
 describe("FormFieldTaxNumber is split", () => {
   let props;
+  const exampleInput = "exampleInput";
 
   beforeEach(() => {
     props = {
@@ -13,6 +14,7 @@ describe("FormFieldTaxNumber is split", () => {
       fieldId: "fooId",
       label: {
         text: "foo",
+        exampleInput: exampleInput,
       },
       errors: [],
       values: [],
@@ -23,6 +25,10 @@ describe("FormFieldTaxNumber is split", () => {
 
   it("Show three input fields", () => {
     expect(screen.getAllByRole("textbox")).toHaveLength(3);
+  });
+
+  it("Do not show example input", () => {
+    expect(screen.queryByText("exampleInput")).toBeNull();
   });
 
   describe("Type 12 characters into each input", () => {
@@ -91,6 +97,7 @@ describe("FormFieldTaxNumber is split", () => {
 
 describe("FormFieldTaxNumber is not split", () => {
   let props;
+  const exampleInput = "exampleInput";
 
   beforeEach(() => {
     props = {
@@ -98,6 +105,7 @@ describe("FormFieldTaxNumber is not split", () => {
       fieldId: "fooId",
       label: {
         text: "foo",
+        exampleInput: exampleInput,
       },
       errors: [],
       values: [],
@@ -108,6 +116,10 @@ describe("FormFieldTaxNumber is not split", () => {
 
   it("Show only one input field", () => {
     expect(screen.getAllByRole("textbox")).toHaveLength(1);
+  });
+
+  it("show example input", () => {
+    expect(screen.queryByText("exampleInput")).toBeNull();
   });
 
   describe("Type 12 characters into input", () => {

--- a/webapp/client/src/components/FormFieldTaxNumber.test.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.test.js
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { fireEvent } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
+import FormFieldTaxNumber from "./FormFieldTaxNumber";
+
+describe("FormFieldTaxNumber is split", () => {
+  let props;
+
+  beforeEach(() => {
+    props = {
+      fieldName: "fooName",
+      fieldId: "fooId",
+      label: {
+        text: "foo",
+      },
+      errors: [],
+      values: [],
+      isSplit: true,
+    };
+    render(<FormFieldTaxNumber {...props} />);
+  });
+
+  it("Show three input fields", () => {
+    expect(screen.getAllByRole("textbox")).toHaveLength(3);
+  });
+
+  describe("Type 12 characters into each input", () => {
+    const input_characters = "123456789012";
+
+    beforeEach(() => {
+      userEvent.type(screen.getAllByRole("textbox")[0], input_characters);
+      userEvent.type(screen.getAllByRole("textbox")[1], input_characters);
+      userEvent.type(screen.getAllByRole("textbox")[2], input_characters);
+    });
+
+    it("First input contains only first 3 characters", () => {
+      expect(screen.getAllByRole("textbox")[0]).toHaveValue(
+        input_characters.slice(0, 3)
+      );
+    });
+
+    it("First input contains only first 4 characters", () => {
+      expect(screen.getAllByRole("textbox")[1]).toHaveValue(
+        input_characters.slice(0, 4)
+      );
+    });
+
+    it("First input contains only first 4 characters", () => {
+      expect(screen.getAllByRole("textbox")[2]).toHaveValue(
+        input_characters.slice(0, 4)
+      );
+    });
+  });
+});
+
+describe("FormFieldTaxNumber is not split", () => {
+  let props;
+
+  beforeEach(() => {
+    props = {
+      fieldName: "fooName",
+      fieldId: "fooId",
+      label: {
+        text: "foo",
+      },
+      errors: [],
+      values: [],
+      isSplit: false,
+    };
+    render(<FormFieldTaxNumber {...props} />);
+  });
+
+  it("Show only one input field", () => {
+    expect(screen.getAllByRole("textbox")).toHaveLength(1);
+  });
+
+  describe("Type 12 characters into input", () => {
+    const input_characters = "123456789012";
+
+    beforeEach(() => {
+      userEvent.type(screen.getByRole("textbox"), input_characters);
+    });
+
+    it("Input contains only first 11 characters", () => {
+      expect(screen.getByRole("textbox")).toHaveValue(
+        input_characters.slice(0, 11)
+      );
+    });
+  });
+});

--- a/webapp/client/src/components/FormFieldTaxNumber.test.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.test.js
@@ -23,7 +23,7 @@ describe("FormFieldTaxNumber is split", () => {
     render(<FormFieldTaxNumber {...props} />);
   });
 
-  it("Show three input fields", () => {
+  it("should show three input fields", () => {
     expect(screen.getAllByRole("textbox")).toHaveLength(3);
   });
 

--- a/webapp/client/src/components/FormFieldTaxNumber.test.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { fireEvent } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import FormFieldTaxNumber from "./FormFieldTaxNumber";
 
@@ -23,15 +22,15 @@ describe("FormFieldTaxNumber is split", () => {
     render(<FormFieldTaxNumber {...props} />);
   });
 
-  it("should show three input fields", () => {
+  it("Should show three input fields", () => {
     expect(screen.getAllByRole("textbox")).toHaveLength(3);
   });
 
-  it("Do not show example input", () => {
+  it("Should not show example input", () => {
     expect(screen.queryByText("exampleInput")).toBeNull();
   });
 
-  describe("Type 12 characters into each input", () => {
+  describe("When typing 12 characters into each input", () => {
     const input_characters = "123456789012";
 
     beforeEach(() => {
@@ -40,19 +39,19 @@ describe("FormFieldTaxNumber is split", () => {
       userEvent.type(screen.getAllByRole("textbox")[2], input_characters);
     });
 
-    it("First input contains only first 3 characters", () => {
+    it("First input should only contain first 3 characters", () => {
       expect(screen.getAllByRole("textbox")[0]).toHaveValue(
         input_characters.slice(0, 3)
       );
     });
 
-    it("First input contains only first 4 characters", () => {
+    it("Second input should only contain first 4 characters", () => {
       expect(screen.getAllByRole("textbox")[1]).toHaveValue(
         input_characters.slice(0, 4)
       );
     });
 
-    it("First input contains only first 4 characters", () => {
+    it("Third input should only contain first 4 characters", () => {
       expect(screen.getAllByRole("textbox")[2]).toHaveValue(
         input_characters.slice(0, 4)
       );
@@ -64,7 +63,7 @@ describe("FormFieldTaxNumber is split", () => {
       userEvent.tab();
     });
 
-    it("Set focus on first input field", () => {
+    it("Should focus on first input field", () => {
       expect(screen.getAllByRole("textbox")[0]).toHaveFocus();
     });
 
@@ -75,19 +74,19 @@ describe("FormFieldTaxNumber is split", () => {
         userEvent.keyboard(input_characters);
       });
 
-      it("Enter letters into first input field", () => {
+      it("Should enter letters into first input field", () => {
         expect(screen.getAllByRole("textbox")[0]).toHaveValue(
           input_characters.slice(0, 3)
         );
       });
     });
 
-    it("Set focus on second input field after second tab", () => {
+    it("Should set focus on second input field after second tab", () => {
       userEvent.tab();
       expect(screen.getAllByRole("textbox")[1]).toHaveFocus();
     });
 
-    it("Set focus on third input field after third tab", () => {
+    it("Should set focus on third input field after third tab", () => {
       userEvent.tab();
       userEvent.tab();
       expect(screen.getAllByRole("textbox")[2]).toHaveFocus();
@@ -114,22 +113,22 @@ describe("FormFieldTaxNumber is not split", () => {
     render(<FormFieldTaxNumber {...props} />);
   });
 
-  it("Show only one input field", () => {
+  it("Should only show one input field", () => {
     expect(screen.getAllByRole("textbox")).toHaveLength(1);
   });
 
-  it("show example input", () => {
+  it("Should show example input", () => {
     expect(screen.queryByText("exampleInput")).toBeNull();
   });
 
-  describe("Type 12 characters into input", () => {
+  describe("When typing 12 characters into input", () => {
     const input_characters = "123456789012";
 
     beforeEach(() => {
       userEvent.type(screen.getByRole("textbox"), input_characters);
     });
 
-    it("Input contains only first 11 characters", () => {
+    it("Input should contain only first 11 characters", () => {
       expect(screen.getByRole("textbox")).toHaveValue(
         input_characters.slice(0, 11)
       );
@@ -141,7 +140,7 @@ describe("FormFieldTaxNumber is not split", () => {
       userEvent.tab();
     });
 
-    it("Set focus on input field", () => {
+    it("Should set focus on input field", () => {
       expect(screen.getByRole("textbox")).toHaveFocus();
     });
 
@@ -152,7 +151,7 @@ describe("FormFieldTaxNumber is not split", () => {
         userEvent.keyboard(input_characters);
       });
 
-      it("Enter letters into input field", () => {
+      it("Should enter letters into input field", () => {
         expect(screen.getByRole("textbox")).toHaveValue(
           input_characters.slice(0, 11)
         );

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -95,6 +95,16 @@ const translations = {
         "Mit Ihrer Registrierung beantragen Sie einen Freischaltcode bei Ihrer Finanzverwaltung. Sie erhalten diesen mit einem Brief <bold>innerhalb von zwei Wochen</bold> nach erfolgreicher Beantragung. Wenn Sie die Zusammenveranlagung nutzen möchten, muss sich nur eine Person registrieren.",
     },
   },
+  lotseFlow: {
+    taxNumber: {
+      taxNumberInput: {
+        label: {
+          labelText: "Steuernummer",
+          exampleInput: "Muss 10 oder 11 Ziffern haben",
+        },
+      },
+    },
+  },
   dateField: {
     day: "Tag",
     month: "Monat",

--- a/webapp/client/src/stories/FormFieldTaxNumber.stories.js
+++ b/webapp/client/src/stories/FormFieldTaxNumber.stories.js
@@ -1,0 +1,28 @@
+import React from "react";
+
+import FormFieldTaxNumber from "../components/FormFieldTaxNumber";
+import StepForm from "../components/StepForm";
+import { Default as StepFormDefault } from "./StepForm.stories";
+
+export default {
+  title: "Form Fields/TaxNumber",
+  component: FormFieldTaxNumber,
+};
+
+const Template = (args) => (
+  <StepForm {...StepFormDefault.args}>
+    <FormFieldTaxNumber {...args} />
+  </StepForm>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  fieldId: "taxNumber",
+  fieldName: "taxNumber",
+  label: {
+    text: "Steuernummer",
+  },
+  errors: [],
+  values: [],
+  isSplit: false,
+};

--- a/webapp/client/src/stories/FormFieldTaxNumber.stories.js
+++ b/webapp/client/src/stories/FormFieldTaxNumber.stories.js
@@ -21,6 +21,7 @@ Default.args = {
   fieldName: "taxNumber",
   label: {
     text: "Steuernummer",
+    exampleInput: "123 3455 3456",
   },
   errors: [],
   values: [],

--- a/webapp/client/src/stories/FormFieldTaxNumber.stories.js
+++ b/webapp/client/src/stories/FormFieldTaxNumber.stories.js
@@ -27,3 +27,16 @@ Default.args = {
   values: [],
   isSplit: false,
 };
+
+export const NotSplitDefaultValue = Template.bind({});
+NotSplitDefaultValue.args = {
+  ...Default.args,
+  values: ["12345678901"],
+};
+
+export const SplitDefaultValue = Template.bind({});
+SplitDefaultValue.args = {
+  ...Default.args,
+  values: ["123", "4567", "8901"],
+  isSplit: true,
+};


### PR DESCRIPTION
# Short Description
Similarly to #336  and #335, this adds another component needed to reactify the tax number page

# Changes
- Add a React component for the tax number that can be split
- Add unit tests for that component
- Add a storybook for that component

# Feedback
- Are there any tests missing?
- Anything else that you would have done differently?
