### PR TITLE
Add calculation for fahrkostenpauschbetrag

### DIFF
--- a/webapp/app/forms/steps/lotse/fahrkostenpauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/fahrkostenpauschbetrag.py
@@ -1,0 +1,12 @@
+def calculate_fahrkostenpauschbetrag(has_pflegegrad=False, disability_degree=None, has_merkzeichen_bl=False, has_merkzeichen_tbl=False,
+                                     has_merkzeichen_h=False, has_merkzeichen_ag=False, has_merkzeichen_g=False):
+    if has_pflegegrad or has_merkzeichen_bl or has_merkzeichen_tbl or has_merkzeichen_tbl or has_merkzeichen_h or has_merkzeichen_ag:
+        return 4500
+
+    elif disability_degree >= 80:
+        return 900
+    elif has_merkzeichen_g and disability_degree >= 70:
+        return 900
+
+    else:
+        return None

--- a/webapp/tests/forms/steps/lotse/test_fahrkostenpauschbetrag.py
+++ b/webapp/tests/forms/steps/lotse/test_fahrkostenpauschbetrag.py
@@ -1,0 +1,348 @@
+from app.forms.steps.lotse.fahrkostenpauschbetrag import calculate_fahrkostenpauschbetrag
+
+
+class TestCalculatePauschbetrag:
+
+    def test_if_no_merkzeichen_or_pflegegrad_set_then_return_correct_value_for_disability_degree(self):
+        input_output_pairs = [
+            (20, None),
+            (25, None),
+            (30, None),
+            (35, None),
+            (40, None),
+            (45, None),
+            (50, None),
+            (55, None),
+            (60, None),
+            (65, None),
+            (70, None),
+            (75, None),
+            (80, 900),
+            (85, 900),
+            (90, 900),
+            (95, 900),
+            (100, 900),
+        ]
+
+        params = {
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
+            'has_merkzeichen_ag': False,
+            'has_merkzeichen_g': False,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_merkzeichen_g_and_no_pflegegrad_set_then_return_correct_value_for_disability_degree(self):
+        input_output_pairs = [
+            (20, None),
+            (30, None),
+            (40, None),
+            (50, None),
+            (60, None),
+            (70, 900),
+            (80, 900),
+            (90, 900),
+            (100, 900),
+        ]
+
+        params = {
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
+            'has_merkzeichen_ag': False,
+            'has_merkzeichen_g': True,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_merkzeichen_bl_and_no_pflegegrad_set_then_return_4500_for_all_disability_degrees(self):
+        input_output_pairs = [
+            (20, 4500),
+            (30, 4500),
+            (40, 4500),
+            (50, 4500),
+            (60, 4500),
+            (70, 4500),
+            (80, 4500),
+            (90, 4500),
+            (100, 4500),
+        ]
+
+        params = {
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': True,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
+            'has_merkzeichen_ag': False,
+            'has_merkzeichen_g': False,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_merkzeichen_tbl_and_no_pflegegrad_set_then_return_4500_for_all_disability_degrees(self):
+        input_output_pairs = [
+            (20, 4500),
+            (30, 4500),
+            (40, 4500),
+            (50, 4500),
+            (60, 4500),
+            (70, 4500),
+            (80, 4500),
+            (90, 4500),
+            (100, 4500),
+        ]
+
+        params = {
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': True,
+            'has_merkzeichen_h': False,
+            'has_merkzeichen_ag': False,
+            'has_merkzeichen_g': False,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_merkzeichen_h_and_no_pflegegrad_set_then_return_4500_for_all_disability_degrees(self):
+        input_output_pairs = [
+            (20, 4500),
+            (30, 4500),
+            (40, 4500),
+            (50, 4500),
+            (60, 4500),
+            (70, 4500),
+            (80, 4500),
+            (90, 4500),
+            (100, 4500),
+        ]
+
+        params = {
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': True,
+            'has_merkzeichen_ag': False,
+            'has_merkzeichen_g': False,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_merkzeichen_ag_and_no_pflegegrad_set_then_return_4500_for_all_disability_degrees(self):
+        input_output_pairs = [
+            (20, 4500),
+            (30, 4500),
+            (40, 4500),
+            (50, 4500),
+            (60, 4500),
+            (70, 4500),
+            (80, 4500),
+            (90, 4500),
+            (100, 4500),
+        ]
+
+        params = {
+            'has_pflegegrad': False,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
+            'has_merkzeichen_ag': True,
+            'has_merkzeichen_g': False,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_pflegrad_set_and_no_merkzeichen_set_then_return_4500_for_all_disability_degrees(self):
+        input_output_pairs = [
+            (20, 4500),
+            (30, 4500),
+            (40, 4500),
+            (50, 4500),
+            (60, 4500),
+            (70, 4500),
+            (80, 4500),
+            (90, 4500),
+            (100, 4500),
+        ]
+
+        params = {
+            'has_pflegegrad': True,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
+            'has_merkzeichen_ag': False,
+            'has_merkzeichen_g': False,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_pflegrad_set_and_merkzeichen_bl_set_then_return_4500_for_all_disability_degrees(self):
+        input_output_pairs = [
+            (20, 4500),
+            (30, 4500),
+            (40, 4500),
+            (50, 4500),
+            (60, 4500),
+            (70, 4500),
+            (80, 4500),
+            (90, 4500),
+            (100, 4500),
+        ]
+
+        params = {
+            'has_pflegegrad': True,
+            'has_merkzeichen_bl': True,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
+            'has_merkzeichen_ag': False,
+            'has_merkzeichen_g': False,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_pflegrad_set_and_merkzeichen_tbl_set_then_return_4500_for_all_disability_degrees(self):
+        input_output_pairs = [
+            (20, 4500),
+            (30, 4500),
+            (40, 4500),
+            (50, 4500),
+            (60, 4500),
+            (70, 4500),
+            (80, 4500),
+            (90, 4500),
+            (100, 4500),
+        ]
+
+        params = {
+            'has_pflegegrad': True,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': True,
+            'has_merkzeichen_h': False,
+            'has_merkzeichen_ag': False,
+            'has_merkzeichen_g': False,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_pflegrad_set_and_merkzeichen_h_set_then_return_4500_for_all_disability_degrees(self):
+        input_output_pairs = [
+            (20, 4500),
+            (30, 4500),
+            (40, 4500),
+            (50, 4500),
+            (60, 4500),
+            (70, 4500),
+            (80, 4500),
+            (90, 4500),
+            (100, 4500),
+        ]
+
+        params = {
+            'has_pflegegrad': True,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': True,
+            'has_merkzeichen_ag': False,
+            'has_merkzeichen_g': False,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_pflegrad_set_and_merkzeichen_ag_set_then_return_4500_for_all_disability_degrees(self):
+        input_output_pairs = [
+            (20, 4500),
+            (30, 4500),
+            (40, 4500),
+            (50, 4500),
+            (60, 4500),
+            (70, 4500),
+            (80, 4500),
+            (90, 4500),
+            (100, 4500),
+        ]
+
+        params = {
+            'has_pflegegrad': True,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
+            'has_merkzeichen_ag': True,
+            'has_merkzeichen_g': False,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result
+
+    def test_if_pflegrad_set_and_merkzeichen_g_set_then_return_4500_for_all_disability_degrees(self):
+        input_output_pairs = [
+            (20, 4500),
+            (30, 4500),
+            (40, 4500),
+            (50, 4500),
+            (60, 4500),
+            (70, 4500),
+            (80, 4500),
+            (90, 4500),
+            (100, 4500),
+        ]
+
+        params = {
+            'has_pflegegrad': True,
+            'has_merkzeichen_bl': False,
+            'has_merkzeichen_tbl': False,
+            'has_merkzeichen_h': False,
+            'has_merkzeichen_ag': False,
+            'has_merkzeichen_g': True,
+        }
+
+        for disability_degree, expected_result in input_output_pairs:
+
+            calculated_pauschbetrag = calculate_fahrkostenpauschbetrag(**params, disability_degree=disability_degree)
+
+            assert calculated_pauschbetrag == expected_result


### PR DESCRIPTION
# Short Description
Similar to #489 this adds a function to calculate the so-called Fahrkostenpauschale. I have added the function to the new file fahrkostenpauschale.py which we could then use to put also the new step in. You can find the table with the values [here](https://docs.google.com/spreadsheets/d/1UeZCD3Aa8SOZfEs6cZLYq1kLxGL3EKfBiavFCLgfrBc/edit#gid=375554284).

# Changes
- Add the function + tests

# Feedback
- Do you see any missing tests?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
