### PR TITLE
Delete costs for driving

### DIFF
--- a/webapp/app/forms/steps/lotse/steuerminderungen.py
+++ b/webapp/app/forms/steps/lotse/steuerminderungen.py
@@ -225,15 +225,6 @@ class StepAussergBela(LotseFormSteuerlotseStep):
             label=_l('form.lotse.field_beh_aufw_anspruch'),
             render_kw={'data_label': _l('form.lotse.field_beh_aufw_anspruch.data_label')},
             validators=[IntegerLength(max=EURO_FIELD_MAX_LENGTH)])
-        stmind_beh_kfz_summe = EuroField(
-            label=_l('form.lotse.field_beh_kfz_summe'),
-            render_kw={'help': _l('form.lotse.field_beh_kfz-help'),
-                       'data_label': _l('form.lotse.field_beh_kfz_summe.data_label')},
-            validators=[IntegerLength(max=EURO_FIELD_MAX_LENGTH)])
-        stmind_beh_kfz_anspruch = EuroField(
-            label=_l('form.lotse.field_beh_kfz_anspruch'),
-            render_kw={'data_label': _l('form.lotse.field_beh_kfz_anspruch.data_label')},
-            validators=[IntegerLength(max=EURO_FIELD_MAX_LENGTH)])
         stmind_bestattung_summe = EuroField(
             label=_l('form.lotse.bestattung_summe'),
             render_kw={'help': _l('form.lotse.bestattung-help'),

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-11-29 10:58+0100\n"
+"POT-Creation-Date: 2021-12-01 16:48+0100\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -159,23 +159,23 @@ msgstr "Jahr"
 msgid "fields.date_field.example_input.text"
 msgstr "z.B. 29.2.1951"
 
-#: app/forms/fields.py:387
+#: app/forms/fields.py:424
 msgid "fields.euro_field.example_input.text"
 msgstr "z.B. 343,20"
 
-#: app/forms/fields.py:419
+#: app/forms/fields.py:456
 msgid "confirmation_field_must_be_set"
 msgstr "Sie müssen dieses Feld auswählen, um weiter zu machen."
 
-#: app/forms/fields.py:438
+#: app/forms/fields.py:475
 msgid "jquery_entries.add"
 msgstr "Weiteren Eintrag hinzufügen"
 
-#: app/forms/fields.py:503
+#: app/forms/fields.py:541
 msgid "switch.yes"
 msgstr "Ja"
 
-#: app/forms/fields.py:503
+#: app/forms/fields.py:541
 msgid "switch.no"
 msgstr "Nein"
 
@@ -283,11 +283,11 @@ msgstr "Ihre Steuererklärung"
 msgid "form.logout"
 msgstr "Abmelden"
 
-#: app/forms/flows/lotse_flow.py:321
+#: app/forms/flows/lotse_flow.py:316
 msgid "form.lotse.no_answer"
 msgstr "Keine Angabe"
 
-#: app/forms/flows/lotse_flow.py:373
+#: app/forms/flows/lotse_flow.py:368
 msgid "form.lotse.missing_mandatory_field"
 msgstr "Dieses Feld müssen Sie noch angeben."
 
@@ -319,7 +319,7 @@ msgstr ""
 #: app/forms/steps/eligibility_steps.py:98
 #: app/forms/steps/eligibility_steps.py:158
 #: app/forms/steps/eligibility_steps.py:736
-#: app/forms/steps/eligibility_steps.py:768
+#: app/forms/steps/eligibility_steps.py:757
 msgid "form.eligibility.header-title"
 msgstr "Nutzung Prüfen - Der Steuerlotse für Rente und Pension"
 
@@ -921,48 +921,13 @@ msgstr ""
 "die Finanzverwaltung übermitteln. Außerdem haben Sie keine weiteren "
 "Einkünfte, die Sie in Ihrer Steuererklärung geltend machen müssen."
 
-#: app/forms/steps/eligibility_steps.py:744
-msgid "form.eligibility.result-note.deadline"
-msgstr ""
-"Wenn Sie verpflichtet sind eine Einkommensteuererklärung einzureichen und"
-" die Steuerabgabefrist am 31. Oktober verpasst haben, können Sie Ihre "
-"Steuererklärung auch nach der Frist noch einreichen. Warten Sie jedoch "
-"lieber nicht allzu lange. Es kann vorkommen, dass Ihr Finanzamt einen "
-"Verspätungszuschlag einfordert, wenn Sie sich zu viel Zeit lassen."
-
-#: app/forms/steps/eligibility_steps.py:747
-msgid "form.eligibility.result-note.user_b_elster_account"
-msgstr ""
-"Wenn Sie Ihre Steuererklärung gemeinsam als Paar machen möchten, muss "
-"sich trotzdem nur eine Person registrieren."
-
-#: app/forms/steps/eligibility_steps.py:748
-msgid "form.eligibility.result-note.user_b_elster_account-registration"
-msgstr ""
-"Bitte registrieren Sie sich mit den Angaben der Person, die noch kein "
-"Konto bei Mein ELSTER hat. Für die Überprüfung Ihrer Identität braucht "
-"unser Service einen Freischaltcode. Dieser Freischaltcode wird von ELSTER"
-" erstellt und per Post versendet. Aus technischen Gründen geschieht das "
-"allerdings nur, wenn Sie noch kein Konto bei Mein ELSTER haben."
-
-#: app/forms/steps/eligibility_steps.py:752
-msgid "form.eligibility.result-note.capital_investment"
-msgstr ""
-"Die Besteuerung von Kapitalerträgen erledigen Banken und Versicherungen "
-"für Sie. Wenn Sie Freistellungsaufträge erteilt haben, dann erhalten Sie "
-"dort auch Ihren Sparerfreibetrag. Wenn Sie keine Freistellungsaufträge "
-"erteilt haben oder mit der Höhe der für Sie abgeführten Steuern nicht "
-"einverstanden sind, dann können Sie in der Einkommensteuererklärung eine "
-"Änderung der Steuerbelastung beantragen. Der Steuerlotse bietet Ihnen "
-"dafür allerdings derzeit keine Möglichkeiten."
-
-#: app/forms/steps/eligibility_steps.py:761
+#: app/forms/steps/eligibility_steps.py:750
 msgid "form.eligibility.success.maybe.title"
 msgstr ""
 "Sie können Ihre Steuererklärung für das Jahr 2020 vielleicht mit dem "
 "Steuerlotsen machen."
 
-#: app/forms/steps/eligibility_steps.py:762
+#: app/forms/steps/eligibility_steps.py:751
 msgid "form.eligibility.success.maybe.intro"
 msgstr ""
 "Sie können Ihre Steuererklärung mit dem Steuerlotsen machen, wenn Ihnen "
@@ -979,11 +944,11 @@ msgstr ""
 "Finanzverwaltung übermitteln. Außerdem haben Sie keine weiteren "
 "Einkünfte, die Sie in Ihrer Steuererklärung geltend machen müssen."
 
-#: app/forms/steps/eligibility_steps.py:779
+#: app/forms/steps/eligibility_steps.py:767
 msgid "form.eligibility.result-note.when_unlock_code.title"
 msgstr "Wann bekomme ich einen Freischaltcode?"
 
-#: app/forms/steps/eligibility_steps.py:780
+#: app/forms/steps/eligibility_steps.py:768
 msgid "form.eligibility.result-note.when_unlock_code.description"
 msgstr ""
 "Sie bekommen einen Freischaltcode, wenn Sie sich bei Mein Elster mit "
@@ -996,6 +961,41 @@ msgstr ""
 "einen Brief mit einem Freischaltcode erhalten, können Sie diesen nutzen, "
 "um Ihre Steuererklärung mit dem Steuerlotsen zu machen. Wenn Sie keinen "
 "Brief erhalten, können Sie den Steuerlotsen leider nicht nutzen."
+
+#: app/forms/steps/eligibility_steps.py:774
+msgid "form.eligibility.result-note.deadline"
+msgstr ""
+"Wenn Sie verpflichtet sind eine Einkommensteuererklärung einzureichen und"
+" die Steuerabgabefrist am 31. Oktober verpasst haben, können Sie Ihre "
+"Steuererklärung auch nach der Frist noch einreichen. Warten Sie jedoch "
+"lieber nicht allzu lange. Es kann vorkommen, dass Ihr Finanzamt einen "
+"Verspätungszuschlag einfordert, wenn Sie sich zu viel Zeit lassen."
+
+#: app/forms/steps/eligibility_steps.py:777
+msgid "form.eligibility.result-note.user_b_elster_account"
+msgstr ""
+"Wenn Sie Ihre Steuererklärung gemeinsam als Paar machen möchten, muss "
+"sich trotzdem nur eine Person registrieren."
+
+#: app/forms/steps/eligibility_steps.py:778
+msgid "form.eligibility.result-note.user_b_elster_account-registration"
+msgstr ""
+"Bitte registrieren Sie sich mit den Angaben der Person, die noch kein "
+"Konto bei Mein ELSTER hat. Für die Überprüfung Ihrer Identität braucht "
+"unser Service einen Freischaltcode. Dieser Freischaltcode wird von ELSTER"
+" erstellt und per Post versendet. Aus technischen Gründen geschieht das "
+"allerdings nur, wenn Sie noch kein Konto bei Mein ELSTER haben."
+
+#: app/forms/steps/eligibility_steps.py:781
+msgid "form.eligibility.result-note.capital_investment"
+msgstr ""
+"Die Besteuerung von Kapitalerträgen erledigen Banken und Versicherungen "
+"für Sie. Wenn Sie Freistellungsaufträge erteilt haben, dann erhalten Sie "
+"dort auch Ihren Sparerfreibetrag. Wenn Sie keine Freistellungsaufträge "
+"erteilt haben oder mit der Höhe der für Sie abgeführten Steuern nicht "
+"einverstanden sind, dann können Sie in der Einkommensteuererklärung eine "
+"Änderung der Steuerbelastung beantragen. Der Steuerlotse bietet Ihnen "
+"dafür allerdings derzeit keine Möglichkeiten."
 
 #: app/forms/steps/logout_steps.py:16
 msgid "form.logout.input-title"
@@ -1013,8 +1013,8 @@ msgstr ""
 msgid "form.logout.header-title"
 msgstr "Infos zur Abmeldung - Der Steuerlotse für Rente und Pension"
 
+#: app/forms/steps/lotse/personal_data.py:211
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:198
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:320
 #: app/forms/steps/unlock_code_activation_steps.py:19
 #: app/forms/steps/unlock_code_request_steps.py:22
 #: app/forms/steps/unlock_code_revocation_steps.py:20
@@ -1115,7 +1115,7 @@ msgstr "Steueridentifikationsnummer"
 msgid "unlock-code-revocation.dob"
 msgstr "Geburtsdatum"
 
-#: app/forms/steps/unlock_code_revocation_steps.py:21
+#: app/forms/steps/unlock_code_revocation_steps.py:23
 msgid "validate.day-of-birth-missing"
 msgstr "Geben Sie Ihr Geburtsdatum ein."
 
@@ -1175,11 +1175,11 @@ msgstr ""
 msgid "form.lotse.confirm_complete_correct.required"
 msgstr "Bestätigen Sie, dass Ihre Angaben korrekt sind, um fortfahren zu können."
 
-#: app/forms/steps/lotse/personal_data.py:24
+#: app/forms/steps/lotse/personal_data.py:29
 msgid "form.lotse.steuernummer-title"
 msgstr "Steuernummer"
 
-#: app/forms/steps/lotse/personal_data.py:25
+#: app/forms/steps/lotse/personal_data.py:30
 msgid "form.lotse.steuernummer-intro"
 msgstr ""
 "Die Steuernummer wird Ihnen vom zuständigen Finanzamt zugeteilt – dort, "
@@ -1188,44 +1188,44 @@ msgstr ""
 "beispielsweise ein Umzug, eine Heirat oder die Änderung der "
 "Veranlagungsart sein."
 
-#: app/forms/steps/lotse/personal_data.py:26
+#: app/forms/steps/lotse/personal_data.py:31
+#: app/forms/steps/lotse/personal_data.py:191
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:151
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:276
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:402
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:451
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:338
 msgid "form.lotse.mandatory_data.header-title"
 msgstr "Steuerformular - Pflichtangaben - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse/personal_data.py:31
+#: app/forms/steps/lotse/personal_data.py:36
 msgid "form.lotse.step_steuernummer.label"
 msgstr "Steuernummer"
 
-#: app/forms/steps/lotse/personal_data.py:32
+#: app/forms/steps/lotse/personal_data.py:37
+#: app/forms/steps/lotse/personal_data.py:197
 #: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:20
 #: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:61
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:22
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:193
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:304
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:416
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:303
 msgid "form.lotse.mandatory_data.label"
 msgstr "Pflichtangaben"
 
-#: app/forms/steps/lotse/personal_data.py:40
-#: app/forms/steps/lotse/personal_data.py:137
+#: app/forms/steps/lotse/personal_data.py:45
+#: app/forms/steps/lotse/personal_data.py:143
 msgid "form.lotse.steuernummer_exists"
 msgid_plural "form.lotse.steuernummer_exists"
 msgstr[0] "Haben Sie bereits eine Steuernummer?"
 msgstr[1] "Haben Sie bereits eine gemeinsame Steuernummer?"
 
-#: app/forms/steps/lotse/personal_data.py:41
+#: app/forms/steps/lotse/personal_data.py:46
 msgid "form.lotse.steuernummer_exists.data_label"
 msgstr "Steuernummer vorhanden"
 
-#: app/forms/steps/lotse/personal_data.py:42
+#: app/forms/steps/lotse/personal_data.py:47
 msgid "form.lotse.steuernummer_exists.detail.title"
 msgstr "Wo finde Ich diese Nummer?"
 
-#: app/forms/steps/lotse/personal_data.py:43
+#: app/forms/steps/lotse/personal_data.py:48
 msgid "form.lotse.steuernummer_exists.detail.text"
 msgstr ""
 "Sie finden Ihre Steuernummer auf jedem Steuerbescheid. Sollten Sie noch "
@@ -1233,108 +1233,108 @@ msgstr ""
 "beantragen. Bitte beachten Sie, dass die Steuernummer und die Steuer-"
 "Identifikationsnummer zwei verschiedene Nummern sind."
 
-#: app/forms/steps/lotse/personal_data.py:42
+#: app/forms/steps/lotse/personal_data.py:49
 msgid "form.lotse.steuernummer.selection_input_required"
 msgstr "Beantworten Sie die Frage, um fortfahren zu können."
 
-#: app/forms/steps/lotse/personal_data.py:44
+#: app/forms/steps/lotse/personal_data.py:51
 msgid "form.lotse.field_bundesland"
 msgstr "Wählen Sie Ihr Bundesland"
 
-#: app/forms/steps/lotse/personal_data.py:48
+#: app/forms/steps/lotse/personal_data.py:53
 msgid "form.lotse.field_bundesland_bw"
 msgstr "Baden-Württemberg"
 
-#: app/forms/steps/lotse/personal_data.py:49
+#: app/forms/steps/lotse/personal_data.py:54
 msgid "form.lotse.field_bundesland_by"
 msgstr "Bayern"
 
-#: app/forms/steps/lotse/personal_data.py:50
+#: app/forms/steps/lotse/personal_data.py:55
 msgid "form.lotse.field_bundesland_be"
 msgstr "Berlin"
 
-#: app/forms/steps/lotse/personal_data.py:51
+#: app/forms/steps/lotse/personal_data.py:56
 msgid "form.lotse.field_bundesland_bb"
 msgstr "Brandenburg"
 
-#: app/forms/steps/lotse/personal_data.py:52
+#: app/forms/steps/lotse/personal_data.py:57
 msgid "form.lotse.field_bundesland_hb"
 msgstr "Bremen"
 
-#: app/forms/steps/lotse/personal_data.py:53
+#: app/forms/steps/lotse/personal_data.py:58
 msgid "form.lotse.field_bundesland_hh"
 msgstr "Hamburg"
 
-#: app/forms/steps/lotse/personal_data.py:54
+#: app/forms/steps/lotse/personal_data.py:59
 msgid "form.lotse.field_bundesland_he"
 msgstr "Hessen"
 
-#: app/forms/steps/lotse/personal_data.py:55
+#: app/forms/steps/lotse/personal_data.py:60
 msgid "form.lotse.field_bundesland_mv"
 msgstr "Mecklenburg-Vorpommern "
 
-#: app/forms/steps/lotse/personal_data.py:56
+#: app/forms/steps/lotse/personal_data.py:61
 msgid "form.lotse.field_bundesland_nd"
 msgstr "Niedersachsen"
 
-#: app/forms/steps/lotse/personal_data.py:57
+#: app/forms/steps/lotse/personal_data.py:62
 msgid "form.lotse.field_bundesland_nw"
 msgstr "Nordrhein-Westfalen"
 
-#: app/forms/steps/lotse/personal_data.py:58
+#: app/forms/steps/lotse/personal_data.py:63
 msgid "form.lotse.field_bundesland_rp"
 msgstr "Rheinland-Pfalz"
 
-#: app/forms/steps/lotse/personal_data.py:59
+#: app/forms/steps/lotse/personal_data.py:64
 msgid "form.lotse.field_bundesland_sl"
 msgstr "Saarland"
 
-#: app/forms/steps/lotse/personal_data.py:60
+#: app/forms/steps/lotse/personal_data.py:65
 msgid "form.lotse.field_bundesland_sn"
 msgstr "Sachsen"
 
-#: app/forms/steps/lotse/personal_data.py:61
+#: app/forms/steps/lotse/personal_data.py:66
 msgid "form.lotse.field_bundesland_st"
 msgstr "Sachsen-Anhalt "
 
-#: app/forms/steps/lotse/personal_data.py:62
+#: app/forms/steps/lotse/personal_data.py:67
 msgid "form.lotse.field_bundesland_sh"
 msgstr "Schleswig-Holstein"
 
-#: app/forms/steps/lotse/personal_data.py:63
+#: app/forms/steps/lotse/personal_data.py:68
 msgid "form.lotse.field_bundesland_th"
 msgstr "Thüringen"
 
-#: app/forms/steps/lotse/personal_data.py:65
+#: app/forms/steps/lotse/personal_data.py:70
 msgid "form.lotse.field_bundesland.data_label"
 msgstr "Auswahl Bundesland"
 
-#: app/forms/steps/lotse/personal_data.py:65
+#: app/forms/steps/lotse/personal_data.py:71
 msgid "form.lotse.steuernummer.input_required"
 msgstr "Diese Angabe wird benötigt, um fortfahren zu können."
 
-#: app/forms/steps/lotse/personal_data.py:68
+#: app/forms/steps/lotse/personal_data.py:74
 msgid "form.lotse.bufa_nr"
 msgstr "Wählen Sie Ihr Finanzamt "
 
-#: app/forms/steps/lotse/personal_data.py:72
+#: app/forms/steps/lotse/personal_data.py:78
 msgid "form.lotse.bufa_nr.data_label"
 msgstr "Auswahl Finanzamt"
 
-#: app/forms/steps/lotse/personal_data.py:74
+#: app/forms/steps/lotse/personal_data.py:80
 msgid "form.lotse.steuernummer"
 msgstr "Steuernummer"
 
-#: app/forms/steps/lotse/personal_data.py:76
+#: app/forms/steps/lotse/personal_data.py:82
 msgid "form.lotse.steuernummer.data_label"
 msgstr "Steuernummer"
 
-#: app/forms/steps/lotse/personal_data.py:77
+#: app/forms/steps/lotse/personal_data.py:83
 msgid "form.lotse.steuernummer.example_input"
 msgstr "Muss 10 oder 11 Ziffern haben"
 
-#: app/forms/steps/lotse/personal_data.py:80
-#: app/forms/steps/lotse/personal_data.py:140
+#: app/forms/steps/lotse/personal_data.py:86
+#: app/forms/steps/lotse/personal_data.py:146
 msgid "form.lotse.steuernummer.request_new_tax_number"
 msgid_plural "form.lotse.steuernummer.request_new_tax_number"
 msgstr[0] ""
@@ -1344,11 +1344,11 @@ msgstr[1] ""
 "Hiermit bestätigen wir, dass wir noch keine Steuernummer bei unserem "
 "Finanzamt haben und eine neue Steuernummer beantragen möchten."
 
-#: app/forms/steps/lotse/personal_data.py:81
+#: app/forms/steps/lotse/personal_data.py:87
 msgid "form.lotse.steuernummer.request_new_tax_number.data_label"
 msgstr "Neue Steuernummer beantragen"
 
-#: app/forms/steps/lotse/personal_data.py:126
+#: app/forms/steps/lotse/personal_data.py:132
 msgid "form.lotse.tax-number.invalid-tax-number-error"
 msgstr ""
 "Die Steuernummer ist nicht korrekt. Prüfen Sie:<ul><li>ob es sich bei der"
@@ -1356,6 +1356,203 @@ msgstr ""
 "Identifikatiosnummer handelt</li><li>ob die Auswahl des Bundeslandes "
 "korrekt ist</li></ul>Bitte wenden Sie sich andernfalls mit einer E-Mail "
 "an uns und schildern Sie uns das Problem. "
+
+#: app/forms/steps/lotse/personal_data.py:178
+msgid "form.lotse.skip_reason.familienstand_single"
+msgstr "Sie haben als Familienstand ledig angegeben."
+
+#: app/forms/steps/lotse/personal_data.py:189
+msgid "form.lotse.person-b-title"
+msgstr "Angaben für Person B"
+
+#: app/forms/steps/lotse/personal_data.py:190
+msgid "form.lotse.person-b-intro"
+msgstr ""
+"Geben Sie hier bitte die Daten der Ehefrau an. Wenn Sie in einer "
+"gleichgeschlechtlichen Partnerschaft leben, geben Sie bitte die Person "
+"an, deren Name im Alphabet zuletzt kommt."
+
+#: app/forms/steps/lotse/personal_data.py:196
+msgid "form.lotse.step_person_b.label"
+msgstr "Person B"
+
+#: app/forms/steps/lotse/personal_data.py:211
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:197
+msgid "form.lotse.field_person_idnr"
+msgstr "Steuer-Identifikationsnummer"
+
+#: app/forms/steps/lotse/personal_data.py:212
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:199
+msgid "form.lotse.field_person_idnr.data_label"
+msgstr "Steuer-Identifikationsnummer"
+
+#: app/forms/steps/lotse/personal_data.py:214
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:201
+msgid "form.lotse.field_person_dob"
+msgstr "Geburtsdatum"
+
+#: app/forms/steps/lotse/personal_data.py:215
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:202
+msgid "form.lotse.field_person_dob.data_label"
+msgstr "Geburtsdatum"
+
+#: app/forms/steps/lotse/personal_data.py:216
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:203
+msgid "form.lotse.validation-dob-missing"
+msgstr ""
+"Geben Sie Ihr vollständiges Geburtsdatum ein. Ihre Angabe muss folgendem "
+"Muster entsprechen: 29 2 1951 "
+
+#: app/forms/steps/lotse/personal_data.py:219
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:206
+msgid "form.lotse.field_person_first_name"
+msgstr "Vorname"
+
+#: app/forms/steps/lotse/personal_data.py:220
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:207
+msgid "form.lotse.field_person_first_name.data_label"
+msgstr "Vorname"
+
+#: app/forms/steps/lotse/personal_data.py:224
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:211
+msgid "form.lotse.field_person_last_name"
+msgstr "Nachname"
+
+#: app/forms/steps/lotse/personal_data.py:225
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:212
+msgid "form.lotse.field_person_last_name.data_label"
+msgstr "Nachname"
+
+#: app/forms/steps/lotse/personal_data.py:231
+msgid "form.lotse.field_person_b_same_address.data_label"
+msgstr "Mein Partner / Meine Partnerin und ich wohnen zusammen."
+
+#: app/forms/steps/lotse/personal_data.py:233
+msgid "form.lotse.field_person_b_same_address-yes"
+msgstr "Mein Partner / Meine Partnerin und ich wohnen zusammen."
+
+#: app/forms/steps/lotse/personal_data.py:234
+msgid "form.lotse.field_person_b_same_address-no"
+msgstr ""
+"Mein Partner / Meine Partnerin und ich wohnen nicht zusammen. Er / Sie "
+"ist wohnhaft in:"
+
+#: app/forms/steps/lotse/personal_data.py:237
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:216
+msgid "form.lotse.field_person_street"
+msgstr "Straße"
+
+#: app/forms/steps/lotse/personal_data.py:238
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:217
+msgid "form.lotse.field_person_street.data_label"
+msgstr "Straße"
+
+#: app/forms/steps/lotse/personal_data.py:243
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:221
+msgid "form.lotse.field_person_street_number"
+msgstr "Hausnummer"
+
+#: app/forms/steps/lotse/personal_data.py:244
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:222
+msgid "form.lotse.field_person_street_number.data_label"
+msgstr "Hausnummer"
+
+#: app/forms/steps/lotse/personal_data.py:250
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:226
+msgid "form.lotse.field_person_street_number_ext"
+msgstr "Hausnummerzusatz"
+
+#: app/forms/steps/lotse/personal_data.py:251
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:227
+msgid "form.lotse.field_person_street_number_ext.data_label"
+msgstr "Hausnummerzusatz"
+
+#: app/forms/steps/lotse/personal_data.py:255
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:231
+msgid "form.lotse.field_person_address_ext"
+msgstr "Adressergänzung"
+
+#: app/forms/steps/lotse/personal_data.py:256
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:232
+msgid "form.lotse.field_person_address_ext.data_label"
+msgstr "Adressergänzung"
+
+#: app/forms/steps/lotse/personal_data.py:260
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:236
+msgid "form.lotse.field_person_plz"
+msgstr "Postleitzahl"
+
+#: app/forms/steps/lotse/personal_data.py:261
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:237
+msgid "form.lotse.field_person_plz.data_label"
+msgstr "Postleitzahl"
+
+#: app/forms/steps/lotse/personal_data.py:266
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:241
+msgid "form.lotse.field_person_town"
+msgstr "Wohnort"
+
+#: app/forms/steps/lotse/personal_data.py:267
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:242
+msgid "form.lotse.field_person_town.data_label"
+msgstr "Wohnort"
+
+#: app/forms/steps/lotse/personal_data.py:274
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:248
+msgid "form.lotse.field_person_beh_grad"
+msgstr "Grad der Behinderung"
+
+#: app/forms/steps/lotse/personal_data.py:276
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:251
+msgid "form.lotse.field_person_beh_grad-help"
+msgstr ""
+"Tragen Sie bitte hier den Grad der Behinderung ein. Der Grad der "
+"Behinderung, abgekürzt GdB, wird mit einem ärztlichen Gutachten "
+"individuell festgelegt. Er steht ebenfalls auf dem "
+"Behindertenausweis.<br/><br/>Menschen mit Behinderung und einem Grad der "
+"Behinderung von mindestens 25 aber weniger als 50 steht der entsprechende"
+" Pauschbetrag jedoch nur zu <ul><li>wenn wegen der Behinderung ein "
+"gesetzlicher Anspruch auf Rente (z.B. Unfallrente) oder auf andere "
+"laufende Bezüge besteht</li><li>wenn die Behinderung zu einer dauernden "
+"Einbuße der körperlichen Beweglichkeit geführt hat oder auf einer "
+"typischen Berufskrankheit beruht.</li><ul>"
+
+#: app/forms/steps/lotse/personal_data.py:277
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:252
+msgid "form.lotse.field_person_beh_grad.data_label"
+msgstr "Grad der Behinderung"
+
+#: app/forms/steps/lotse/personal_data.py:278
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:253
+msgid "form.lotse.field_person_beh_grad.example_input"
+msgstr "z.B. 25, 30, 35 etc. "
+
+#: app/forms/steps/lotse/personal_data.py:281
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:256
+msgid "form.lotse.field_person_blind"
+msgstr "blind / ständig hilflos oder Pflegegrad 4 oder 5"
+
+#: app/forms/steps/lotse/personal_data.py:282
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:257
+msgid "form.lotse.field_person_blind.data_label"
+msgstr "blind / ständig hilflos oder Pflegegrad 4 oder 5"
+
+#: app/forms/steps/lotse/personal_data.py:284
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:259
+msgid "form.lotse.field_person_gehbeh"
+msgstr "geh- und stehbehindert"
+
+#: app/forms/steps/lotse/personal_data.py:285
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:260
+msgid "form.lotse.field_person_gehbeh.data_label"
+msgstr "geh- und stehbehindert"
+
+#: app/forms/steps/lotse/personal_data.py:289
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:264
+msgid "form.lotse.validation-person-beh-grad"
+msgstr ""
+"Sie haben eine Geh- oder Stehbehinderung angegeben. Bitte geben Sie hier "
+"den Grad der Behinderung an."
 
 #: app/forms/steps/lotse/steuerminderungen.py:25
 msgid "form.lotse.select_stmind-title"
@@ -1372,13 +1569,13 @@ msgstr ""
 #: app/forms/steps/lotse/steuerminderungen.py:156
 #: app/forms/steps/lotse/steuerminderungen.py:185
 #: app/forms/steps/lotse/steuerminderungen.py:192
-#: app/forms/steps/lotse/steuerminderungen.py:265
-#: app/forms/steps/lotse/steuerminderungen.py:339
-#: app/forms/steps/lotse/steuerminderungen.py:367
-#: app/forms/steps/lotse/steuerminderungen.py:410
-#: app/forms/steps/lotse/steuerminderungen.py:417
-#: app/forms/steps/lotse/steuerminderungen.py:444
-#: app/forms/steps/lotse/steuerminderungen.py:451
+#: app/forms/steps/lotse/steuerminderungen.py:256
+#: app/forms/steps/lotse/steuerminderungen.py:330
+#: app/forms/steps/lotse/steuerminderungen.py:358
+#: app/forms/steps/lotse/steuerminderungen.py:401
+#: app/forms/steps/lotse/steuerminderungen.py:408
+#: app/forms/steps/lotse/steuerminderungen.py:435
+#: app/forms/steps/lotse/steuerminderungen.py:442
 msgid "form.lotse.steuerminderungen.header-title"
 msgstr ""
 "Steuerformular - Steuermindernde Aufwendungen - Der Steuerlotse für Rente"
@@ -1391,10 +1588,10 @@ msgstr "Ihre Ausgaben"
 #: app/forms/steps/lotse/steuerminderungen.py:35
 #: app/forms/steps/lotse/steuerminderungen.py:163
 #: app/forms/steps/lotse/steuerminderungen.py:198
-#: app/forms/steps/lotse/steuerminderungen.py:271
-#: app/forms/steps/lotse/steuerminderungen.py:373
-#: app/forms/steps/lotse/steuerminderungen.py:423
-#: app/forms/steps/lotse/steuerminderungen.py:456
+#: app/forms/steps/lotse/steuerminderungen.py:262
+#: app/forms/steps/lotse/steuerminderungen.py:364
+#: app/forms/steps/lotse/steuerminderungen.py:414
+#: app/forms/steps/lotse/steuerminderungen.py:447
 msgid "form.lotse.section_steuerminderung.label"
 msgstr "Steuermindernde Aufwendungen"
 
@@ -1597,45 +1794,10 @@ msgid "form.lotse.field_beh_aufw_anspruch.data_label"
 msgstr "Behinderungsbedingte Aufwendungen Anspruch auf Erstattung"
 
 #: app/forms/steps/lotse/steuerminderungen.py:229
-msgid "form.lotse.field_beh_kfz_summe"
-msgstr "Behinderungsbedingte Kfz-Kosten Summe"
-
-#: app/forms/steps/lotse/steuerminderungen.py:230
-msgid "form.lotse.field_beh_kfz-help"
-msgstr ""
-"Unter behinderungsbedingten Kfz-Kosten versteht man durch die Behinderung"
-" veranlasste unvermeidbare Fahrten. Dazu zählen zum Beispiel Arztfahrten,"
-" Fahrten zur Apotheke, zum Therapeuten oder zu Behörden, aber auch "
-"Einkaufsfahrten. <br/><br/>Berücksichtigt werden können diese von "
-"Personen, deren Grad der Behinderung mindestens 70 beträgt und die "
-"zugleich geh- und stehbehindert sind (Merkzeichen »G« oder orangefarbener"
-" Flächenaufdruck im Schwerbehindertenausweis). Als angemessen werden im "
-"Allgemeinen 900 Euro (3.000 km zu 30 Cent) anerkannt. <br/><br/>Bei "
-"Menschen, die sich außerhalb des Hauses nur mit Hilfe eines Kfz bewegen "
-"können (Merkzeichen »aG«), bei Personen mit den Merkzeichen »H« oder »Bl«"
-" und bei Personen, die in Pflegegrad 4 oder 5 eingestuft sind, werden in "
-"angemessenem Rahmen (regelmäßig bis zu 15.000 km jährlich) alle "
-"Privatfahrten anerkannt. Die tatsächliche Fahrleistung ist nachzuweisen "
-"oder glaubhaft zu machen. Ein höherer Kilometersatz als 30 Cent wird vom "
-"Finanzamt nicht berücksichtigt."
-
-#: app/forms/steps/lotse/steuerminderungen.py:231
-msgid "form.lotse.field_beh_kfz_summe.data_label"
-msgstr "Behinderungsbedingte Kfz-Kosten Summe"
-
-#: app/forms/steps/lotse/steuerminderungen.py:234
-msgid "form.lotse.field_beh_kfz_anspruch"
-msgstr "Behinderungsbedingte Kfz-Kosten Anspruch auf Erstattung"
-
-#: app/forms/steps/lotse/steuerminderungen.py:235
-msgid "form.lotse.field_beh_kfz_anspruch.data_label"
-msgstr "Behinderungsbedingte Kfz-Kosten Anspruch auf Erstattung"
-
-#: app/forms/steps/lotse/steuerminderungen.py:238
 msgid "form.lotse.bestattung_summe"
 msgstr "Bestattungskosten Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:239
+#: app/forms/steps/lotse/steuerminderungen.py:230
 msgid "form.lotse.bestattung-help"
 msgstr ""
 " Unter den Bestattungskosten können Sie Kosten, die unmittelbar mit der "
@@ -1647,23 +1809,23 @@ msgstr ""
 "Bewirtung der Trauergäste sowie Reisekosten anlässlich der Bestattung "
 "werden nicht anerkannt."
 
-#: app/forms/steps/lotse/steuerminderungen.py:240
+#: app/forms/steps/lotse/steuerminderungen.py:231
 msgid "form.lotse.bestattung_summe.data_label"
 msgstr "Bestattungskosten Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:243
+#: app/forms/steps/lotse/steuerminderungen.py:234
 msgid "form.lotse.bestattung_anspruch"
 msgstr "Bestattungskosten Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:244
+#: app/forms/steps/lotse/steuerminderungen.py:235
 msgid "form.lotse.bestattung_anspruch.data_label"
 msgstr "Bestattungskosten Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:247
+#: app/forms/steps/lotse/steuerminderungen.py:238
 msgid "form.lotse.aussergbela_sonst_summe"
 msgstr "Sonstige Außergewöhnliche Belastungen Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:248
+#: app/forms/steps/lotse/steuerminderungen.py:239
 msgid "form.lotse.aussergbela_sonst-help"
 msgstr ""
 "Zu den sonstigen außergewöhnliche Belastungen zählen zum Beispiel Kosten "
@@ -1672,23 +1834,23 @@ msgstr ""
 " zugängliche und übliche Versicherung möglich war. Dies gilt auch für die"
 " notwendigen und angemessenen Kosten der Schadensbeseitigung."
 
-#: app/forms/steps/lotse/steuerminderungen.py:249
+#: app/forms/steps/lotse/steuerminderungen.py:240
 msgid "form.lotse.aussergbela_sonst_summe.data_label"
 msgstr "Sonstige Außergewöhnliche Belastungen Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:252
+#: app/forms/steps/lotse/steuerminderungen.py:243
 msgid "form.lotse.aussergbela_sonst_anspruch"
 msgstr "Sonstige Außergewöhnliche Belastungen Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:253
+#: app/forms/steps/lotse/steuerminderungen.py:244
 msgid "form.lotse.aussergbela_sonst_anspruch.data_label"
 msgstr "Sonstige Außergewöhnliche Belastungen Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:263
+#: app/forms/steps/lotse/steuerminderungen.py:254
 msgid "form.lotse.haushaltsnahe-handwerker-title"
 msgstr "Haushaltsnahe Dienstleistungen und Handwerkerleistungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:264
+#: app/forms/steps/lotse/steuerminderungen.py:255
 msgid "form.lotse.handwerker-haushaltsnahe-intro"
 msgstr ""
 "Geben Sie hier an, welche haushaltsnahen Dienstleistungen und Tätigkeiten"
@@ -1696,15 +1858,15 @@ msgstr ""
 "müssen in Ihren eigenen vier Wänden oder auf Ihrem Grundstück ausgeführt "
 "werden."
 
-#: app/forms/steps/lotse/steuerminderungen.py:269
+#: app/forms/steps/lotse/steuerminderungen.py:260
 msgid "form.lotse.step_haushaltsnahe_handwerker.label"
 msgstr "Haushaltsnahe Dienstleistungen und Handwerkerleistungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:275
+#: app/forms/steps/lotse/steuerminderungen.py:266
 msgid "form.lotse.field_haushaltsnahe_entries"
 msgstr "Aufwendungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:277
+#: app/forms/steps/lotse/steuerminderungen.py:268
 msgid "form.lotse.field_haushaltsnahe_entries-help"
 msgstr ""
 "<p class='mt-2'>Haushaltsnahe Tätigkeiten und Dienstleistungen sind zum "
@@ -1723,27 +1885,27 @@ msgstr ""
 " Belastungen noch als haushaltsnahe Pflegeleistung geltend machen können,"
 " wenn Sie den Behinderten-Pauschbetrag beantragt haben.</p>"
 
-#: app/forms/steps/lotse/steuerminderungen.py:278
+#: app/forms/steps/lotse/steuerminderungen.py:269
 msgid "form.lotse.field_haushaltsnahe_entries.data_label"
 msgstr "Haushaltsnahe Aufwendungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:280
+#: app/forms/steps/lotse/steuerminderungen.py:271
 msgid "form.lotse.field_haushaltsnahe_summe"
 msgstr "Summe der Rechnungsbeträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:281
+#: app/forms/steps/lotse/steuerminderungen.py:272
 msgid "form.lotse.field_haushaltsnahe_summe-help"
 msgstr "Tragen Sie hier die Summe Ihrer angegebenen Aufwendungen ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:282
+#: app/forms/steps/lotse/steuerminderungen.py:273
 msgid "form.lotse.field_haushaltsnahe_summe.data_label"
 msgstr "Summe der Rechnungsbeträge (Haushalt)"
 
-#: app/forms/steps/lotse/steuerminderungen.py:285
+#: app/forms/steps/lotse/steuerminderungen.py:276
 msgid "form.lotse.field_handwerker_entries"
 msgstr "Aufwendungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:287
+#: app/forms/steps/lotse/steuerminderungen.py:278
 msgid "form.lotse.field_handwerker_entries-help"
 msgstr ""
 "Handwerkerleistungen sind zum Beispiel: <ul><li>Reparatur, Streichen, "
@@ -1752,66 +1914,66 @@ msgstr ""
 "Einbauküche.</li></ul> Die Arbeitsleistung muss im eigenen Haushalt "
 "erbracht worden sein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:288
+#: app/forms/steps/lotse/steuerminderungen.py:279
 msgid "form.lotse.field_handwerker_entries.data_label"
 msgstr "Handwerker Aufwendungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:290
+#: app/forms/steps/lotse/steuerminderungen.py:281
 msgid "form.lotse.field_handwerker_summe"
 msgstr "Summe der Rechnungsbeträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:291
+#: app/forms/steps/lotse/steuerminderungen.py:282
 msgid "form.lotse.field_handwerker_summe-help"
 msgstr "Tragen Sie hier die Summe Ihrer angegebenen Aufwendungen ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:292
+#: app/forms/steps/lotse/steuerminderungen.py:283
 msgid "form.lotse.field_handwerker_summe.data_label"
 msgstr "Summe der Rechnungsbeträge (Handwerker)"
 
-#: app/forms/steps/lotse/steuerminderungen.py:295
+#: app/forms/steps/lotse/steuerminderungen.py:286
 msgid "form.lotse.field_handwerker_lohn_etc_summe"
 msgstr "darin enthaltene Lohnanteile, Maschinen- und Fahrtkosten, inkl. USt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:296
+#: app/forms/steps/lotse/steuerminderungen.py:287
 msgid "form.lotse.field_handwerker_lohn_etc_summe.data_label"
 msgstr "darin enthaltene Lohnanteile, Maschinen- und Fahrtkosten, inkl. USt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:301
+#: app/forms/steps/lotse/steuerminderungen.py:292
 msgid "form.lotse.validation-haushaltsnahe-summe"
 msgstr ""
 "Sie haben angegeben, dass es haushaltsnahe Dienstleistungen gab. Bitte "
 "geben Sie hier deren Summe ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:308
+#: app/forms/steps/lotse/steuerminderungen.py:299
 msgid "form.lotse.validation-haushaltsnahe-entries"
 msgstr ""
 "Sie haben angegeben, dass es haushaltsnahe Dienstleistungen gab. Bitte "
 "geben Sie hier deren Art ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:314
+#: app/forms/steps/lotse/steuerminderungen.py:305
 msgid "form.lotse.validation-handwerker-summe"
 msgstr ""
 "Sie haben angegeben, dass es Handwerkerleistungen gab. Bitte geben Sie "
 "hier deren Summe ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:321
+#: app/forms/steps/lotse/steuerminderungen.py:312
 msgid "form.lotse.validation-handwerker-entries"
 msgstr ""
 "Sie haben angegeben, dass es Handwerkerleistungen gab. Bitte geben Sie "
 "hier deren Art ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:327
+#: app/forms/steps/lotse/steuerminderungen.py:318
 msgid "form.lotse.validation-handwerker-lohn-etc-summe"
 msgstr ""
 "Sie haben angegeben, dass es Handwerkerleistungen gab. Bitte geben Sie "
 "hier die Summe der Lohnanteile, Maschinen- und Fahrtkosten inklusive "
 "Umsatzsteuer ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:340
+#: app/forms/steps/lotse/steuerminderungen.py:331
 msgid "form.lotse.steuerminderungen.details-title"
 msgstr "Was muss ich beachten?"
 
-#: app/forms/steps/lotse/steuerminderungen.py:341
+#: app/forms/steps/lotse/steuerminderungen.py:332
 msgid "form.lotse.steuerminderungen.details-text"
 msgstr ""
 "Falls Sie in einer Mietwohnung wohnen und neben den Leistungen aus der "
@@ -1820,39 +1982,39 @@ msgstr ""
 "haben dabei die Möglichkeit mehrere Antworten auszuwählen. Bitte beachten"
 " Sie:"
 
-#: app/forms/steps/lotse/steuerminderungen.py:343
+#: app/forms/steps/lotse/steuerminderungen.py:334
 msgid "form.lotse.steuerminderungen.details-list-item-1"
 msgstr ""
 "Es <strong>muss eine Rechnung</strong> vorliegen, die zum Beispiel per "
 "Überweisung oder EC-Kartenzahlung beglichen worden ist. "
 "<strong>Barzahlungen können nicht</strong> geltend gemacht werden."
 
-#: app/forms/steps/lotse/steuerminderungen.py:344
+#: app/forms/steps/lotse/steuerminderungen.py:335
 msgid "form.lotse.steuerminderungen.details-list-item-2"
 msgstr ""
 "Abgesetzt werden können Kosten, die Sie <strong>im Besteuerungsjahr "
 "bezahlt</strong> haben. Relevant ist der Zeitpunkt der Bezahlung, nicht "
 "der Rechnungsstellung."
 
-#: app/forms/steps/lotse/steuerminderungen.py:345
+#: app/forms/steps/lotse/steuerminderungen.py:336
 msgid "form.lotse.steuerminderungen.details-list-item-3"
 msgstr ""
 "Wenn Sie sich als <strong>Arbeitgeber betätigen und "
 "Haushaltshilfen</strong> als Arbeitnehmer einstellen, können Sie dies im "
 "Steuerlotsen <strong>nicht steuerlich absetzen</strong>."
 
-#: app/forms/steps/lotse/steuerminderungen.py:351
+#: app/forms/steps/lotse/steuerminderungen.py:342
 msgid "form.lotse.skip_reason.stmind_gem_haushalt.no_handwerker_haushaltsnahe"
 msgstr ""
 "Bitte überspringen Sie diese Angaben. Die Angabe zum gemeinsamen Haushalt"
 " ist nur relevant, wenn Sie Angaben zu haushaltsnaheh Tätigkeiten und "
 "Dienstleistungen und/oder Handwerkerleistungen machen."
 
-#: app/forms/steps/lotse/steuerminderungen.py:365
+#: app/forms/steps/lotse/steuerminderungen.py:356
 msgid "form.lotse.gem-haushalt-title"
 msgstr "Gemeinsamer Haushalt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:366
+#: app/forms/steps/lotse/steuerminderungen.py:357
 msgid "form.lotse.gem-haushalt-intro"
 msgstr ""
 "Haben Sie in 2020 mit weiteren Personen zusammengewohnt? Bei "
@@ -1861,63 +2023,63 @@ msgstr ""
 "Dann geben Sie die weiteren Personen Ihres Haushalts bitte an. Sie müssen"
 " diese Angaben nur machen, wenn Sie"
 
-#: app/forms/steps/lotse/steuerminderungen.py:371
+#: app/forms/steps/lotse/steuerminderungen.py:362
 msgid "form.lotse.step_gem_haushalt.label"
 msgstr "Gemeinsamer Haushalt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:377
+#: app/forms/steps/lotse/steuerminderungen.py:368
 msgid "form.lotse.field_gem_haushalt_count"
 msgstr "Anzahl der weiteren Personen im Haushalt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:378
+#: app/forms/steps/lotse/steuerminderungen.py:369
 msgid "form.lotse.field_gem_haushalt_count.data_label"
 msgstr "Anzahl der weiteren Personen im Haushalt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:382
+#: app/forms/steps/lotse/steuerminderungen.py:373
 msgid "form.lotse.field_gem_haushalt_entries"
 msgstr ""
 "Name, Vorname, Geburtsdatum der weiteren alleinstehenden Personen im "
 "Haushalt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:383
+#: app/forms/steps/lotse/steuerminderungen.py:374
 msgid "form.lotse.field_gem_haushalt_entries-help"
 msgstr ""
 "Alleinstehend sind Personen, die weder verheiratet noch verpartnert nach "
 "dem Lebenspartnerschaftsgesetz sind. "
 
-#: app/forms/steps/lotse/steuerminderungen.py:384
+#: app/forms/steps/lotse/steuerminderungen.py:375
 msgid "form.lotse.field_gem_haushalt_entries.data_label"
 msgstr ""
 "Name, Vorname, Geburtsdatum der weiteren alleinstehenden Personen im "
 "Haushalt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:390
+#: app/forms/steps/lotse/steuerminderungen.py:381
 msgid "form.lotse.validation-gem-haushalt-count"
 msgstr ""
 "Sie haben weitere Personen angegeben. Bitte geben Sie hier die "
 "entsprechende Anzahl der Personen ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:397
+#: app/forms/steps/lotse/steuerminderungen.py:388
 msgid "form.lotse.validation-gem-haushalt-entries"
 msgstr ""
 "Sie haben angegeben, dass weitere Personen im Haushalt leben. Bitte geben"
 " Sie hier die die Daten der Personen ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:408
+#: app/forms/steps/lotse/steuerminderungen.py:399
 msgid "form.lotse.gem_haushalt-list-item-1"
 msgstr "alleinstehend sind"
 
-#: app/forms/steps/lotse/steuerminderungen.py:409
+#: app/forms/steps/lotse/steuerminderungen.py:400
 msgid "form.lotse.gem_haushalt-list-item-2"
 msgstr ""
 "haushaltsnahe Dienstleistungen und/oder Handwerkerleistungen angegeben "
 "haben"
 
-#: app/forms/steps/lotse/steuerminderungen.py:415
+#: app/forms/steps/lotse/steuerminderungen.py:406
 msgid "form.lotse.religion-title"
 msgstr "Steuern für Ihre Religionsgemeinschaft"
 
-#: app/forms/steps/lotse/steuerminderungen.py:416
+#: app/forms/steps/lotse/steuerminderungen.py:407
 msgid "form.lotse.religion-intro"
 msgstr ""
 "Wenn Sie Mitglied einer Religionsgemeinschaft sind, die als Körperschaft "
@@ -1929,27 +2091,27 @@ msgstr ""
 "Kirchensteuer (ohne Kirchensteuer auf Abgeltungsteuer) ein, die Sie 2020 "
 "gezahlt haben bzw. die Ihnen 2020 erstattet wurde."
 
-#: app/forms/steps/lotse/steuerminderungen.py:421
+#: app/forms/steps/lotse/steuerminderungen.py:412
 msgid "form.lotse.step_religion.label"
 msgstr "Steuern für Ihre Religionsgemeinschaft"
 
-#: app/forms/steps/lotse/steuerminderungen.py:427
+#: app/forms/steps/lotse/steuerminderungen.py:418
 msgid "form.lotse.field_religion_paid_summe"
 msgstr "Gezahlt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:429
+#: app/forms/steps/lotse/steuerminderungen.py:420
 msgid "form.lotse.field_religion_paid_summe-help"
 msgstr "Tragen Sie dafür die Summe Ihrer 2020 gezahlten Kirchensteuer ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:430
+#: app/forms/steps/lotse/steuerminderungen.py:421
 msgid "form.lotse.field_religion_paid_summe.data_label"
 msgstr "Gezahlt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:432
+#: app/forms/steps/lotse/steuerminderungen.py:423
 msgid "form.lotse.field_religion_reimbursed_summe"
 msgstr "Erstattet"
 
-#: app/forms/steps/lotse/steuerminderungen.py:433
+#: app/forms/steps/lotse/steuerminderungen.py:424
 msgid "form.lotse.field_religion_reimbursed-help"
 msgstr ""
 "Wenn Sie letztes Jahr eine Steuererklärung gemacht haben und Ihnen zu "
@@ -1957,32 +2119,32 @@ msgstr ""
 "Summe der erstatteten Kirchensteuer finden Sie beispielsweise auf dem "
 "Steuerbescheid des Vorjahres."
 
-#: app/forms/steps/lotse/steuerminderungen.py:434
+#: app/forms/steps/lotse/steuerminderungen.py:425
 msgid "form.lotse.field_religion_reimbursed_summe.data_label"
 msgstr "Erstattet"
 
-#: app/forms/steps/lotse/steuerminderungen.py:449
+#: app/forms/steps/lotse/steuerminderungen.py:440
 msgid "form.lotse.spenden-inland-title"
 msgstr "Spenden und Mitgliedsbeiträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:450
+#: app/forms/steps/lotse/steuerminderungen.py:441
 msgid "form.lotse.spenden-inland-intro"
 msgstr ""
 "Tragen Sie hier die Summe Ihrer Spenden und Mitgliedsbeiträge ein. Alle "
 "Spenden und Mitgliedsbeiträge für steuerbegünstigte Zwecke sind nur auf "
 "Anforderung des Finanzamts durch eine Bestätigung nachzuweisen. "
 
-#: app/forms/steps/lotse/steuerminderungen.py:455
+#: app/forms/steps/lotse/steuerminderungen.py:446
 msgid "form.lotse.step_spenden.label"
 msgstr "Spenden und Mitgliedsbeiträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:460
+#: app/forms/steps/lotse/steuerminderungen.py:451
 msgid "form.lotse.spenden-inland"
 msgstr ""
 "Spenden und Mitgliedsbeiträge zur Förderung steuerbegünstigter Zwecke an "
 "Empfänger im Inland"
 
-#: app/forms/steps/lotse/steuerminderungen.py:462
+#: app/forms/steps/lotse/steuerminderungen.py:453
 msgid "form.lotse.spenden-help"
 msgstr ""
 "Alle Spenden und Mitgliedsbeiträge für steuerbegünstigte Zwecke sind "
@@ -1992,21 +2154,21 @@ msgstr ""
 "Betätigungen, die in erster Linie der Freizeitgestaltung dienen, oder die"
 " Heimatpflege und Heimatkunde fördert."
 
-#: app/forms/steps/lotse/steuerminderungen.py:463
+#: app/forms/steps/lotse/steuerminderungen.py:454
 msgid "form.lotse.spenden-inland.data_label"
 msgstr "Spenden und Mitgliedsbeiträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:465
+#: app/forms/steps/lotse/steuerminderungen.py:456
 msgid "form.lotse.spenden-inland-parteien"
 msgstr "Spenden und Mitgliedsbeiträge an inländische politische Parteien"
 
-#: app/forms/steps/lotse/steuerminderungen.py:466
+#: app/forms/steps/lotse/steuerminderungen.py:457
 msgid "form.lotse.spenden-inland-parteien-help"
 msgstr ""
 "Der Abzug ist nicht möglich, sofern die politische Partei von der "
 "staatlichen Parteienfinan­zierung ausgeschlossen ist."
 
-#: app/forms/steps/lotse/steuerminderungen.py:467
+#: app/forms/steps/lotse/steuerminderungen.py:458
 msgid "form.lotse.spenden-inland-parteien.data_label}"
 msgstr "an inländische politische Parteien"
 
@@ -2053,15 +2215,15 @@ msgstr ""
 "übermittelt. Bewahren Sie Ihre Nachweise für Nachfragen gut auf."
 
 #: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:67
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:84
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:86
 msgid "form.lotse.filing.header-title"
 msgstr "Steuerformular - Abgabebestätigung - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:73
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:75
 msgid "form.lotse.filing.failure.header-title"
 msgstr "Steuerformular - Abgabebefehler - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:80
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:82
 msgid "form.lotse.ack.alert.title"
 msgstr "Herzlichen Glückwunsch! Sie sind mit Ihrer Steuererklärung fertig!"
 
@@ -2423,170 +2585,6 @@ msgstr ""
 msgid "form.lotse.field_person_religion.data_label"
 msgstr "Religionszugehörigkeit"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:197
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:320
-msgid "form.lotse.field_person_idnr"
-msgstr "Steuer-Identifikationsnummer"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:199
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:321
-msgid "form.lotse.field_person_idnr.data_label"
-msgstr "Steuer-Identifikationsnummer"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:201
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:323
-msgid "form.lotse.field_person_dob"
-msgstr "Geburtsdatum"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:202
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:324
-msgid "form.lotse.field_person_dob.data_label"
-msgstr "Geburtsdatum"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:203
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:325
-msgid "form.lotse.validation-dob-missing"
-msgstr ""
-"Geben Sie Ihr vollständiges Geburtsdatum ein. Ihre Angabe muss folgendem "
-"Muster entsprechen: 29 2 1951 "
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:206
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:328
-msgid "form.lotse.field_person_first_name"
-msgstr "Vorname"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:207
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:329
-msgid "form.lotse.field_person_first_name.data_label"
-msgstr "Vorname"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:211
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:333
-msgid "form.lotse.field_person_last_name"
-msgstr "Nachname"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:212
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:334
-msgid "form.lotse.field_person_last_name.data_label"
-msgstr "Nachname"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:216
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:346
-msgid "form.lotse.field_person_street"
-msgstr "Straße"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:217
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:347
-msgid "form.lotse.field_person_street.data_label"
-msgstr "Straße"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:221
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:352
-msgid "form.lotse.field_person_street_number"
-msgstr "Hausnummer"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:222
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:353
-msgid "form.lotse.field_person_street_number.data_label"
-msgstr "Hausnummer"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:226
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:359
-msgid "form.lotse.field_person_street_number_ext"
-msgstr "Hausnummerzusatz"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:227
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:360
-msgid "form.lotse.field_person_street_number_ext.data_label"
-msgstr "Hausnummerzusatz"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:231
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:364
-msgid "form.lotse.field_person_address_ext"
-msgstr "Adressergänzung"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:232
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:365
-msgid "form.lotse.field_person_address_ext.data_label"
-msgstr "Adressergänzung"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:236
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:369
-msgid "form.lotse.field_person_plz"
-msgstr "Postleitzahl"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:237
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:370
-msgid "form.lotse.field_person_plz.data_label"
-msgstr "Postleitzahl"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:241
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:375
-msgid "form.lotse.field_person_town"
-msgstr "Wohnort"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:242
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:376
-msgid "form.lotse.field_person_town.data_label"
-msgstr "Wohnort"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:248
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:383
-msgid "form.lotse.field_person_beh_grad"
-msgstr "Grad der Behinderung"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:251
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:385
-msgid "form.lotse.field_person_beh_grad-help"
-msgstr ""
-"Tragen Sie bitte hier den Grad der Behinderung ein. Der Grad der "
-"Behinderung, abgekürzt GdB, wird mit einem ärztlichen Gutachten "
-"individuell festgelegt. Er steht ebenfalls auf dem "
-"Behindertenausweis.<br/><br/>Menschen mit Behinderung und einem Grad der "
-"Behinderung von mindestens 25 aber weniger als 50 steht der entsprechende"
-" Pauschbetrag jedoch nur zu <ul><li>wenn wegen der Behinderung ein "
-"gesetzlicher Anspruch auf Rente (z.B. Unfallrente) oder auf andere "
-"laufende Bezüge besteht</li><li>wenn die Behinderung zu einer dauernden "
-"Einbuße der körperlichen Beweglichkeit geführt hat oder auf einer "
-"typischen Berufskrankheit beruht.</li><ul>"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:252
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:386
-msgid "form.lotse.field_person_beh_grad.data_label"
-msgstr "Grad der Behinderung"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:253
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:387
-msgid "form.lotse.field_person_beh_grad.example_input"
-msgstr "z.B. 25, 30, 35 etc. "
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:256
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:390
-msgid "form.lotse.field_person_blind"
-msgstr "blind / ständig hilflos oder Pflegegrad 4 oder 5"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:257
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:391
-msgid "form.lotse.field_person_blind.data_label"
-msgstr "blind / ständig hilflos oder Pflegegrad 4 oder 5"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:259
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:393
-msgid "form.lotse.field_person_gehbeh"
-msgstr "geh- und stehbehindert"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:260
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:394
-msgid "form.lotse.field_person_gehbeh.data_label"
-msgstr "geh- und stehbehindert"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:264
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:315
-msgid "form.lotse.validation-person-beh-grad"
-msgstr ""
-"Sie haben eine Geh- oder Stehbehinderung angegeben. Bitte geben Sie hier "
-"den Grad der Behinderung an."
-
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:283
 msgid "form.lotse.step_person_a.label"
 msgid_plural "form.lotse.step_person_a.label"
@@ -2606,87 +2604,54 @@ msgstr ""
 "einer gleichgeschlechtlichen Partnerschaft leben, geben Sie bitte "
 "zunächst die Person an, deren Name im Alphabet zuerst kommt."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:303
-msgid "form.lotse.step_person_b.label"
-msgstr "Person B"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:340
-msgid "form.lotse.field_person_b_same_address.data_label"
-msgstr "Mein Partner / Meine Partnerin und ich wohnen zusammen."
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:342
-msgid "form.lotse.field_person_b_same_address-yes"
-msgstr "Mein Partner / Meine Partnerin und ich wohnen zusammen."
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:343
-msgid "form.lotse.field_person_b_same_address-no"
-msgstr ""
-"Mein Partner / Meine Partnerin und ich wohnen nicht zusammen. Er / Sie "
-"ist wohnhaft in:"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:398
-msgid "form.lotse.person-b-title"
-msgstr "Angaben für Person B"
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:399
-msgid "form.lotse.person-b-intro"
-msgstr ""
-"Geben Sie hier bitte die Daten der Ehefrau an. Wenn Sie in einer "
-"gleichgeschlechtlichen Partnerschaft leben, geben Sie bitte die Person "
-"an, deren Name im Alphabet zuletzt kommt."
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:410
-msgid "form.lotse.skip_reason.familienstand_single"
-msgstr "Sie haben als Familienstand ledig angegeben."
-
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:415
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:302
 msgid "form.lotse.step_iban.label"
 msgstr "Bankverbindung"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:420
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:307
 msgid "form.lotse.iban.account-holder"
 msgstr "Wer ist Kontoinhaber:in?"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:421
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:308
 msgid "form.lotse.iban.account-holder.data_label"
 msgstr "Kontoinhaber:in"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:422
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:309
 msgid "form.lotse.iban.account-holder-person-a"
 msgstr "Person A"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:423
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:310
 msgid "form.lotse.iban.account-holder-person-b"
 msgstr "Person B"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:426
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:438
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:313
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:325
 msgid "form.lotse.field_iban"
 msgstr "IBAN "
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:427
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:439
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:314
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:326
 msgid "form.lotse.field_iban.data_label"
 msgstr "IBAN "
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:428
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:440
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:315
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:327
 msgid "form.lotse.field_iban.example_input"
 msgstr "inländisches Geldinstitut"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:435
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:322
 msgid "form.lotse.field_is_user_account_holder"
 msgstr "Ja, ich bin Kontoinhaber:in."
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:436
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:323
 msgid "form.lotse.field_is_user_account_holder.data_label"
 msgstr "Das angegebene Konto gehört Ihnen"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:447
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:334
 msgid "form.lotse.iban-title"
 msgstr "Bankverbindung"
 
-#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:448
+#: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:335
 msgid "form.lotse.iban-intro"
 msgstr ""
 "Falls Sie Vorauszahlungen getätigt haben, werden eventuelle Erstattungen "
@@ -2755,7 +2720,7 @@ msgstr "Geben Sie an seit wann Sie als Paar dauernd getrennt leben."
 msgid "validate.date-of-too-far-in-past"
 msgstr "Das Datum darf nicht vor dem 1.1.1900 liegen."
 
-#: app/model/form_data.py:347
+#: app/model/form_data.py:366
 msgid "form.lotse.input_invalid.mandatory_field_missing"
 msgid_plural "form.lotse.input_invalid.mandatory_field_missing"
 msgstr[0] ""
@@ -2765,11 +2730,11 @@ msgstr[1] ""
 "Bitte füllen Sie alle notwendigen Felder aus, um Ihre Angaben verschicken"
 " zu können. Es sind noch %(num)s notwendige Felder nicht ausgefüllt."
 
-#: app/model/form_data.py:352
+#: app/model/form_data.py:371
 msgid "form.lotse.input_invalid.confirmation_missing"
 msgstr "Bitte erteilen Sie alle notwendigen Einwilligungen um fortzufahren."
 
-#: app/model/form_data.py:358
+#: app/model/form_data.py:377
 msgid "form.lotse.input_invalid.idnr_mismatch"
 msgstr ""
 "Bitte prüfen Sie die Steuer-Identifikationsnummer. Die Angabe muss mit "
@@ -4907,28 +4872,28 @@ msgstr ""
 msgid "form.eligibility.use-elster-button"
 msgstr "Zu Mein ELSTER"
 
-#: app/templates/eligibility/display_maybe.html:15
+#: app/templates/eligibility/display_maybe.html:17
 msgid "maybe_icon"
 msgstr "Fragezeichen Icon auf gelbem Kreis"
 
-#: app/templates/eligibility/display_maybe.html:27
+#: app/templates/eligibility/display_maybe.html:33
 #: app/templates/eligibility/display_success.html:25
 msgid "form.eligibility.success-next-step"
 msgstr "Wie geht es weiter?"
 
-#: app/templates/eligibility/display_maybe.html:28
+#: app/templates/eligibility/display_maybe.html:34
 #: app/templates/eligibility/display_success.html:26
 msgid "form.eligibility.success-next-step-text"
 msgstr ""
 "Als Nächstes können Sie sich registrieren. Dazu brauchen Sie Ihre Steuer-"
 "Identifikationsnummer und Ihr Geburtsdatum."
 
-#: app/templates/eligibility/display_maybe.html:34
+#: app/templates/eligibility/display_maybe.html:40
 #: app/templates/eligibility/display_success.html:32
 msgid "form.eligibility.success-attention.heading"
 msgstr "Bitte beachten Sie"
 
-#: app/templates/eligibility/display_maybe.html:44
+#: app/templates/eligibility/display_maybe.html:50
 #: app/templates/eligibility/display_success.html:42
 msgid "form.eligibility.use-register-button"
 msgstr "Registrieren"
@@ -5308,4 +5273,3 @@ msgstr ""
 #: app/templates/unlock_code/registration_success.html:21
 msgid "register.success.preparation.button"
 msgstr "Vorbereitungshilfe herunterladen"
-


### PR DESCRIPTION
# Short Description
We do not need all the steuerminderung fields for tax declarations for 2021 because they will be replaced by the Fahrtkostenpauschale.

# Changes
- Delete the fields
- Delete corresponding texts

# Feedback
- Any?