### PR TITLE
Change Veranlagungszeitraum date

### DIFF
--- a/erica_app/erica/elster_xml/elster_xml_generator.py
+++ b/erica_app/erica/elster_xml/elster_xml_generator.py
@@ -17,7 +17,7 @@ from erica.pyeric.eric import get_eric_wrapper
 # TODO: Refactor how the xml is generated.
 #       The current structure does not have an easy entrypoint and we currently have quite similar functions
 
-VERANLAGUNGSJAHR = 2020
+VERANLAGUNGSJAHR = 2021
 
 Vorsatz = namedtuple(
     'Vorsatz',
@@ -303,7 +303,7 @@ def _add_vast_list_xml_nutzdaten(xml_top, version='7'):
     list_xml.set('version', version)
 
 
-def _add_vast_beleg_ids_request_nutzdaten(xml_top, user_data, year='2020'):
+def _add_vast_beleg_ids_request_nutzdaten(xml_top, user_data, year='2021'):
     """ Generates <Nutzdaten> with the given user_data and adds it to given xml_top. """
     nutzdaten_xml = SubElement(xml_top, 'Nutzdaten')
     datenabholung_xml = SubElement(nutzdaten_xml, 'Datenabholung')
@@ -321,7 +321,7 @@ def _add_abrufcode_request_nutzdaten(xml_top):
     SubElement(antrag_xml, 'EMail').text = get_settings().testing_email_address
 
 
-def _add_vast_beleg_request_xml_nutzdaten(xml_top, user_data, beleg_id, year='2020'):
+def _add_vast_beleg_request_xml_nutzdaten(xml_top, user_data, beleg_id, year='2021'):
     """ Generates <Nutzdaten> with the given user_data and adds it to given xml_top. """
     nutzdaten_xml = SubElement(xml_top, 'Nutzdaten')
     datenabholung_xml = SubElement(nutzdaten_xml, 'Datenabholung')

--- a/erica_app/tests/elster_xml/test_elster_xml_generator.py
+++ b/erica_app/tests/elster_xml/test_elster_xml_generator.py
@@ -1,4 +1,5 @@
 import copy
+import datetime
 import unittest
 from unittest.mock import patch, MagicMock, call
 from xml.etree.ElementTree import XML, ParseError, Element, SubElement, tostring
@@ -23,6 +24,9 @@ from erica.pyeric.eric import get_eric_wrapper
 from erica.pyeric.eric_errors import EricProcessNotSuccessful
 from erica.elster_xml.transfer_header_fields import TransferHeaderFields
 from tests.utils import missing_cert, missing_pyeric_lib, use_testmerker_env_set_false
+
+_VERANLAGUNGSJAHR = 2021
+_BEANTRAGUNGSJAHR = _VERANLAGUNGSJAHR+ 1
 
 
 class TestGenerateVorsatzWithTaxNumber(unittest.TestCase):
@@ -976,12 +980,13 @@ class TestVastRequest(unittest.TestCase):
     @freeze_time("2021-06-24")
     def test_add_vast_antrag_nutzdaten(self):
         xml_top = Element('top')
-        _add_vast_request_xml_nutzdaten(xml_top, self.valid_user_data)
+        with patch('erica.elster_xml.elster_xml_generator.dt.date.today', MagicMock(return_value=datetime.date(_BEANTRAGUNGSJAHR, 1, 1))):
+            _add_vast_request_xml_nutzdaten(xml_top, self.valid_user_data)
         xml_string = _pretty(xml_top)
 
         self.assertEqual('false', xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Unbeschraenkt').text)
-        self.assertEqual('2020', xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Veranlagungsjahre/Jahr').text)
-        self.assertEqual('2021-12-31', xml_top.find('.//SpezRechtAntrag/GueltigBis').text)
+        self.assertEqual(str(_VERANLAGUNGSJAHR), xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Veranlagungsjahre/Jahr').text)
+        self.assertEqual('2022-12-31', xml_top.find('.//SpezRechtAntrag/GueltigBis').text)
         self.assertIn('<SpezRechtAntrag version="' + self.expected_antrag_version + '">', xml_string)
         self.assertIn(
             '<DateninhaberIdNr>04452397687</DateninhaberIdNr><DateninhaberGeburtstag>1985-01-01</DateninhaberGeburtstag>',
@@ -1158,7 +1163,7 @@ class TestVastBelegIdsRequest(unittest.TestCase):
         xml_string = _pretty(xml_top)
 
         self.assertIn('idnr="' + self.idnr + '"', xml_string)
-        self.assertIn('veranlagungsjahr="2020"', xml_string)
+        self.assertIn(f'veranlagungsjahr="{_VERANLAGUNGSJAHR}"', xml_string)
 
     def test_that_add_vast_beleg_ids_request_xml_nutzdaten_adds_correct_year(self):
         xml_top = Element('top')
@@ -1288,7 +1293,7 @@ class TestVastBelegRequest(unittest.TestCase):
         _add_vast_beleg_request_xml_nutzdaten(xml_top, self.valid_user_data, self.beleg_id_1)
 
         self.assertEqual(1, len(xml_top.findall('Nutzdaten/Datenabholung/Abholung')))
-        self.assertEqual('2020', xml_top.findall('Nutzdaten/Datenabholung/Abholung')[0].get('veranlagungsjahr'))
+        self.assertEqual(str(_VERANLAGUNGSJAHR), xml_top.findall('Nutzdaten/Datenabholung/Abholung')[0].get('veranlagungsjahr'))
 
     @pytest.mark.skipif(missing_pyeric_lib(), reason="skipped because of missing eric lib; see pyeric/README.md")
     def test_that_generate_full_vast_beleg_request_xml_generates_transfer_header(self):

--- a/erica_app/tests/elster_xml/test_elster_xml_generator.py
+++ b/erica_app/tests/elster_xml/test_elster_xml_generator.py
@@ -986,7 +986,7 @@ class TestVastRequest(unittest.TestCase):
 
         self.assertEqual('false', xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Unbeschraenkt').text)
         self.assertEqual(str(VERANLAGUNGSJAHR), xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Veranlagungsjahre/Jahr').text)
-        self.assertEqual('2022-12-31', xml_top.find('.//SpezRechtAntrag/GueltigBis').text)
+        self.assertEqual(f'{_BEANTRAGUNGSJAHR}-12-31', xml_top.find('.//SpezRechtAntrag/GueltigBis').text)
         self.assertIn('<SpezRechtAntrag version="' + self.expected_antrag_version + '">', xml_string)
         self.assertIn(
             '<DateninhaberIdNr>04452397687</DateninhaberIdNr><DateninhaberGeburtstag>1985-01-01</DateninhaberGeburtstag>',

--- a/erica_app/tests/elster_xml/test_elster_xml_generator.py
+++ b/erica_app/tests/elster_xml/test_elster_xml_generator.py
@@ -16,7 +16,7 @@ from erica.elster_xml.elster_xml_generator import _pretty, _add_xml_nutzdaten_he
     _add_vast_beleg_ids_request_nutzdaten, generate_full_vast_beleg_ids_request_xml, \
     _add_abrufcode_request_nutzdaten, generate_full_abrufcode_request_xml, _add_vast_beleg_request_xml_nutzdaten, \
     generate_full_vast_beleg_request_xml, _add_vast_revocation_xml_nutzdaten, generate_full_vast_revocation_xml, \
-    generate_vorsatz_with_tax_number, _compute_valid_until_date, generate_vorsatz_without_tax_number
+    generate_vorsatz_with_tax_number, _compute_valid_until_date, generate_vorsatz_without_tax_number, VERANLAGUNGSJAHR
 from erica.elster_xml.xml_parsing.erica_xml_parsing import remove_declaration_and_namespace
 from erica.elster_xml.elster_xml_tree import ElsterXmlTreeNode
 from erica.elster_xml.est_mapping import PersonSpecificFieldId
@@ -25,8 +25,8 @@ from erica.pyeric.eric_errors import EricProcessNotSuccessful
 from erica.elster_xml.transfer_header_fields import TransferHeaderFields
 from tests.utils import missing_cert, missing_pyeric_lib, use_testmerker_env_set_false
 
-_VERANLAGUNGSJAHR = 2021
-_BEANTRAGUNGSJAHR = _VERANLAGUNGSJAHR+ 1
+
+_BEANTRAGUNGSJAHR = VERANLAGUNGSJAHR + 1
 
 
 class TestGenerateVorsatzWithTaxNumber(unittest.TestCase):
@@ -985,7 +985,7 @@ class TestVastRequest(unittest.TestCase):
         xml_string = _pretty(xml_top)
 
         self.assertEqual('false', xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Unbeschraenkt').text)
-        self.assertEqual(str(_VERANLAGUNGSJAHR), xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Veranlagungsjahre/Jahr').text)
+        self.assertEqual(str(VERANLAGUNGSJAHR), xml_top.find('.//SpezRechtAntrag/Veranlagungszeitraum/Veranlagungsjahre/Jahr').text)
         self.assertEqual('2022-12-31', xml_top.find('.//SpezRechtAntrag/GueltigBis').text)
         self.assertIn('<SpezRechtAntrag version="' + self.expected_antrag_version + '">', xml_string)
         self.assertIn(
@@ -1163,7 +1163,7 @@ class TestVastBelegIdsRequest(unittest.TestCase):
         xml_string = _pretty(xml_top)
 
         self.assertIn('idnr="' + self.idnr + '"', xml_string)
-        self.assertIn(f'veranlagungsjahr="{_VERANLAGUNGSJAHR}"', xml_string)
+        self.assertIn(f'veranlagungsjahr="{VERANLAGUNGSJAHR}"', xml_string)
 
     def test_that_add_vast_beleg_ids_request_xml_nutzdaten_adds_correct_year(self):
         xml_top = Element('top')
@@ -1293,7 +1293,7 @@ class TestVastBelegRequest(unittest.TestCase):
         _add_vast_beleg_request_xml_nutzdaten(xml_top, self.valid_user_data, self.beleg_id_1)
 
         self.assertEqual(1, len(xml_top.findall('Nutzdaten/Datenabholung/Abholung')))
-        self.assertEqual(str(_VERANLAGUNGSJAHR), xml_top.findall('Nutzdaten/Datenabholung/Abholung')[0].get('veranlagungsjahr'))
+        self.assertEqual(str(VERANLAGUNGSJAHR), xml_top.findall('Nutzdaten/Datenabholung/Abholung')[0].get('veranlagungsjahr'))
 
     @pytest.mark.skipif(missing_pyeric_lib(), reason="skipped because of missing eric lib; see pyeric/README.md")
     def test_that_generate_full_vast_beleg_request_xml_generates_transfer_header(self):


### PR DESCRIPTION
# Short Description
This should adapt the tax period for which we are requesting the FSC. I had to adapt some of the tests. I tried to make them more reliable.

# Changes
- Change VERANLAGUNGSJAHR from 2020 to 2021
- Adapt tests

# Feedback
- Is that what you had in mind?
- What do you think about the adapted tests?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
