### PR TITLE
Remove arrows on number input

### DIFF
--- a/webapp/client/public/css/base.css
+++ b/webapp/client/public/css/base.css
@@ -100,6 +100,16 @@ a:visited {
   max-width: var(--input-width-25);
 }
 
+input[type=number] {
+  -moz-appearance: textfield;
+}
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
 input.form-control {
   border: 2px solid var(--border-color);
   border-radius: 0;


### PR DESCRIPTION
# Short Description
- We had arrows on the right of every number input. Also, it was possible to change the number by scrolling in the field. This disables that.

# Changes
- Add classes to disable arrows + scrolling in the different browsers

# Feedback
- Could you check that it works on Safari? (I only checked Chrome, Edge and Firefox)

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
