### PR TITLE
Set stored_data correctly for display steps

### DIFF
--- a/webapp/app/forms/steps/steuerlotse_step.py
+++ b/webapp/app/forms/steps/steuerlotse_step.py
@@ -141,13 +141,11 @@ class FormSteuerlotseStep(SteuerlotseStep):
     @classmethod
     def prepare_render_info(cls, stored_data, input_data=None, should_update_data=False, *args, **kwargs):
         render_info = super().prepare_render_info(stored_data, input_data, should_update_data, *args, **kwargs)
-        render_info.form = cls.create_form(form_data=input_data, prefilled_data=stored_data)
+        render_info.form = cls.create_form(form_data=input_data, prefilled_data=render_info.stored_data)
 
         if should_update_data and render_info.form.validate():
             render_info.data_is_valid = True
-            stored_data.update(render_info.form.data)
-
-        render_info.stored_data = stored_data
+            render_info.stored_data.update(render_info.form.data)
 
         return render_info
 

--- a/webapp/app/forms/steps/steuerlotse_step.py
+++ b/webapp/app/forms/steps/steuerlotse_step.py
@@ -60,6 +60,7 @@ class SteuerlotseStep(object):
             step_intro=ngettext(cls.intro, cls.intro_multiple, num=cls.number_of_users(stored_data))
             if cls.intro_multiple else cls.intro,
             form=None,
+            stored_data=stored_data,
             prev_url=None,
             next_url=None,
             submit_url=None,

--- a/webapp/tests/forms/steps/test_eligibility_steps.py
+++ b/webapp/tests/forms/steps/test_eligibility_steps.py
@@ -3397,8 +3397,28 @@ class TestForeignCountriesDecisionEligibilityInputFormSteuerlotseStep:
 
 class TestEligibilitySuccessDisplaySteuerlotseStep(unittest.TestCase):
     @pytest.fixture(autouse=True)
-    def attach_fixtures(self, test_request_context):
+    def attach_fixtures(self, test_request_context, app):
         self.req = test_request_context
+        self.app = app
+
+    def test_if_session_data_correct_then_set_prev_input_step_correctly(self):
+        correct_session_data = {'marital_status_eligibility': 'single',
+                                'user_a_has_elster_account_eligibility': 'no',
+                                'alimony_eligibility': 'no',
+                                'pension_eligibility': 'yes',
+                                'investment_income_eligibility': 'no',
+                                'taxed_investment_income_eligibility': 'no',
+                                'employment_income_eligibility': 'no',
+                                'other_income_eligibility': 'no',
+                                'foreign_country_eligibility': 'no'}
+        with self.app.test_request_context(method='GET') as req:
+            req.session = SecureCookieSession(
+                {_ELIGIBILITY_DATA_KEY: create_session_form_data(correct_session_data)})
+            step = EligibilityStepChooser('eligibility').get_correct_step(
+                EligibilitySuccessDisplaySteuerlotseStep.name, False, ImmutableMultiDict({}))
+            expected_url = step.url_for_step(ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep.name)
+            step.handle()
+        self.assertEqual(expected_url, step.render_info.prev_url)
 
     def test_if_user_b_has_no_elster_account_then_set_correct_info(self):
         expected_information = ['form.eligibility.result-note.deadline',

--- a/webapp/tests/forms/steps/test_steuerlotse_step.py
+++ b/webapp/tests/forms/steps/test_steuerlotse_step.py
@@ -173,6 +173,10 @@ class TestSteuerlotseStepHandle(unittest.TestCase):
             self.assertEqual(post_handle_stored_data, handle_result)
 
 class TestSteuerlotseStepPrepareRenderInfo:
+    def test_stored_data_set_to_render_info(self):
+        stored_data = {'favourite_characters': 'Fred & George'}
+        render_info = MockMiddleStep.prepare_render_info(stored_data)
+        assert render_info.stored_data == stored_data
 
     def test_if_single_then_set_title_and_intro_correct(self):
         single_title = "Joe"
@@ -191,9 +195,6 @@ class TestSteuerlotseStepPrepareRenderInfo:
 
         assert render_info.step_title == single_title
         assert render_info.step_intro == single_intro
-
-
-
 
     def test_if_multiple_then_set_title_and_intro_correct(self):
         multiple_title = "Kevin, Joe, Nick"


### PR DESCRIPTION
# Short Description
- The back link for the eligibility success page didn't work properly: You were redirected to the first step of the eligibility flow instead of the foreign_country step.
- This was caused by no data being in the render_info after executing `prepare_render_info`.
- This is because the success step is a display step. But we only set `render_info.stored_data` for FormSteps.
- So far we didn't use any DisplaySteps in the lotse flow (where deleting data would be more of an issue)

# Changes
- Set the stored_data in the `prepare_render_info` method
- Test that it's set
- Test that the backlink works for the success page

# Feedback
- Any^^
