### PR TITLE
Use destructuring assignment correctly

### DIFF
--- a/webapp/client/src/components/FieldLabel.js
+++ b/webapp/client/src/components/FieldLabel.js
@@ -10,11 +10,12 @@ const Label = styled.label`
 `;
 
 export default function FieldLabel(props) {
+  const { fieldId } = props;
   return (
     <FieldLabelScaffolding
       {...props}
       render={(innerContent, className) => (
-        <Label htmlFor={props.fieldId} className={className}>
+        <Label htmlFor={fieldId} className={className}>
           {innerContent}
         </Label>
       )}


### PR DESCRIPTION
# Short Description
- The `main` storybook deploy is currently failing because a rule is not enforced correctly: [react/destructuring-assignment](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md#enforce-consistent-usage-of-destructuring-assignment-of-props-state-and-context-reactdestructuring-assignment)
- This rule was enforced more forwardly (also in nested functions) by this PR: https://github.com/digitalservice4germany/steuerlotse/pull/374

# Changes
- Destructure the props correctly in FieldLabel (the only place this is now failing

# Feedback
- Would you rather use another way to do this - as there are multiple - see the linked documentation
