### PR TITLE
Set no max length for Hessen's tax number input

### DIFF
--- a/webapp/client/src/components/FormFieldSeparatedField.js
+++ b/webapp/client/src/components/FormFieldSeparatedField.js
@@ -38,6 +38,7 @@ function FormFieldSeparatedField({
   inputFieldLabels,
   extraFieldProps,
   transformUppercase,
+  setMaxLength,
 }) {
   const container = useRef();
 
@@ -97,7 +98,7 @@ function FormFieldSeparatedField({
               name={fieldName}
               onPaste={handlePaste}
               defaultValue={values.length > index ? values[index] : ""}
-              maxLength={length}
+              maxLength={setMaxLength ? length : null}
               data-field-length={length}
               // TODO: autofocus is under review.
               // eslint-disable-next-line
@@ -168,6 +169,7 @@ FormFieldSeparatedField.propTypes = {
   transformUppercase: PropTypes.bool,
   required: PropTypes.bool,
   autofocus: PropTypes.bool,
+  setMaxLength: PropTypes.bool,
 };
 
 FormFieldSeparatedField.defaultProps = {
@@ -179,6 +181,7 @@ FormFieldSeparatedField.defaultProps = {
   transformUppercase: false,
   required: false,
   autofocus: false,
+  setMaxLength: true,
 };
 
 export default FormFieldSeparatedField;

--- a/webapp/client/src/components/FormFieldTaxNumber.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.js
@@ -28,6 +28,7 @@ function FormFieldTaxNumber({
 
   let reformattedValues = values.join("");
   let inputFieldLengths;
+  let setMaxLength = true;
   switch (splitType) {
     case "splitType_0":
       inputFieldLengths = [2, 3, 5];
@@ -55,6 +56,7 @@ function FormFieldTaxNumber({
       break;
     default:
       inputFieldLengths = [11];
+      setMaxLength = false;
       reformattedValues = [reformattedValues];
       label.exampleInput = t(
         "lotseFlow.taxNumber.taxNumberInput.label.exampleInput"
@@ -97,6 +99,7 @@ function FormFieldTaxNumber({
               ? values
               : reformattedValues,
             required,
+            setMaxLength,
           }}
           key={`steuernummerField-${splitType}`} // Enforce re-rendering if other splitType is used
           autoFocus={autofocus || Boolean(errors.length)}

--- a/webapp/client/src/components/FormFieldTaxNumber.test.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.test.js
@@ -225,6 +225,10 @@ describe("FormFieldTaxNumber is not split", () => {
     render(<FormFieldTaxNumber {...props} />);
   });
 
+  it("Should set no maxLength attribute", () => {
+    expect(screen.getAllByRole("textbox")).not.toHaveProperty("max-lenght");
+  });
+
   it("Should only show one input field", () => {
     expect(screen.getAllByRole("textbox")).toHaveLength(1);
   });
@@ -240,10 +244,8 @@ describe("FormFieldTaxNumber is not split", () => {
       userEvent.type(screen.getByRole("textbox"), inputCharacters);
     });
 
-    it("Input should contain only first 11 characters", () => {
-      expect(screen.getByRole("textbox")).toHaveValue(
-        inputCharacters.slice(0, 11)
-      );
+    it("Input should contain all 12 characters", () => {
+      expect(screen.getByRole("textbox")).toHaveValue(inputCharacters);
     });
   });
 
@@ -264,9 +266,7 @@ describe("FormFieldTaxNumber is not split", () => {
       });
 
       it("Should enter letters into input field", () => {
-        expect(screen.getByRole("textbox")).toHaveValue(
-          inputCharacters.slice(0, 11)
-        );
+        expect(screen.getByRole("textbox")).toHaveValue(inputCharacters);
       });
     });
   });

--- a/webapp/client/src/components/FormFieldTaxNumber.test.js
+++ b/webapp/client/src/components/FormFieldTaxNumber.test.js
@@ -226,7 +226,7 @@ describe("FormFieldTaxNumber is not split", () => {
   });
 
   it("Should set no maxLength attribute", () => {
-    expect(screen.getAllByRole("textbox")).not.toHaveProperty("max-lenght");
+    expect(screen.getByRole("textbox").hasOwnProperty("maxLength")).toBe(false);
   });
 
   it("Should only show one input field", () => {

--- a/webapp/client/src/pages/TaxNumberPage.test.js
+++ b/webapp/client/src/pages/TaxNumberPage.test.js
@@ -76,6 +76,7 @@ describe("TaxNumberPage", () => {
         },
       ],
       numberOfUsers: 1,
+      prevUrl: "fooUrl",
     };
     render(<TaxNumberPage {...props} />);
   });
@@ -470,6 +471,7 @@ describe("TaxNumberPage with tax number set", () => {
         },
       ],
       numberOfUsers: 1,
+      prevUrl: "fooUrl",
     };
     render(<TaxNumberPage {...props} />);
   });

--- a/webapp/client/src/stories/FormFieldTaxNumber.stories.js
+++ b/webapp/client/src/stories/FormFieldTaxNumber.stories.js
@@ -21,7 +21,7 @@ Default.args = {
   fieldName: "taxNumber",
   errors: [],
   values: [],
-  splitType: "3",
+  splitType: "splitType_notSplit",
 };
 
 export const NotSplitDefaultValue = Template.bind({});
@@ -30,23 +30,22 @@ NotSplitDefaultValue.args = {
   values: ["12345678901"],
 };
 
-export const SplitDefaultValue = Template.bind({});
-SplitDefaultValue.args = {
-  ...Default.args,
-  values: ["123", "4567", "8901"],
-  splitType: "0",
-};
-
-export const SplitWithError = Template.bind({});
-SplitWithError.args = {
+export const NotSplitWithError = Template.bind({});
+NotSplitWithError.args = {
   ...Default.args,
   values: ["123", "4567", "8901"],
   errors: ["Sie müssen eine gültige Steuernummer angeben"],
 };
 
-export const NotSplitWithError = Template.bind({});
-NotSplitWithError.args = {
+export const SplitDefaultValue = Template.bind({});
+SplitDefaultValue.args = {
   ...Default.args,
   values: ["123", "4567", "8901"],
+  splitType: "splitType_0",
+};
+
+export const SplitWithError = Template.bind({});
+SplitWithError.args = {
+  ...SplitDefaultValue.args,
   errors: ["Sie müssen eine gültige Steuernummer angeben"],
 };


### PR DESCRIPTION
# Short Description
In QA it was mentioned that the tax number input for Hessen should not have a max length attribute. This changes that.

# Changes
- Add a flag for the SplitField to indicate whether the max-length should be set
- Use that flag to indicate no maxLength for Hessen's input field
- Add tests

# Feedback
- Would have had a better idea to implement this?
