### PR TITLE
Adapt 2019 and 2021

### DIFF
--- a/acceptance_tests/cypress/integration/lotse_flow.spec.js
+++ b/acceptance_tests/cypress/integration/lotse_flow.spec.js
@@ -105,7 +105,7 @@ const taxReturnData = {
 
 const older_date_day = '31'
 const older_date_month = '12'
-const older_date_year = '2019'
+const older_date_year = '2020'
 const recent_date_day = '01'
 const recent_date_month = '01'
 const recent_date_year = '2021'

--- a/erica_app/erica/elster_xml/est_mapping.py
+++ b/erica_app/erica/elster_xml/est_mapping.py
@@ -215,7 +215,7 @@ def _convert_to_elster_identifiers(form_data):
     return result
 
 
-def check_and_generate_entries(est_data, year=2019):
+def check_and_generate_entries(est_data):
     # Add mandatory fields for digital submission
     enriched_est_data = est_data
     enriched_est_data['is_einkommensteuererklaerung'] = 'X'

--- a/erica_app/tests/elster_xml/test_elster_xml_generator.py
+++ b/erica_app/tests/elster_xml/test_elster_xml_generator.py
@@ -34,7 +34,7 @@ class TestGenerateVorsatzWithTaxNumber(unittest.TestCase):
         steuernummer = '123456789'
         person_a_idnr = '04452397687'
         person_b_idnr = '02293417683'
-        year = 2019
+        year = TEST_EST_VERANLAGUNGSJAHR
         first_name = 'Herbert'
         last_name = 'Müller'
         street = 'Schlossallee'
@@ -67,7 +67,7 @@ class TestGenerateVorsatzWithoutTaxNumber(unittest.TestCase):
     def test_if_no_steuernummer_given_then_fields_set_correctly(self):
         person_a_idnr = '04452397687'
         person_b_idnr = '02293417683'
-        year = 2019
+        year = TEST_EST_VERANLAGUNGSJAHR
         first_name = 'Herbert'
         last_name = 'Müller'
         street = 'Schlossallee'

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-12-09 10:49+0100\n"
+"POT-Creation-Date: 2021-12-10 12:12+0100\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -2405,7 +2405,7 @@ msgstr "seit dem"
 
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:43
 msgid "form.lotse.familienstand_married_lived_separated"
-msgstr "Haben Sie als Paar vor dem 01.01.2021 dauernd getrennt gelebt?"
+msgstr "Haben Sie als Paar vor dem 01.01.2022 dauernd getrennt gelebt?"
 
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:44
 msgid "form.lotse.familienstand_married_lived_separated.example_input"
@@ -2415,7 +2415,7 @@ msgstr ""
 
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:45
 msgid "form.lotse.familienstand_married_lived_separated.data_label"
-msgstr "Vor dem 01.01.2021 dauernd getrennt gelebt"
+msgstr "Vor dem 01.01.2022 dauernd getrennt gelebt"
 
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:47
 msgid "form.lotse.familienstand_married_lived_separated_since"


### PR DESCRIPTION
# Short Description
- Searched for occurrences of the adjacent years and replace meaningful occurrences
- Still the old years: Antragsdatum in one sample XML, Test Dates, Readme (EZVA)

# Changes
- Small adaptions of the years

# Feedback
- Any? :D

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
