### PR TITLE
Add function to calculate Pausch

### DIFF
--- a/webapp/app/forms/steps/lotse/pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/pauschbetrag.py
@@ -1,24 +1,34 @@
-def calculate_pauschbetrag(pflegegrad=False, beh_grad=None, merkzeichen_bl=False, merkzeichen_tbl=False, merkzeichen_h=False,
-                           merkzeichen_ag=False, merkzeichen_g=False):
-    if pflegegrad:
-        return 7400
-    if merkzeichen_bl:
-        return 7400
-    if merkzeichen_tbl:
-        return 7400
-    if merkzeichen_h:
+def calculate_pauschbetrag(has_pflegegrad=False, disability_degree=None, has_merkzeichen_bl=False, has_merkzeichen_tbl=False, has_merkzeichen_h=False):
+    """
+    Calculates the pauschbetrag given some information about the user.
+
+    :param has_pflegegrad: A boolean indicating whether the user has a "Pflegegrad" of 4 or 5
+    :param disability_degree: An integer indicating the disability degree of the user. Must be between 20 and 100
+    :param has_merkzeichen_bl: A boolean indicating whether the user has the Merkzeichen Bl
+    :param has_merkzeichen_tbl: A boolean indicating whether the user has the Merkzeichen TBl
+    :param has_merkzeichen_h: A boolean indicating whether the user has the Merkzeichen H
+    """
+    if has_pflegegrad or has_merkzeichen_bl or has_merkzeichen_tbl or has_merkzeichen_h:
         return 7400
 
-    beh_grad_to_pauschal_betrag_mapping = {
-        20: 384,
-        30: 620,
-        40: 860,
-        50: 1140,
-        60: 1440,
-        70: 1780,
-        80: 2120,
-        90: 2460,
-        100: 2840,
-    }
+    if disability_degree > 100 or disability_degree < 20:
+        raise ValueError(f"Disability degree has incorrect value of {disability_degree}. Accept only values between 20 and 100.")
 
-    return beh_grad_to_pauschal_betrag_mapping[beh_grad]
+    if disability_degree == 100:
+        return 2840
+    elif disability_degree >= 90:
+        return 2460
+    elif disability_degree >= 80:
+        return 2120
+    elif disability_degree >= 70:
+        return 1780
+    elif disability_degree >= 60:
+        return 1440
+    elif disability_degree >= 50:
+        return 1140
+    elif disability_degree >= 40:
+        return 860
+    elif disability_degree >= 30:
+        return 620
+    elif disability_degree >= 20:
+        return 384

--- a/webapp/app/forms/steps/lotse/pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/pauschbetrag.py
@@ -11,9 +11,6 @@ def calculate_pauschbetrag(has_pflegegrad=False, disability_degree=None, has_mer
     if has_pflegegrad or has_merkzeichen_bl or has_merkzeichen_tbl or has_merkzeichen_h:
         return 7400
 
-    if disability_degree > 100 or disability_degree < 20:
-        raise ValueError(f"Disability degree has incorrect value of {disability_degree}. Accept only values between 20 and 100.")
-
     if disability_degree == 100:
         return 2840
     elif disability_degree >= 90:

--- a/webapp/app/forms/steps/lotse/pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/pauschbetrag.py
@@ -1,0 +1,24 @@
+def calculate_pauschbetrag(pflegegrad=False, beh_grad=None, merkzeichen_bl=False, merkzeichen_tbl=False, merkzeichen_h=False,
+                           merkzeichen_ag=False, merkzeichen_g=False):
+    if pflegegrad:
+        return 7400
+    if merkzeichen_bl:
+        return 7400
+    if merkzeichen_tbl:
+        return 7400
+    if merkzeichen_h:
+        return 7400
+
+    beh_grad_to_pauschal_betrag_mapping = {
+        20: 384,
+        30: 620,
+        40: 860,
+        50: 1140,
+        60: 1440,
+        70: 1780,
+        80: 2120,
+        90: 2460,
+        100: 2840,
+    }
+
+    return beh_grad_to_pauschal_betrag_mapping[beh_grad]

--- a/webapp/tests/forms/steps/lotse/test_pauschbetrag.py
+++ b/webapp/tests/forms/steps/lotse/test_pauschbetrag.py
@@ -1,9 +1,52 @@
+import pytest
+
 from app.forms.steps.lotse.pauschbetrag import calculate_pauschbetrag
 
 
 class TestCalculatePauschbetrag:
 
-    def test_if_no_merkzeichen_or_pflegegrad_set_then_return_correct_value_for_beh_grad(self):
+    def test_if_no_merkzeichen_or_pflegegrad_set_then_return_correct_value_for_disability_degree(self):
+        input_output_pairs = [
+            (20, 384),
+            (25, 384),
+            (30, 620),
+            (35, 620),
+            (40, 860),
+            (45, 860),
+            (50, 1140),
+            (55, 1140),
+            (60, 1440),
+            (65, 1440),
+            (70, 1780),
+            (75, 1780),
+            (80, 2120),
+            (85, 2120),
+            (90, 2460),
+            (95, 2460),
+            (100, 2840),
+        ]
+
+        params = {
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_incorrect_disability_degree_then_raise_value_error(self):
+        incorrect_disability_degrees = [-10, 18, 101]
+
+        for incorrect_disability_degree in incorrect_disability_degrees:
+            with pytest.raises(ValueError):
+                calculate_pauschbetrag(disability_degree=incorrect_disability_degree)
+
+    def test_if_merkzeichen_ag_and_no_pflegegrad_set_then_return_correct_value_for_disability_degree(self):
         input_output_pairs = [
             (20, 384),
             (30, 620),
@@ -17,21 +60,18 @@ class TestCalculatePauschbetrag:
         ]
 
         params = {
-            'pflegegrad': False,
-            'merkzeichen_bl': False,
-            'merkzeichen_tbl': False,
-            'merkzeichen_h': False,
-            'merkzeichen_ag': False,
-            'merkzeichen_g': False,
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
         }
 
-        for beh_grad, expected_result in input_output_pairs:
+        for disability_degree, expected_result in input_output_pairs:
 
-            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
 
             assert calculated_pauschbetrag == expected_result
 
-    def test_if_merkzeichen_ag_and_no_pflegegrad_set_then_return_correct_value_for_beh_grad(self):
         input_output_pairs = [
             (20, 384),
             (30, 620),
@@ -45,170 +85,126 @@ class TestCalculatePauschbetrag:
         ]
 
         params = {
-            'pflegegrad': False,
-            'merkzeichen_bl': False,
-            'merkzeichen_tbl': False,
-            'merkzeichen_h': False,
-            'merkzeichen_ag': True,
-            'merkzeichen_g': False,
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
         }
 
-        for beh_grad, expected_result in input_output_pairs:
+        for disability_degree, expected_result in input_output_pairs:
 
-            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
 
             assert calculated_pauschbetrag == expected_result
 
-    def test_if_merkzeichen_g_and_no_pflegegrad_set_then_return_correct_value_for_beh_grad(self):
-        input_output_pairs = [
-            (20, 384),
-            (30, 620),
-            (40, 860),
-            (50, 1140),
-            (60, 1440),
-            (70, 1780),
-            (80, 2120),
-            (90, 2460),
-            (100, 2840),
-        ]
+    def test_if_pflegegrad_set_and_no_merkzeichen_then_return_7400_for_all_disability_degree(self):
+        disability_degree_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
 
         params = {
-            'pflegegrad': False,
-            'merkzeichen_bl': False,
-            'merkzeichen_tbl': False,
-            'merkzeichen_h': False,
-            'merkzeichen_ag': False,
-            'merkzeichen_g': True,
+            'has_pflegegrad': True,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
         }
 
-        for beh_grad, expected_result in input_output_pairs:
+        for disability_degree in disability_degree_values:
 
-            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
-
-            assert calculated_pauschbetrag == expected_result
-
-    def test_if_pflegegrad_set_and_no_merkzeichen_then_return_7400_for_all_beh_grad(self):
-        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
-
-        params = {
-            'pflegegrad': True,
-            'merkzeichen_bl': False,
-            'merkzeichen_tbl': False,
-            'merkzeichen_h': False,
-            'merkzeichen_ag': False,
-            'merkzeichen_g': False,
-        }
-
-        for beh_grad in beh_grad_values:
-
-            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
 
             assert calculated_pauschbetrag == 7400
 
-    def test_if_pflegegrad_set_and_merkzeichen_bl_then_return_7400_for_all_beh_grad(self):
-        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+    def test_if_pflegegrad_set_and_merkzeichen_bl_then_return_7400_for_all_disability_degree(self):
+        disability_degree_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
 
         params = {
-            'pflegegrad': True,
-            'merkzeichen_bl': True,
-            'merkzeichen_tbl': False,
-            'merkzeichen_h': False,
-            'merkzeichen_ag': False,
-            'merkzeichen_g': False,
+            'has_pflegegrad': True,
+            'has_merkzeichen_bl': True,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
         }
 
-        for beh_grad in beh_grad_values:
+        for disability_degree in disability_degree_values:
 
-            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
 
             assert calculated_pauschbetrag == 7400
 
-    def test_if_pflegegrad_set_and_merkzeichen_tbl_then_return_7400_for_all_beh_grad(self):
-        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+    def test_if_pflegegrad_set_and_merkzeichen_tbl_then_return_7400_for_all_disability_degree(self):
+        disability_degree_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
 
         params = {
-            'pflegegrad': True,
-            'merkzeichen_bl': False,
-            'merkzeichen_tbl': True,
-            'merkzeichen_h': False,
-            'merkzeichen_ag': False,
-            'merkzeichen_g': False,
+            'has_pflegegrad': True,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': True,
+            'has_merkzeichen_h': False,
         }
 
-        for beh_grad in beh_grad_values:
+        for disability_degree in disability_degree_values:
 
-            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
 
             assert calculated_pauschbetrag == 7400
 
-    def test_if_pflegegrad_set_and_merkzeichen_h_then_return_7400_for_all_beh_grad(self):
-        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+    def test_if_pflegegrad_set_and_merkzeichen_h_then_return_7400_for_all_disability_degree(self):
+        disability_degree_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
 
         params = {
-            'pflegegrad': True,
-            'merkzeichen_bl': False,
-            'merkzeichen_tbl': False,
-            'merkzeichen_h': True,
-            'merkzeichen_ag': False,
-            'merkzeichen_g': False,
+            'has_pflegegrad': True,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': True,
         }
 
-        for beh_grad in beh_grad_values:
+        for disability_degree in disability_degree_values:
 
-            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
 
             assert calculated_pauschbetrag == 7400
 
-    def test_if_merkzeichen_bl_and_no_pflegegrad_set_then_return_7400_for_all_beh_grad(self):
-        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+    def test_if_merkzeichen_bl_and_no_pflegegrad_set_then_return_7400_for_all_disability_degree(self):
+        disability_degree_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
 
         params = {
-            'pflegegrad': False,
-            'merkzeichen_bl': True,
-            'merkzeichen_tbl': False,
-            'merkzeichen_h': False,
-            'merkzeichen_ag': False,
-            'merkzeichen_g': False,
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': True,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
         }
 
-        for beh_grad in beh_grad_values:
+        for disability_degree in disability_degree_values:
 
-            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
 
             assert calculated_pauschbetrag == 7400
 
-    def test_if_merkzeichen_tbl_and_no_pflegegrad_set_then_return_7400_for_all_beh_grad(self):
-        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+    def test_if_merkzeichen_tbl_and_no_pflegegrad_set_then_return_7400_for_all_disability_degree(self):
+        disability_degree_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
 
         params = {
-            'pflegegrad': False,
-            'merkzeichen_bl': False,
-            'merkzeichen_tbl': True,
-            'merkzeichen_h': False,
-            'merkzeichen_ag': False,
-            'merkzeichen_g': False,
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': True,
+            'has_merkzeichen_h': False,
         }
 
-        for beh_grad in beh_grad_values:
+        for disability_degree in disability_degree_values:
 
-            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
 
             assert calculated_pauschbetrag == 7400
 
-    def test_if_merkzeichen_h_and_no_pflegegrad_set_then_return_7400_for_all_beh_grad(self):
-        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+    def test_if_merkzeichen_h_and_no_pflegegrad_set_then_return_7400_for_all_disability_degree(self):
+        disability_degree_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
 
         params = {
-            'pflegegrad': False,
-            'merkzeichen_bl': False,
-            'merkzeichen_tbl': False,
-            'merkzeichen_h': True,
-            'merkzeichen_ag': False,
-            'merkzeichen_g': False,
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': True,
         }
 
-        for beh_grad in beh_grad_values:
+        for disability_degree in disability_degree_values:
 
-            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
 
             assert calculated_pauschbetrag == 7400

--- a/webapp/tests/forms/steps/lotse/test_pauschbetrag.py
+++ b/webapp/tests/forms/steps/lotse/test_pauschbetrag.py
@@ -34,9 +34,7 @@ class TestCalculatePauschbetrag:
         }
 
         for disability_degree, expected_result in input_output_pairs:
-
             calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
-
             assert calculated_pauschbetrag == expected_result
 
     def test_if_incorrect_disability_degree_then_raise_value_error(self):
@@ -67,9 +65,7 @@ class TestCalculatePauschbetrag:
         }
 
         for disability_degree, expected_result in input_output_pairs:
-
             calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
-
             assert calculated_pauschbetrag == expected_result
 
         input_output_pairs = [
@@ -92,9 +88,7 @@ class TestCalculatePauschbetrag:
         }
 
         for disability_degree, expected_result in input_output_pairs:
-
             calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
-
             assert calculated_pauschbetrag == expected_result
 
     def test_if_pflegegrad_set_and_no_merkzeichen_then_return_7400_for_all_disability_degree(self):
@@ -108,9 +102,7 @@ class TestCalculatePauschbetrag:
         }
 
         for disability_degree in disability_degree_values:
-
             calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
-
             assert calculated_pauschbetrag == 7400
 
     def test_if_pflegegrad_set_and_merkzeichen_bl_then_return_7400_for_all_disability_degree(self):
@@ -124,9 +116,7 @@ class TestCalculatePauschbetrag:
         }
 
         for disability_degree in disability_degree_values:
-
             calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
-
             assert calculated_pauschbetrag == 7400
 
     def test_if_pflegegrad_set_and_merkzeichen_tbl_then_return_7400_for_all_disability_degree(self):
@@ -140,9 +130,7 @@ class TestCalculatePauschbetrag:
         }
 
         for disability_degree in disability_degree_values:
-
             calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
-
             assert calculated_pauschbetrag == 7400
 
     def test_if_pflegegrad_set_and_merkzeichen_h_then_return_7400_for_all_disability_degree(self):
@@ -156,9 +144,7 @@ class TestCalculatePauschbetrag:
         }
 
         for disability_degree in disability_degree_values:
-
             calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
-
             assert calculated_pauschbetrag == 7400
 
     def test_if_merkzeichen_bl_and_no_pflegegrad_set_then_return_7400_for_all_disability_degree(self):
@@ -172,9 +158,7 @@ class TestCalculatePauschbetrag:
         }
 
         for disability_degree in disability_degree_values:
-
             calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
-
             assert calculated_pauschbetrag == 7400
 
     def test_if_merkzeichen_tbl_and_no_pflegegrad_set_then_return_7400_for_all_disability_degree(self):
@@ -188,9 +172,7 @@ class TestCalculatePauschbetrag:
         }
 
         for disability_degree in disability_degree_values:
-
             calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
-
             assert calculated_pauschbetrag == 7400
 
     def test_if_merkzeichen_h_and_no_pflegegrad_set_then_return_7400_for_all_disability_degree(self):
@@ -204,7 +186,5 @@ class TestCalculatePauschbetrag:
         }
 
         for disability_degree in disability_degree_values:
-
             calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
-
             assert calculated_pauschbetrag == 7400

--- a/webapp/tests/forms/steps/lotse/test_pauschbetrag.py
+++ b/webapp/tests/forms/steps/lotse/test_pauschbetrag.py
@@ -37,13 +37,6 @@ class TestCalculatePauschbetrag:
             calculated_pauschbetrag = calculate_pauschbetrag(**params, disability_degree=disability_degree)
             assert calculated_pauschbetrag == expected_result
 
-    def test_if_incorrect_disability_degree_then_raise_value_error(self):
-        incorrect_disability_degrees = [-10, 18, 101]
-
-        for incorrect_disability_degree in incorrect_disability_degrees:
-            with pytest.raises(ValueError):
-                calculate_pauschbetrag(disability_degree=incorrect_disability_degree)
-
     def test_if_merkzeichen_ag_and_no_pflegegrad_set_then_return_correct_value_for_disability_degree(self):
         input_output_pairs = [
             (20, 384),

--- a/webapp/tests/forms/steps/lotse/test_pauschbetrag.py
+++ b/webapp/tests/forms/steps/lotse/test_pauschbetrag.py
@@ -1,0 +1,214 @@
+from app.forms.steps.lotse.pauschbetrag import calculate_pauschbetrag
+
+
+class TestCalculatePauschbetrag:
+
+    def test_if_no_merkzeichen_or_pflegegrad_set_then_return_correct_value_for_beh_grad(self):
+        input_output_pairs = [
+            (20, 384),
+            (30, 620),
+            (40, 860),
+            (50, 1140),
+            (60, 1440),
+            (70, 1780),
+            (80, 2120),
+            (90, 2460),
+            (100, 2840),
+        ]
+
+        params = {
+            'pflegegrad': False,
+            'merkzeichen_bl': False,
+            'merkzeichen_tbl': False,
+            'merkzeichen_h': False,
+            'merkzeichen_ag': False,
+            'merkzeichen_g': False,
+        }
+
+        for beh_grad, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_merkzeichen_ag_and_no_pflegegrad_set_then_return_correct_value_for_beh_grad(self):
+        input_output_pairs = [
+            (20, 384),
+            (30, 620),
+            (40, 860),
+            (50, 1140),
+            (60, 1440),
+            (70, 1780),
+            (80, 2120),
+            (90, 2460),
+            (100, 2840),
+        ]
+
+        params = {
+            'pflegegrad': False,
+            'merkzeichen_bl': False,
+            'merkzeichen_tbl': False,
+            'merkzeichen_h': False,
+            'merkzeichen_ag': True,
+            'merkzeichen_g': False,
+        }
+
+        for beh_grad, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_merkzeichen_g_and_no_pflegegrad_set_then_return_correct_value_for_beh_grad(self):
+        input_output_pairs = [
+            (20, 384),
+            (30, 620),
+            (40, 860),
+            (50, 1140),
+            (60, 1440),
+            (70, 1780),
+            (80, 2120),
+            (90, 2460),
+            (100, 2840),
+        ]
+
+        params = {
+            'pflegegrad': False,
+            'merkzeichen_bl': False,
+            'merkzeichen_tbl': False,
+            'merkzeichen_h': False,
+            'merkzeichen_ag': False,
+            'merkzeichen_g': True,
+        }
+
+        for beh_grad, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_pflegegrad_set_and_no_merkzeichen_then_return_7400_for_all_beh_grad(self):
+        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+
+        params = {
+            'pflegegrad': True,
+            'merkzeichen_bl': False,
+            'merkzeichen_tbl': False,
+            'merkzeichen_h': False,
+            'merkzeichen_ag': False,
+            'merkzeichen_g': False,
+        }
+
+        for beh_grad in beh_grad_values:
+
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+
+            assert calculated_pauschbetrag == 7400
+
+    def test_if_pflegegrad_set_and_merkzeichen_bl_then_return_7400_for_all_beh_grad(self):
+        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+
+        params = {
+            'pflegegrad': True,
+            'merkzeichen_bl': True,
+            'merkzeichen_tbl': False,
+            'merkzeichen_h': False,
+            'merkzeichen_ag': False,
+            'merkzeichen_g': False,
+        }
+
+        for beh_grad in beh_grad_values:
+
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+
+            assert calculated_pauschbetrag == 7400
+
+    def test_if_pflegegrad_set_and_merkzeichen_tbl_then_return_7400_for_all_beh_grad(self):
+        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+
+        params = {
+            'pflegegrad': True,
+            'merkzeichen_bl': False,
+            'merkzeichen_tbl': True,
+            'merkzeichen_h': False,
+            'merkzeichen_ag': False,
+            'merkzeichen_g': False,
+        }
+
+        for beh_grad in beh_grad_values:
+
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+
+            assert calculated_pauschbetrag == 7400
+
+    def test_if_pflegegrad_set_and_merkzeichen_h_then_return_7400_for_all_beh_grad(self):
+        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+
+        params = {
+            'pflegegrad': True,
+            'merkzeichen_bl': False,
+            'merkzeichen_tbl': False,
+            'merkzeichen_h': True,
+            'merkzeichen_ag': False,
+            'merkzeichen_g': False,
+        }
+
+        for beh_grad in beh_grad_values:
+
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+
+            assert calculated_pauschbetrag == 7400
+
+    def test_if_merkzeichen_bl_and_no_pflegegrad_set_then_return_7400_for_all_beh_grad(self):
+        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+
+        params = {
+            'pflegegrad': False,
+            'merkzeichen_bl': True,
+            'merkzeichen_tbl': False,
+            'merkzeichen_h': False,
+            'merkzeichen_ag': False,
+            'merkzeichen_g': False,
+        }
+
+        for beh_grad in beh_grad_values:
+
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+
+            assert calculated_pauschbetrag == 7400
+
+    def test_if_merkzeichen_tbl_and_no_pflegegrad_set_then_return_7400_for_all_beh_grad(self):
+        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+
+        params = {
+            'pflegegrad': False,
+            'merkzeichen_bl': False,
+            'merkzeichen_tbl': True,
+            'merkzeichen_h': False,
+            'merkzeichen_ag': False,
+            'merkzeichen_g': False,
+        }
+
+        for beh_grad in beh_grad_values:
+
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+
+            assert calculated_pauschbetrag == 7400
+
+    def test_if_merkzeichen_h_and_no_pflegegrad_set_then_return_7400_for_all_beh_grad(self):
+        beh_grad_values = [20, 30, 40, 50, 60, 70, 80, 90, 100]
+
+        params = {
+            'pflegegrad': False,
+            'merkzeichen_bl': False,
+            'merkzeichen_tbl': False,
+            'merkzeichen_h': True,
+            'merkzeichen_ag': False,
+            'merkzeichen_g': False,
+        }
+
+        for beh_grad in beh_grad_values:
+
+            calculated_pauschbetrag = calculate_pauschbetrag(**params, beh_grad=beh_grad)
+
+            assert calculated_pauschbetrag == 7400


### PR DESCRIPTION
# Short Description
We want to be able to calculate the Pauschbetrag (see [this ticket](https://steuerlotse.atlassian.net/browse/STL-1678)). I have added a function to calculate the Pauschbetrag following [this table](https://docs.google.com/spreadsheets/d/1UeZCD3Aa8SOZfEs6cZLYq1kLxGL3EKfBiavFCLgfrBc/edit?usp=sharing).
I decided to place it into pauschalbetrag.py because I think this method will probably only be used by the corresponding step.

# Changes
- Add calculation function and tests

# Feedback
- Does the placement make sense to you?
- Do you think we should omit the not needed merkzeichen in the function declaration? I have added them to clarify what we need but they do not make any difference for the result
- Are any tests missing? I tried to test all the edge cases for the different combinations.

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
