### PR TITLE
Ignore boto3 patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,4 +25,8 @@ updates:
     schedule:
       interval: "daily"
     ignore:
+      # For storybook, ignore all updates. We update storybook manually
       - dependency-name: "@storybook/*"
+      # For boto3, ignore all patch updates
+      - dependency-name: "boto3"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
# Short Description
We want to tell dependabot to ignore patches of boto3 because we only use it for our cicd pipeline and do not need every new feature. This adds boto3 patch updates to the ignore list of the dependabot.yml

# Feedback
- Anything I missed?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
