### PR TITLE
Expand field label width over the field's width

### DIFF
--- a/webapp/client/public/css/base.css
+++ b/webapp/client/public/css/base.css
@@ -68,26 +68,32 @@ a:visited {
 /* INPUTS */
 .input-width-2 {
   width: var(--input-width-2);
+  max-width: var(--input-width-2);
 }
 
 .input-width-3 {
   width: var(--input-width-3);
+  max-width: var(--input-width-3);
 }
 
 .input-width-4 {
   width: var(--input-width-4);
+  max-width: var(--input-width-4);
 }
 
 .input-width-5 {
   width: var(--input-width-5);
+  max-width: var(--input-width-5);
 }
 
 .input-width-6 {
   width: var(--input-width-6);
+  max-width: var(--input-width-6);
 }
 
 .input-width-10 {
   width: var(--input-width-10);
+  max-width: var(--input-width-10);
 }
 
 .input-width-25 {

--- a/webapp/client/src/components/FormFieldConsentBox.js
+++ b/webapp/client/src/components/FormFieldConsentBox.js
@@ -59,7 +59,6 @@ function FormFieldConsentBox({
       {...{
         fieldName,
         errors,
-        cols: "12",
       }}
       hideLabel
       render={() => (

--- a/webapp/client/src/components/FormFieldDropDown.js
+++ b/webapp/client/src/components/FormFieldDropDown.js
@@ -40,11 +40,11 @@ function FormFieldDropDown({
         errors,
         cols: "6",
       }}
-      labelComponent=<FieldLabel {...{ label, fieldId, details }} />
+      labelComponent={<FieldLabel {...{ label, fieldId, details }} />}
       render={() => (
         <DropDown
           id={fieldId}
-          className="custom-select steuerlotse-select"
+          className="custom-select steuerlotse-select input-width-25"
           name={fieldName}
           defaultValue={selectedValue}
           required={required}

--- a/webapp/client/src/components/FormFieldDropDown.js
+++ b/webapp/client/src/components/FormFieldDropDown.js
@@ -38,7 +38,6 @@ function FormFieldDropDown({
       {...{
         fieldName,
         errors,
-        cols: "6",
       }}
       labelComponent={<FieldLabel {...{ label, fieldId, details }} />}
       render={() => (

--- a/webapp/client/src/components/FormFieldScaffolding.js
+++ b/webapp/client/src/components/FormFieldScaffolding.js
@@ -22,7 +22,6 @@ export default function FormFieldScaffolding({
   fieldName,
   labelComponent,
   errors,
-  cols,
   displayBlock,
   maxCharacters,
   extraClassNames,
@@ -41,7 +40,7 @@ export default function FormFieldScaffolding({
     });
   }, []);
 
-  const divClassNames = classNames(`col-md-${cols}`, "px-0", fieldDivClasses, {
+  const divClassNames = classNames("px-0", fieldDivClasses, {
     "error-found-line": errors.length,
   });
 
@@ -89,7 +88,6 @@ FormFieldScaffolding.propTypes = {
   fieldName: PropTypes.string.isRequired,
   labelComponent: PropTypes.element,
   errors: PropTypes.arrayOf(PropTypes.string),
-  cols: PropTypes.string,
   extraClassNames: PropTypes.string, // field.render_kw['class']
   maxCharacters: PropTypes.string, // field.render_kw['max_characters']
   fieldDivClasses: PropTypes.string,
@@ -101,7 +99,6 @@ FormFieldScaffolding.propTypes = {
 FormFieldScaffolding.defaultProps = {
   labelComponent: undefined,
   errors: [],
-  cols: "6",
   extraClassNames: "",
   fieldDivClasses: "",
   maxCharacters: undefined,

--- a/webapp/client/src/components/FormFieldSeparatedField.js
+++ b/webapp/client/src/components/FormFieldSeparatedField.js
@@ -103,7 +103,10 @@ function FormFieldSeparatedField({
               // eslint-disable-next-line
               autoFocus={autofocus && index === 0}
               required={required}
-              className={classNames("form-control", `input-width-${length}`)}
+              className={classNames(
+                "form-control",
+                `input-width-${length < 11 ? length : 25}`
+              )}
               style={transformUppercase ? { textTransform: "uppercase" } : {}}
               {...extraFieldProps}
             />

--- a/webapp/client/src/components/FormFieldSeparatedField.js
+++ b/webapp/client/src/components/FormFieldSeparatedField.js
@@ -90,6 +90,9 @@ function FormFieldSeparatedField({
       <SeparatedField ref={container} className="separated-field">
         {inputFieldLengths.map((length, index) => {
           const subFieldId = `${fieldId}_${index + 1}`;
+          const subFieldLengthClass = `input-width-${
+            length < 11 ? length : 25
+          }`;
           const inputElement = (
             <input
               type="text"
@@ -103,10 +106,7 @@ function FormFieldSeparatedField({
               // eslint-disable-next-line
               autoFocus={autofocus && index === 0}
               required={required}
-              className={classNames(
-                "form-control",
-                `input-width-${length < 11 ? length : 25}`
-              )}
+              className={classNames("form-control", subFieldLengthClass)}
               style={transformUppercase ? { textTransform: "uppercase" } : {}}
               {...extraFieldProps}
             />
@@ -117,11 +117,7 @@ function FormFieldSeparatedField({
             // eslint-disable-next-line
             <React.Fragment key={index}>
               {inputFieldLabels.length > index ? (
-                <div
-                  className={classNames(
-                    `input-width-${length < 11 ? length : 25}`
-                  )}
-                >
+                <div className={classNames(subFieldLengthClass)}>
                   <SeparatedFieldLabel
                     htmlFor={subFieldId}
                     className="sub-field-label"

--- a/webapp/client/src/components/FormFieldSeparatedField.js
+++ b/webapp/client/src/components/FormFieldSeparatedField.js
@@ -117,7 +117,11 @@ function FormFieldSeparatedField({
             // eslint-disable-next-line
             <React.Fragment key={index}>
               {inputFieldLabels.length > index ? (
-                <div>
+                <div
+                  className={classNames(
+                    `input-width-${length < 11 ? length : 25}`
+                  )}
+                >
                   <SeparatedFieldLabel
                     htmlFor={subFieldId}
                     className="sub-field-label"

--- a/webapp/client/src/components/FormFieldYesNo.js
+++ b/webapp/client/src/components/FormFieldYesNo.js
@@ -99,7 +99,6 @@ function FormFieldYesNo({
       {...{
         fieldName,
         errors,
-        cols: "6",
       }}
       hideLabel
       render={() => (

--- a/webapp/client/src/components/FormRowCentered.js
+++ b/webapp/client/src/components/FormRowCentered.js
@@ -12,6 +12,7 @@ const FormRowCentered = styled.div`
 
   & > * {
     margin: 0 var(--spacing-02);
+    flex: 1;
   }
 
   /* TODO: adapt to make sure this keeps working when adding grouped fields component */

--- a/webapp/client/src/components/SelectableCard.js
+++ b/webapp/client/src/components/SelectableCard.js
@@ -110,7 +110,6 @@ function SelectableCard({
       {...{
         fieldName,
         errors,
-        cols: "12",
       }}
       hideLabel
       render={() => (

--- a/webapp/client/src/pages/TaxNumberPage.js
+++ b/webapp/client/src/pages/TaxNumberPage.js
@@ -275,7 +275,7 @@ export default function TaxNumberPage({
   );
 
   const requestNewTaxNumberCheckbox = (
-    <FormRowCentered key="requestNewTaxNumberRow">
+    <>
       <SubHeading>
         {t("lotseFlow.taxNumber.requestNewTaxNumber.headline")}
       </SubHeading>
@@ -294,7 +294,7 @@ export default function TaxNumberPage({
         }
         errors={fields.requestNewTaxNumber.errors}
       />
-    </FormRowCentered>
+    </>
   );
 
   const shownFields = [];

--- a/webapp/client/src/pages/TaxNumberPage.js
+++ b/webapp/client/src/pages/TaxNumberPage.js
@@ -275,7 +275,7 @@ export default function TaxNumberPage({
   );
 
   const requestNewTaxNumberCheckbox = (
-    <>
+    <div key="requestNewTaxNumberRow">
       <SubHeading>
         {t("lotseFlow.taxNumber.requestNewTaxNumber.headline")}
       </SubHeading>
@@ -294,7 +294,7 @@ export default function TaxNumberPage({
         }
         errors={fields.requestNewTaxNumber.errors}
       />
-    </>
+    </div>
   );
 
   const shownFields = [];

--- a/webapp/client/src/stories/FormFieldTaxNumber.stories.js
+++ b/webapp/client/src/stories/FormFieldTaxNumber.stories.js
@@ -21,7 +21,7 @@ Default.args = {
   fieldName: "taxNumber",
   errors: [],
   values: [],
-  splitType: "3",
+  splitType: "splitType_notSplit",
 };
 
 export const NotSplitDefaultValue = Template.bind({});
@@ -34,13 +34,14 @@ export const SplitDefaultValue = Template.bind({});
 SplitDefaultValue.args = {
   ...Default.args,
   values: ["123", "4567", "8901"],
-  splitType: "0",
+  splitType: "splitType_0",
 };
 
 export const SplitWithError = Template.bind({});
 SplitWithError.args = {
   ...Default.args,
   values: ["123", "4567", "8901"],
+  splitType: "splitType_0",
   errors: ["Sie müssen eine gültige Steuernummer angeben"],
 };
 

--- a/webapp/client/src/storybook-assets/base.css
+++ b/webapp/client/src/storybook-assets/base.css
@@ -69,26 +69,32 @@ a:visited {
 /* INPUTS */
 .input-width-2 {
   width: var(--input-width-2);
+  max-width: var(--input-width-2);
 }
 
 .input-width-3 {
   width: var(--input-width-3);
+  max-width: var(--input-width-3);
 }
 
 .input-width-4 {
   width: var(--input-width-4);
+  max-width: var(--input-width-4);
 }
 
 .input-width-5 {
   width: var(--input-width-5);
+  max-width: var(--input-width-5);
 }
 
 .input-width-6 {
   width: var(--input-width-6);
+  max-width: var(--input-width-6);
 }
 
 .input-width-10 {
   width: var(--input-width-10);
+  max-width: var(--input-width-10);
 }
 
 .input-width-25 {


### PR DESCRIPTION
# Short Description
- We want labels to be able to go over the complete width of the page while the fields themselves stay at a certain width
- To do this I get rid of the cols attribute and instead set the classes we already set for normal text input fields: input-width-x

# Changes
- Remove cols
- Limit Dropdown width
- Add `flex: 1` to elements inside a `FormRowCentered` to let the elements expand properly
- Add max-width to the `input-width-x` classes
- Remove form row for the request_new_tax_nr field - this was never a row anyways^^

# Feedback
- What do you think of the solution?
- Do you think we also need to do this for the templates right away? Or can that wait until we properly implement them as react components?
