### PR TITLE
Add telephone number react page

### DIFF
--- a/webapp/client/src/components/FieldLabelScaffolding.js
+++ b/webapp/client/src/components/FieldLabelScaffolding.js
@@ -27,7 +27,7 @@ export default function FieldLabelScaffolding({
       {render(
         <>
           {label.text}
-          {label.optional && <OptionalHint />}
+          {label.showOptionalTag && <OptionalHint />}
           {label.help && <HelpModal title={label.text} body={label.help} />}
         </>,
         labelClassNames
@@ -52,7 +52,7 @@ FieldLabelScaffolding.propTypes = {
   fieldId: PropTypes.string.isRequired,
   label: PropTypes.exact({
     text: PropTypes.string,
-    optional: PropTypes.bool,
+    showOptionalTag: PropTypes.bool,
     help: PropTypes.string, // field.render_kw['help']
     exampleInput: PropTypes.string, // field.render_kw["example_input"]
   }),
@@ -66,7 +66,7 @@ FieldLabelScaffolding.propTypes = {
 FieldLabelScaffolding.defaultProps = {
   label: {
     text: undefined,
-    optional: false,
+    showOptionalTag: false,
     help: undefined,
     exampleInput: undefined,
   },

--- a/webapp/client/src/components/FormFieldTextInput.js
+++ b/webapp/client/src/components/FormFieldTextInput.js
@@ -1,0 +1,68 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import FormFieldScaffolding from "./FormFieldScaffolding";
+import FieldLabel from "./FieldLabel";
+import FormFieldSeparatedField from "./FormFieldSeparatedField";
+
+function FormFieldTextInput({
+  fieldName,
+  fieldId,
+  value,
+  required,
+  autofocus,
+  label,
+  maxLength,
+  setMaxLength,
+  details,
+  errors,
+}) {
+  return (
+    <FormFieldScaffolding
+      {...{
+        fieldName,
+        errors,
+      }}
+      labelComponent={<FieldLabel {...{ label, fieldId, details }} />}
+      render={() => (
+        <input
+          type="text"
+          id={fieldId}
+          name={fieldName}
+          defaultValue={value}
+          maxLength={setMaxLength ? maxLength : null}
+          data-field-length={maxLength}
+          // TODO: autofocus is under review.
+          // eslint-disable-next-line
+          autoFocus={autofocus || Boolean(errors.length)}
+          required={required}
+          className={classNames("form-control", `input-width-${maxLength}`)}
+        />
+      )}
+    />
+  );
+}
+
+FormFieldTextInput.propTypes = {
+  fieldId: PropTypes.string.isRequired,
+  fieldName: PropTypes.string.isRequired,
+  errors: PropTypes.arrayOf(PropTypes.string).isRequired,
+  autofocus: PropTypes.bool,
+  required: PropTypes.bool,
+  value: PropTypes.string.isRequired,
+  label: FieldLabel.propTypes.label,
+  maxLength: PropTypes.number,
+  setMaxLength: PropTypes.bool,
+  details: FieldLabel.propTypes.details,
+};
+
+FormFieldTextInput.defaultProps = {
+  autofocus: FormFieldSeparatedField.defaultProps.autofocus,
+  required: FormFieldSeparatedField.defaultProps.required,
+  label: FieldLabel.defaultProps.label,
+  maxLength: 25,
+  setMaxLength: false,
+  details: FieldLabel.defaultProps.details,
+};
+
+export default FormFieldTextInput;

--- a/webapp/client/src/components/FormFieldTextInput.js
+++ b/webapp/client/src/components/FormFieldTextInput.js
@@ -12,8 +12,8 @@ function FormFieldTextInput({
   required,
   autofocus,
   label,
+  maxWidth,
   maxLength,
-  setMaxLength,
   details,
   errors,
 }) {
@@ -30,13 +30,12 @@ function FormFieldTextInput({
           id={fieldId}
           name={fieldName}
           defaultValue={value}
-          maxLength={setMaxLength ? maxLength : null}
-          data-field-length={maxLength}
+          maxLength={maxLength}
           // TODO: autofocus is under review.
           // eslint-disable-next-line
           autoFocus={autofocus || Boolean(errors.length)}
           required={required}
-          className={classNames("form-control", `input-width-${maxLength}`)}
+          className={classNames("form-control", `input-width-${maxWidth}`)}
         />
       )}
     />
@@ -51,8 +50,8 @@ FormFieldTextInput.propTypes = {
   required: PropTypes.bool,
   value: PropTypes.string.isRequired,
   label: FieldLabel.propTypes.label,
+  maxWidth: PropTypes.number,
   maxLength: PropTypes.number,
-  setMaxLength: PropTypes.bool,
   details: FieldLabel.propTypes.details,
 };
 
@@ -60,8 +59,8 @@ FormFieldTextInput.defaultProps = {
   autofocus: FormFieldSeparatedField.defaultProps.autofocus,
   required: FormFieldSeparatedField.defaultProps.required,
   label: FieldLabel.defaultProps.label,
-  maxLength: 25,
-  setMaxLength: false,
+  maxWidth: 25,
+  maxLength: undefined,
   details: FieldLabel.defaultProps.details,
 };
 

--- a/webapp/client/src/components/FormFieldTextInput.test.js
+++ b/webapp/client/src/components/FormFieldTextInput.test.js
@@ -6,7 +6,7 @@ import FormFieldTextInput from "./FormFieldTextInput";
 describe("FormFieldTextInput", () => {
   let props;
 
-  describe("Base Field", () => {
+  describe("When default props used", () => {
     beforeEach(() => {
       props = {
         fieldId: "text-input",
@@ -20,24 +20,51 @@ describe("FormFieldTextInput", () => {
       render(<FormFieldTextInput {...props} />);
     });
 
-    describe("When pressing tab", () => {
-      beforeEach(() => {
-        userEvent.tab();
-      });
+    it("Should set focus on field on tab", () => {
+      userEvent.tab();
+      expect(screen.getByRole("textbox")).toHaveFocus();
+    });
 
-      it("Should set focus on field", () => {
-        expect(screen.getByRole("textbox")).toHaveFocus();
-      });
+    it("Should enter keyboard input into input after pressing tab", () => {
+      userEvent.tab();
+      userEvent.keyboard("Helloo");
+      expect(screen.getByLabelText("Label")).toHaveValue("Helloo");
+    });
 
-      describe("When pressing tab again", () => {
-        beforeEach(() => {
-          userEvent.tab();
-        });
+    it("Should unset focus on field when pressing tab two times", () => {
+      userEvent.tab();
+      userEvent.tab();
+      expect(screen.getByRole("textbox")).not.toHaveFocus();
+    });
+  });
 
-        it("Should unset focus on field", () => {
-          expect(screen.getByRole("textbox")).not.toHaveFocus();
-        });
-      });
+  describe("When maxWidth given", () => {
+    beforeEach(() => {
+      props = {
+        fieldId: "text-input",
+        fieldName: "text-input",
+        label: {
+          text: "Label",
+        },
+        errors: [],
+        value: "",
+        maxWidth: 5,
+      };
+      render(<FormFieldTextInput {...props} />);
+    });
+
+    it("Should not limit input of values", () => {
+      userEvent.type(
+        screen.getByLabelText("Label"),
+        "Supercalifragilisticexpialidocious"
+      );
+      expect(screen.getByLabelText("Label")).toHaveValue(
+        "Supercalifragilisticexpialidocious"
+      );
+    });
+
+    it("should set width class", () => {
+      expect(screen.getByLabelText("Label")).toHaveClass("input-width-5");
     });
   });
 
@@ -56,39 +83,22 @@ describe("FormFieldTextInput", () => {
       render(<FormFieldTextInput {...props} />);
     });
 
-    it("Should not limit input of values", () => {
-      userEvent.type(
-        screen.getByLabelText("Label"),
-        "Supercalifragilisticexpialidocious"
-      );
-      expect(screen.getByLabelText("Label")).toHaveValue(
-        "Supercalifragilisticexpialidocious"
-      );
-    });
-  });
-
-  describe("When maxLength given and setMaxLength true", () => {
-    beforeEach(() => {
-      props = {
-        fieldId: "text-input",
-        fieldName: "text-input",
-        label: {
-          text: "Label",
-        },
-        errors: [],
-        value: "",
-        maxLength: 5,
-        setMaxLength: true,
-      };
-      render(<FormFieldTextInput {...props} />);
-    });
-
     it("Should limit input of values", () => {
       userEvent.type(
         screen.getByLabelText("Label"),
         "Supercalifragilisticexpialidocious"
       );
       expect(screen.getByLabelText("Label")).toHaveValue("Super");
+    });
+
+    it("should not set width class", () => {
+      expect(screen.getByLabelText("Label")).not.toHaveClass("input-width-5");
+    });
+
+    it("Should enter keyboard input into input after pressing tab", () => {
+      userEvent.tab();
+      userEvent.keyboard("Helloo");
+      expect(screen.getByLabelText("Label")).toHaveValue("Hello");
     });
   });
 });

--- a/webapp/client/src/components/FormFieldTextInput.test.js
+++ b/webapp/client/src/components/FormFieldTextInput.test.js
@@ -1,0 +1,94 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FormFieldTextInput from "./FormFieldTextInput";
+
+describe("FormFieldTextInput", () => {
+  let props;
+
+  describe("Base Field", () => {
+    beforeEach(() => {
+      props = {
+        fieldId: "text-input",
+        fieldName: "text-input",
+        label: {
+          text: "Label",
+        },
+        errors: [],
+        value: "",
+      };
+      render(<FormFieldTextInput {...props} />);
+    });
+
+    describe("When pressing tab", () => {
+      beforeEach(() => {
+        userEvent.tab();
+      });
+
+      it("Should set focus on field", () => {
+        expect(screen.getByRole("textbox")).toHaveFocus();
+      });
+
+      describe("When pressing tab again", () => {
+        beforeEach(() => {
+          userEvent.tab();
+        });
+
+        it("Should unset focus on field", () => {
+          expect(screen.getByRole("textbox")).not.toHaveFocus();
+        });
+      });
+    });
+  });
+
+  describe("When maxLength given", () => {
+    beforeEach(() => {
+      props = {
+        fieldId: "text-input",
+        fieldName: "text-input",
+        label: {
+          text: "Label",
+        },
+        errors: [],
+        value: "",
+        maxLength: 5,
+      };
+      render(<FormFieldTextInput {...props} />);
+    });
+
+    it("Should not limit input of values", () => {
+      userEvent.type(
+        screen.getByLabelText("Label"),
+        "Supercalifragilisticexpialidocious"
+      );
+      expect(screen.getByLabelText("Label")).toHaveValue(
+        "Supercalifragilisticexpialidocious"
+      );
+    });
+  });
+
+  describe("When maxLength given and setMaxLength true", () => {
+    beforeEach(() => {
+      props = {
+        fieldId: "text-input",
+        fieldName: "text-input",
+        label: {
+          text: "Label",
+        },
+        errors: [],
+        value: "",
+        maxLength: 5,
+        setMaxLength: true,
+      };
+      render(<FormFieldTextInput {...props} />);
+    });
+
+    it("Should limit input of values", () => {
+      userEvent.type(
+        screen.getByLabelText("Label"),
+        "Supercalifragilisticexpialidocious"
+      );
+      expect(screen.getByLabelText("Label")).toHaveValue("Super");
+    });
+  });
+});

--- a/webapp/client/src/components/OptionalHint.js
+++ b/webapp/client/src/components/OptionalHint.js
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 
 const Hint = styled.span`
+  margin-left: var(--spacing-01);
   font-size: var(--text-medium);
   font-weight: var(--font-normal);
 `;

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -34,6 +34,11 @@ const translations = {
       listItem3:
         "pauschal besteuerte Einkünfte aus geringfügigen Beschäftigungen (Mini-Jobs) bis zu einer Höhe von insgesamt 450 Euro monatlich",
     },
+    telephoneNumber: {
+      fieldTelephoneNumber: {
+        label: "Telefonnummer",
+      },
+    },
     confirmation: {
       fieldRegistrationConfirmDataPrivacy: {
         labelText:

--- a/webapp/client/src/pages/TelephoneNumberPage.js
+++ b/webapp/client/src/pages/TelephoneNumberPage.js
@@ -27,7 +27,7 @@ export default function TelephoneNumberPage({
           value={fields.telephoneNumber.value}
           label={{
             text: t("lotse.telephoneNumber.fieldTelephoneNumber.label"),
-            optional: true,
+            showOptionalTag: true,
           }}
           errors={fields.telephoneNumber.errors}
         />

--- a/webapp/client/src/pages/TelephoneNumberPage.js
+++ b/webapp/client/src/pages/TelephoneNumberPage.js
@@ -1,0 +1,54 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import FormHeader from "../components/FormHeader";
+import StepForm from "../components/StepForm";
+import StepHeaderButtons from "../components/StepHeaderButtons";
+import { fieldPropType } from "../lib/propTypes";
+import FormFieldTextInput from "../components/FormFieldTextInput";
+
+export default function TelephoneNumberPage({
+  stepHeader,
+  form,
+  fields,
+  prevUrl,
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <StepHeaderButtons url={prevUrl} />
+      <FormHeader {...stepHeader} />
+      <StepForm {...form}>
+        <FormFieldTextInput
+          autofocus
+          fieldName="telephone_number"
+          fieldId="telephone_number"
+          value={fields.telephoneNumber.value}
+          label={{
+            text: t("lotse.telephoneNumber.fieldTelephoneNumber.label"),
+            optional: true,
+          }}
+          errors={fields.telephoneNumber.errors}
+        />
+      </StepForm>
+    </>
+  );
+}
+
+TelephoneNumberPage.propTypes = {
+  stepHeader: PropTypes.exact({
+    title: PropTypes.string,
+    intro: PropTypes.string,
+  }).isRequired,
+  form: PropTypes.exact({
+    action: PropTypes.string,
+    csrfToken: PropTypes.string,
+    showOverviewButton: PropTypes.bool,
+    nextButtonLabel: PropTypes.string,
+  }).isRequired,
+  fields: PropTypes.exact({
+    telephoneNumber: fieldPropType,
+  }).isRequired,
+  prevUrl: PropTypes.string.isRequired,
+};

--- a/webapp/client/src/pages/TelephoneNumberPage.js
+++ b/webapp/client/src/pages/TelephoneNumberPage.js
@@ -21,7 +21,6 @@ export default function TelephoneNumberPage({
       <FormHeader {...stepHeader} />
       <StepForm {...form}>
         <FormFieldTextInput
-          autofocus
           fieldName="telephone_number"
           fieldId="telephone_number"
           value={fields.telephoneNumber.value}

--- a/webapp/client/src/pages/TelephoneNumberPage.test.js
+++ b/webapp/client/src/pages/TelephoneNumberPage.test.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import TelephoneNumberPage from "./TelephoneNumberPage";
+import { Default as StepFormDefault } from "../stories/StepForm.stories";
+
+let props = {
+  stepHeader: {
+    title: "Title",
+    intro: "Intro",
+  },
+  form: {
+    ...StepFormDefault.args,
+  },
+  fields: {
+    telephoneNumber: {
+      value: "",
+      errors: [],
+    },
+  },
+  prevUrl: "/some/prev/path",
+};
+
+it("should render step header texts", () => {
+  render(<TelephoneNumberPage {...props} />);
+  expect(screen.getByText("Title")).toBeInTheDocument();
+  expect(screen.getByText("Intro")).toBeInTheDocument();
+});
+
+it("should render field", () => {
+  render(<TelephoneNumberPage {...props} />);
+  expect(
+    screen.getByLabelText("Telefonnummer", { exact: false })
+  ).toBeInTheDocument();
+});
+
+it("should show optional text", () => {
+  render(<TelephoneNumberPage {...props} />);
+  expect(screen.getByText("optional")).toBeInTheDocument();
+});
+
+it("should link to the previous page", () => {
+  render(<TelephoneNumberPage {...props} />);
+  expect(screen.getByText("Zurück").closest("a")).toHaveAttribute(
+    "href",
+    expect.stringContaining("/some/prev/path")
+  );
+});

--- a/webapp/client/src/stories/FieldLabel.stories.js
+++ b/webapp/client/src/stories/FieldLabel.stories.js
@@ -23,7 +23,7 @@ WithAllExtras.args = {
   label: {
     text: "Grad der Behinderung",
     help: "Tragen Sie bitte hier den Grad der Behinderung ein. Der Grad der Behinderung, abgekürzt GdB, wird mit einem ärztlichen Gutachten individuell festgelegt. Er steht ebenfalls auf dem Behindertenausweis.",
-    optional: true,
+    showOptionalTag: true,
     exampleInput: "z.B. 25, 30, 35 etc.",
   },
   details: {

--- a/webapp/client/src/stories/FormFieldTextInput.stories.js
+++ b/webapp/client/src/stories/FormFieldTextInput.stories.js
@@ -19,8 +19,9 @@ export const Default = Template.bind({});
 export const WithValue = Template.bind({});
 export const WithErrors = Template.bind({});
 export const WithDetails = Template.bind({});
+export const WithMaxWidth = Template.bind({});
 export const WithMaxLength = Template.bind({});
-export const WithVisualMaxLength = Template.bind({});
+export const WithMaxLengthAndWidth = Template.bind({});
 
 Default.args = {
   fieldId: "text-input",
@@ -50,13 +51,18 @@ WithDetails.args = {
   },
 };
 
+WithMaxWidth.args = {
+  ...Default.args,
+  maxWidth: 4,
+};
+
 WithMaxLength.args = {
   ...Default.args,
   maxLength: 4,
-  setMaxLength: true,
 };
 
-WithVisualMaxLength.args = {
+WithMaxLengthAndWidth.args = {
   ...Default.args,
   maxLength: 4,
+  maxWidth: 4,
 };

--- a/webapp/client/src/stories/FormFieldTextInput.stories.js
+++ b/webapp/client/src/stories/FormFieldTextInput.stories.js
@@ -1,0 +1,62 @@
+import React from "react";
+
+import FormFieldTextInput from "../components/FormFieldTextInput";
+import StepForm from "../components/StepForm";
+import { Default as StepFormDefault } from "./StepForm.stories";
+
+export default {
+  title: "Form Fields/TextInput",
+  component: FormFieldTextInput,
+};
+
+const Template = (args) => (
+  <StepForm {...StepFormDefault.args}>
+    <FormFieldTextInput {...args} />
+  </StepForm>
+);
+
+export const Default = Template.bind({});
+export const WithValue = Template.bind({});
+export const WithErrors = Template.bind({});
+export const WithDetails = Template.bind({});
+export const WithMaxLength = Template.bind({});
+export const WithVisualMaxLength = Template.bind({});
+
+Default.args = {
+  fieldId: "text-input",
+  fieldName: "text-input",
+  label: {
+    text: "Text",
+  },
+  errors: [],
+  value: "",
+};
+
+WithValue.args = {
+  ...Default.args,
+  value: "Dumbledore",
+};
+
+WithErrors.args = {
+  ...Default.args,
+  errors: ["Dieses Feld wird benötigt"],
+};
+
+WithDetails.args = {
+  ...Default.args,
+  details: {
+    title: "Wann bekomme ich einen Freischaltcode?",
+    text: "Sie bekommen einen Freischaltcode, wenn Sie sich bei Mein Elster mit einer Zertifikatsdatei identifiziert und keinen Abrufcode beantragt haben. Wenn Sie sich z.B. mit Ihrem Personalausweis, einer Karte oder einem Stick bei Mein Elster identifiziert oder einen Abrufcode beantragt haben, bekommen Sie den Brief mit dem Freischaltcode nicht.",
+  },
+};
+
+WithMaxLength.args = {
+  ...Default.args,
+  maxLength: 4,
+  setMaxLength: true,
+};
+
+WithVisualMaxLength.args = {
+  ...Default.args,
+  maxLength: 4,
+};

--- a/webapp/client/src/stories/TelephoneNumberPage.stories.js
+++ b/webapp/client/src/stories/TelephoneNumberPage.stories.js
@@ -36,7 +36,7 @@ WithValue.args = {
   ...Default.args,
   fields: {
     telephoneNumber: {
-      value: "25",
+      value: "555-2368-32168",
       errors: [],
     },
   },

--- a/webapp/client/src/stories/TelephoneNumberPage.stories.js
+++ b/webapp/client/src/stories/TelephoneNumberPage.stories.js
@@ -1,0 +1,53 @@
+import React from "react";
+
+import TelephoneNumberPage from "../pages/TelephoneNumberPage";
+import { Default as StepFormDefault } from "./StepForm.stories";
+
+export default {
+  title: "Pages/TelephoneNumber",
+  component: TelephoneNumberPage,
+};
+
+const Template = (args) => <TelephoneNumberPage {...args} />;
+
+export const Default = Template.bind({});
+export const WithValue = Template.bind({});
+export const WithErrors = Template.bind({});
+
+Default.args = {
+  stepHeader: {
+    title: "Telefonnummer für Rückfragen",
+    intro:
+      "Geben Sie eine Telefonnummer an, wenn Sie wünschen, dass Ihr Finanzamt Sie bei eventuellen Rückfragen kontaktieren kann.",
+  },
+  form: {
+    ...StepFormDefault.args,
+  },
+  fields: {
+    telephoneNumber: {
+      value: "",
+      errors: [],
+    },
+  },
+  prevUrl: "/previous/step",
+};
+
+WithValue.args = {
+  ...Default.args,
+  fields: {
+    telephoneNumber: {
+      value: "25",
+      errors: [],
+    },
+  },
+};
+
+WithErrors.args = {
+  ...Default.args,
+  fields: {
+    telephoneNumber: {
+      value: "25",
+      errors: ["Die Angabe ist 5 Zeichen zu lang."],
+    },
+  },
+};


### PR DESCRIPTION
# Short Description
- This adds the complete react page for the telephone number.
- I had to merge #424 to use the input field, so please review that first. (otherwise: This is just about the files `webapp/client/src/pages/TelephoneNumberPage.js`, `webapp/client/src/pages/TelephoneNumberPage.test.js`, `webapp/client/src/stories/TelephoneNumberPage.stories.js`, `webapp/client/src/components/OptionalHint.js` and `webapp/client/src/lib/translations.js`)
- This does not wire it up yet with the webapp or erica.

# Changes
- Add margin to "optional" span
- Add react page
- Add stories
- Add tests

# Feedback
- More stories? More tests?
