### PR TITLE
Fix doubled label for legacy yes no fields

### DIFF
--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -53,7 +53,7 @@
 {% macro render_field(field, cols=6, class="", field_div_classes="", d_block=False, as_card=False, position_details_after=False, hide_label=False, hide_errors=False, first_field=False, optional=False) %}
     {% if field.type == 'ConfirmationField' %}
         {{ _render_field(field, 12, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, position_details_after=position_details_after, hide_label=True, hide_errors=hide_errors, first_field=first_field, optional=optional) }}
-    {% elif field.type in ('BooleanField', 'YesNoField') %}
+    {% elif field.type in ('BooleanField', 'LegacyYesNoField') %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, position_details_after=position_details_after, hide_label=True, hide_errors=hide_errors, first_field=first_field, optional=optional) }}
     {% elif field.type == 'RadioField' or field.type == 'LegacyIdNrField' or field.type == 'LegacySteuerlotseDateField' %}
         {{ _render_field(field, cols, class=class, field_div_classes=field_div_classes, d_block=d_block, as_card=as_card, position_details_after=position_details_after, hide_label=True, hide_errors=True, first_field=first_field, optional=optional) }}


### PR DESCRIPTION
# Short Description
- There were two labels for the `familienstand_married_lived_separated` and `familienstand_widowed_lived_separated` fields on the familienstand page. 
- That was because the components.html did not reflect the renaming of YesNoField -> LegacyYesNoField

# Changes
- Inlcude `LegacyYesNoField` in the macro to hide one label

# Feedback
- Should we remove the `YesNoField`? It's only used on the steuernummer page (which is react) so it should be fine?
