### PR TITLE
STL-1417-QA-Correct_since_validation_message

### DIFF
--- a/webapp/app/forms/validations/date_validations.py
+++ b/webapp/app/forms/validations/date_validations.py
@@ -40,6 +40,9 @@ class ValidDateOf:
 
         if not day or not month or not year: 
             raise ValidationError(self.message_incomplete)
+        
+        if len(year) < 4:            
+            raise ValidationError(self.message_incomplete)
             
         try:
             input_date = datetime.date(int(year), int(month), int(day))


### PR DESCRIPTION
# Short Description
- If the year (the date since which the user has been widowed, for example) has less than 4 digits, an "incomplete" validation message is displayed in the Steuerlotse.

# Changes
- Add validation in ValidDateOf
