### PR TITLE
Add react integer field

### DIFF
--- a/webapp/client/package.json
+++ b/webapp/client/package.json
@@ -28,6 +28,7 @@
     "react-bootstrap": "^1.6.4",
     "react-dom": "^17.0.2",
     "react-i18next": "^11.15.1",
+    "react-imask": "^6.2.2",
     "react-scripts": "^4.0.3",
     "styled-components": "^5.3.3"
   },

--- a/webapp/client/src/components/FormFieldIntegerInput.js
+++ b/webapp/client/src/components/FormFieldIntegerInput.js
@@ -13,7 +13,7 @@ function FormFieldIntegerInput({
   required,
   autofocus,
   label,
-  maxWidth,
+  fieldWidth,
   maxLength,
   details,
   errors,
@@ -40,7 +40,7 @@ function FormFieldIntegerInput({
           // eslint-disable-next-line
           autoFocus={autofocus || Boolean(errors.length)}
           required={required}
-          className={classNames("form-control", `input-width-${maxWidth}`)}
+          className={classNames("form-control", `input-width-${fieldWidth}`)}
         />
       )}
     />
@@ -56,7 +56,7 @@ FormFieldIntegerInput.propTypes = {
   setMask: PropTypes.bool,
   value: PropTypes.string.isRequired,
   label: FieldLabel.propTypes.label,
-  maxWidth: PropTypes.number,
+  fieldWidth: PropTypes.number,
   maxLength: PropTypes.number,
   details: FieldLabel.propTypes.details,
 };
@@ -66,7 +66,7 @@ FormFieldIntegerInput.defaultProps = {
   required: FormFieldSeparatedField.defaultProps.required,
   setMask: false,
   label: FieldLabel.defaultProps.label,
-  maxWidth: 25,
+  fieldWidth: 25,
   maxLength: undefined,
   details: FieldLabel.defaultProps.details,
 };

--- a/webapp/client/src/components/FormFieldIntegerInput.js
+++ b/webapp/client/src/components/FormFieldIntegerInput.js
@@ -1,0 +1,70 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+import FormFieldScaffolding from "./FormFieldScaffolding";
+import FieldLabel from "./FieldLabel";
+import FormFieldSeparatedField from "./FormFieldSeparatedField";
+
+function FormFieldTextInput({
+  fieldName,
+  fieldId,
+  value,
+  required,
+  autofocus,
+  label,
+  maxWidth,
+  maxLength,
+  details,
+  errors,
+}) {
+  return (
+    <FormFieldScaffolding
+      {...{
+        fieldName,
+        errors,
+      }}
+      labelComponent={<FieldLabel {...{ label, fieldId, details }} />}
+      render={() => (
+        <input
+          type="number"
+          id={fieldId}
+          name={fieldName}
+          defaultValue={value}
+          inputMode="numeric"
+          maxLength={maxLength}
+          // TODO: autofocus is under review.
+          // eslint-disable-next-line
+          autoFocus={autofocus || Boolean(errors.length)}
+          required={required}
+          className={classNames("form-control", `input-width-${maxWidth}`)}
+        />
+      )}
+    />
+  );
+}
+
+FormFieldTextInput.propTypes = {
+  fieldId: PropTypes.string.isRequired,
+  fieldName: PropTypes.string.isRequired,
+  errors: PropTypes.arrayOf(PropTypes.string).isRequired,
+  autofocus: PropTypes.bool,
+  required: PropTypes.bool,
+  setMask: PropTypes.bool,
+  value: PropTypes.string.isRequired,
+  label: FieldLabel.propTypes.label,
+  maxWidth: PropTypes.number,
+  maxLength: PropTypes.number,
+  details: FieldLabel.propTypes.details,
+};
+
+FormFieldTextInput.defaultProps = {
+  autofocus: FormFieldSeparatedField.defaultProps.autofocus,
+  required: FormFieldSeparatedField.defaultProps.required,
+  setMask: false,
+  label: FieldLabel.defaultProps.label,
+  maxWidth: 25,
+  maxLength: undefined,
+  details: FieldLabel.defaultProps.details,
+};
+
+export default FormFieldTextInput;

--- a/webapp/client/src/components/FormFieldIntegerInput.js
+++ b/webapp/client/src/components/FormFieldIntegerInput.js
@@ -26,11 +26,12 @@ function FormFieldTextInput({
       labelComponent={<FieldLabel {...{ label, fieldId, details }} />}
       render={() => (
         <input
-          type="number"
+          type="text"
           id={fieldId}
           name={fieldName}
           defaultValue={value}
           inputMode="numeric"
+          pattern="[0-9]*"
           maxLength={maxLength}
           // TODO: autofocus is under review.
           // eslint-disable-next-line

--- a/webapp/client/src/components/FormFieldIntegerInput.js
+++ b/webapp/client/src/components/FormFieldIntegerInput.js
@@ -6,7 +6,7 @@ import FormFieldScaffolding from "./FormFieldScaffolding";
 import FieldLabel from "./FieldLabel";
 import FormFieldSeparatedField from "./FormFieldSeparatedField";
 
-function FormFieldTextInput({
+function FormFieldIntegerInput({
   fieldName,
   fieldId,
   value,
@@ -47,7 +47,7 @@ function FormFieldTextInput({
   );
 }
 
-FormFieldTextInput.propTypes = {
+FormFieldIntegerInput.propTypes = {
   fieldId: PropTypes.string.isRequired,
   fieldName: PropTypes.string.isRequired,
   errors: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -61,7 +61,7 @@ FormFieldTextInput.propTypes = {
   details: FieldLabel.propTypes.details,
 };
 
-FormFieldTextInput.defaultProps = {
+FormFieldIntegerInput.defaultProps = {
   autofocus: FormFieldSeparatedField.defaultProps.autofocus,
   required: FormFieldSeparatedField.defaultProps.required,
   setMask: false,
@@ -71,4 +71,4 @@ FormFieldTextInput.defaultProps = {
   details: FieldLabel.defaultProps.details,
 };
 
-export default FormFieldTextInput;
+export default FormFieldIntegerInput;

--- a/webapp/client/src/components/FormFieldIntegerInput.js
+++ b/webapp/client/src/components/FormFieldIntegerInput.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { IMaskInput } from "react-imask";
 import classNames from "classnames";
 import FormFieldScaffolding from "./FormFieldScaffolding";
 import FieldLabel from "./FieldLabel";
@@ -25,7 +26,9 @@ function FormFieldTextInput({
       }}
       labelComponent={<FieldLabel {...{ label, fieldId, details }} />}
       render={() => (
-        <input
+        <IMaskInput
+          mask={Number}
+          scale={0}
           type="text"
           id={fieldId}
           name={fieldName}

--- a/webapp/client/src/components/FormFieldIntegerInput.test.js
+++ b/webapp/client/src/components/FormFieldIntegerInput.test.js
@@ -1,0 +1,106 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FormFieldIntegerInput from "./FormFieldIntegerInput";
+
+describe("FormFieldIntegerInput", () => {
+  let props;
+
+  describe("When default props used", () => {
+    beforeEach(() => {
+      props = {
+        fieldId: "integer-input",
+        fieldName: "integer-input",
+        label: {
+          text: "Label",
+        },
+        errors: [],
+        value: "",
+      };
+      render(<FormFieldIntegerInput {...props} />);
+    });
+
+    it("Should not allow input of text", () => {
+      userEvent.type(screen.getByRole("textbox"), "Hello World");
+      expect(screen.getByLabelText("Label")).toHaveValue("");
+    });
+
+    it("Should not allow input of comma", () => {
+      userEvent.type(screen.getByRole("textbox"), "123,45");
+      expect(screen.getByLabelText("Label")).toHaveValue("12345");
+    });
+
+    it("Should set focus on field on tab", () => {
+      userEvent.tab();
+      expect(screen.getByRole("textbox")).toHaveFocus();
+    });
+
+    it("Should enter keyboard input into input after pressing tab", () => {
+      userEvent.tab();
+      userEvent.keyboard("12345");
+      expect(screen.getByLabelText("Label")).toHaveValue("12345");
+    });
+
+    it("Should unset focus on field when pressing tab two times", () => {
+      userEvent.tab();
+      userEvent.tab();
+      expect(screen.getByRole("textbox")).not.toHaveFocus();
+    });
+  });
+
+  describe("When maxWidth given", () => {
+    beforeEach(() => {
+      props = {
+        fieldId: "integer-input",
+        fieldName: "integer-input",
+        label: {
+          text: "Label",
+        },
+        errors: [],
+        value: "",
+        maxWidth: 5,
+      };
+      render(<FormFieldIntegerInput {...props} />);
+    });
+
+    it("Should not limit input of values", () => {
+      userEvent.type(screen.getByLabelText("Label"), "12345678910");
+      expect(screen.getByLabelText("Label")).toHaveValue("12345678910");
+    });
+
+    it("should set width class", () => {
+      expect(screen.getByLabelText("Label")).toHaveClass("input-width-5");
+    });
+  });
+
+  describe("When maxLength given", () => {
+    beforeEach(() => {
+      props = {
+        fieldId: "integer-input",
+        fieldName: "integer-input",
+        label: {
+          text: "Label",
+        },
+        errors: [],
+        value: "",
+        maxLength: 5,
+      };
+      render(<FormFieldIntegerInput {...props} />);
+    });
+
+    it("Should limit input of values", () => {
+      userEvent.type(screen.getByLabelText("Label"), "12345678910");
+      expect(screen.getByLabelText("Label")).toHaveValue("12345");
+    });
+
+    it("should not set width class", () => {
+      expect(screen.getByLabelText("Label")).not.toHaveClass("input-width-5");
+    });
+
+    it("Should enter keyboard input into input after pressing tab", () => {
+      userEvent.tab();
+      userEvent.keyboard("123456");
+      expect(screen.getByLabelText("Label")).toHaveValue("12345");
+    });
+  });
+});

--- a/webapp/client/src/components/FormFieldIntegerInput.test.js
+++ b/webapp/client/src/components/FormFieldIntegerInput.test.js
@@ -97,7 +97,7 @@ describe("FormFieldIntegerInput", () => {
       expect(screen.getByLabelText("Label")).not.toHaveClass("input-width-5");
     });
 
-    it("Should enter keyboard input into input after pressing tab", () => {
+    it("Should limit input of values when using keyboard", () => {
       userEvent.tab();
       userEvent.keyboard("123456");
       expect(screen.getByLabelText("Label")).toHaveValue("12345");

--- a/webapp/client/src/components/FormFieldIntegerInput.test.js
+++ b/webapp/client/src/components/FormFieldIntegerInput.test.js
@@ -48,7 +48,7 @@ describe("FormFieldIntegerInput", () => {
     });
   });
 
-  describe("When maxWidth given", () => {
+  describe("When fieldWidth given", () => {
     beforeEach(() => {
       props = {
         fieldId: "integer-input",
@@ -58,7 +58,7 @@ describe("FormFieldIntegerInput", () => {
         },
         errors: [],
         value: "",
-        maxWidth: 5,
+        fieldWidth: 5,
       };
       render(<FormFieldIntegerInput {...props} />);
     });

--- a/webapp/client/src/components/FormFieldTextInput.js
+++ b/webapp/client/src/components/FormFieldTextInput.js
@@ -12,7 +12,7 @@ function FormFieldTextInput({
   required,
   autofocus,
   label,
-  maxWidth,
+  fieldWidth,
   maxLength,
   details,
   errors,
@@ -35,7 +35,7 @@ function FormFieldTextInput({
           // eslint-disable-next-line
           autoFocus={autofocus || Boolean(errors.length)}
           required={required}
-          className={classNames("form-control", `input-width-${maxWidth}`)}
+          className={classNames("form-control", `input-width-${fieldWidth}`)}
         />
       )}
     />
@@ -50,7 +50,7 @@ FormFieldTextInput.propTypes = {
   required: PropTypes.bool,
   value: PropTypes.string.isRequired,
   label: FieldLabel.propTypes.label,
-  maxWidth: PropTypes.number,
+  fieldWidth: PropTypes.number,
   maxLength: PropTypes.number,
   details: FieldLabel.propTypes.details,
 };
@@ -59,7 +59,7 @@ FormFieldTextInput.defaultProps = {
   autofocus: FormFieldSeparatedField.defaultProps.autofocus,
   required: FormFieldSeparatedField.defaultProps.required,
   label: FieldLabel.defaultProps.label,
-  maxWidth: 25,
+  fieldWidth: 25,
   maxLength: undefined,
   details: FieldLabel.defaultProps.details,
 };

--- a/webapp/client/src/components/FormFieldTextInput.test.js
+++ b/webapp/client/src/components/FormFieldTextInput.test.js
@@ -38,7 +38,7 @@ describe("FormFieldTextInput", () => {
     });
   });
 
-  describe("When maxWidth given", () => {
+  describe("When fieldWidth given", () => {
     beforeEach(() => {
       props = {
         fieldId: "text-input",
@@ -48,7 +48,7 @@ describe("FormFieldTextInput", () => {
         },
         errors: [],
         value: "",
-        maxWidth: 5,
+        fieldWidth: 5,
       };
       render(<FormFieldTextInput {...props} />);
     });

--- a/webapp/client/src/lib/fieldUtils.js
+++ b/webapp/client/src/lib/fieldUtils.js
@@ -1,4 +1,5 @@
 export const baselineBugFix = { placeholder: " " };
+// Don't use these for input masking in new code. Use react-imask instead.
 export const alphanumericInput = { "data-alphanumeric-field": true }; // TODO: replace jquery-mask with non-jquery equivalent
 export const numericInputMask = { "data-mask": "0#" }; // TODO: replace jquery-mask with non-jquery equivalent
 export const numericInputMode = { inputMode: "numeric" };

--- a/webapp/client/src/stories/FormFieldIntegerInput.stories.js
+++ b/webapp/client/src/stories/FormFieldIntegerInput.stories.js
@@ -30,16 +30,6 @@ function TemplateLong(args) {
 }
 
 export const Default = Template.bind({});
-export const WithValue = Template.bind({});
-export const WithErrors = Template.bind({});
-export const WithDetails = Template.bind({});
-export const WithAllLabelExtras = Template.bind({});
-export const WithMaxWidth = Template.bind({});
-export const WithMaxLength = Template.bind({});
-export const WithMaxLengthAndWidth = Template.bind({});
-
-export const OnALongPage = TemplateLong.bind({});
-
 Default.args = {
   fieldId: "number-input",
   fieldName: "number-input",
@@ -50,16 +40,19 @@ Default.args = {
   value: "",
 };
 
+export const WithValue = Template.bind({});
 WithValue.args = {
   ...Default.args,
   value: "20",
 };
 
+export const WithErrors = Template.bind({});
 WithErrors.args = {
   ...Default.args,
   errors: ["Dieses Feld wird benötigt"],
 };
 
+export const WithDetails = Template.bind({});
 WithDetails.args = {
   ...Default.args,
   details: {
@@ -68,6 +61,7 @@ WithDetails.args = {
   },
 };
 
+export const WithAllLabelExtras = Template.bind({});
 WithAllLabelExtras.args = {
   ...WithDetails.args,
   label: {
@@ -78,22 +72,26 @@ WithAllLabelExtras.args = {
   },
 };
 
+export const WithMaxWidth = Template.bind({});
 WithMaxWidth.args = {
   ...Default.args,
   maxWidth: 4,
 };
 
+export const WithMaxLength = Template.bind({});
 WithMaxLength.args = {
   ...Default.args,
   maxLength: 4,
 };
 
+export const WithMaxLengthAndWidth = Template.bind({});
 WithMaxLengthAndWidth.args = {
   ...Default.args,
   maxLength: 4,
   maxWidth: 4,
 };
 
+export const OnALongPage = TemplateLong.bind({});
 OnALongPage.args = {
   ...Default.args,
 };

--- a/webapp/client/src/stories/FormFieldIntegerInput.stories.js
+++ b/webapp/client/src/stories/FormFieldIntegerInput.stories.js
@@ -1,0 +1,99 @@
+import React from "react";
+
+import FormFieldIntegerInput from "../components/FormFieldIntegerInput";
+import StepForm from "../components/StepForm";
+import { Default as StepFormDefault } from "./StepForm.stories";
+
+export default {
+  title: "Form Fields/IntegerInput",
+  component: FormFieldIntegerInput,
+};
+
+function Template(args) {
+  return (
+    <StepForm {...StepFormDefault.args}>
+      <FormFieldIntegerInput {...args} />
+    </StepForm>
+  );
+}
+
+function TemplateLong(args) {
+  const style = {
+    height: 1000,
+  };
+  return (
+    <StepForm {...StepFormDefault.args}>
+      <FormFieldIntegerInput {...args} />
+      <div style={style} />
+    </StepForm>
+  );
+}
+
+export const Default = Template.bind({});
+export const WithValue = Template.bind({});
+export const WithErrors = Template.bind({});
+export const WithDetails = Template.bind({});
+export const WithAllLabelExtras = Template.bind({});
+export const WithMaxWidth = Template.bind({});
+export const WithMaxLength = Template.bind({});
+export const WithMaxLengthAndWidth = Template.bind({});
+
+export const OnALongPage = TemplateLong.bind({});
+
+Default.args = {
+  fieldId: "number-input",
+  fieldName: "number-input",
+  label: {
+    text: "Grad der Behinderung",
+  },
+  errors: [],
+  value: "",
+};
+
+WithValue.args = {
+  ...Default.args,
+  value: "20",
+};
+
+WithErrors.args = {
+  ...Default.args,
+  errors: ["Dieses Feld wird benötigt"],
+};
+
+WithDetails.args = {
+  ...Default.args,
+  details: {
+    title: "Was bedeutet das?",
+    text: "Erklärungs-Platzhalter",
+  },
+};
+
+WithAllLabelExtras.args = {
+  ...WithDetails.args,
+  label: {
+    text: "Grad der Behinderung",
+    showOptionalTag: true,
+    help: "Das ist ein Hilfetext. Hilft er dir?",
+    exampleInput: "ab 20",
+  },
+};
+
+WithMaxWidth.args = {
+  ...Default.args,
+  maxWidth: 4,
+};
+
+WithMaxLength.args = {
+  ...Default.args,
+  maxLength: 4,
+};
+
+WithMaxLengthAndWidth.args = {
+  ...Default.args,
+  maxLength: 4,
+  maxWidth: 4,
+};
+
+OnALongPage.args = {
+  ...Default.args,
+};

--- a/webapp/client/src/stories/FormFieldIntegerInput.stories.js
+++ b/webapp/client/src/stories/FormFieldIntegerInput.stories.js
@@ -72,10 +72,10 @@ WithAllLabelExtras.args = {
   },
 };
 
-export const WithMaxWidth = Template.bind({});
-WithMaxWidth.args = {
+export const WithFieldWidth = Template.bind({});
+WithFieldWidth.args = {
   ...Default.args,
-  maxWidth: 4,
+  fieldWidth: 4,
 };
 
 export const WithMaxLength = Template.bind({});
@@ -88,7 +88,7 @@ export const WithMaxLengthAndWidth = Template.bind({});
 WithMaxLengthAndWidth.args = {
   ...Default.args,
   maxLength: 4,
-  maxWidth: 4,
+  fieldWidth: 4,
 };
 
 export const OnALongPage = TemplateLong.bind({});

--- a/webapp/client/src/stories/FormFieldTextInput.stories.js
+++ b/webapp/client/src/stories/FormFieldTextInput.stories.js
@@ -22,7 +22,7 @@ export const WithValue = Template.bind({});
 export const WithErrors = Template.bind({});
 export const WithDetails = Template.bind({});
 export const WithAllLabelExtras = Template.bind({});
-export const WithMaxWidth = Template.bind({});
+export const WithFieldWidth = Template.bind({});
 export const WithMaxLength = Template.bind({});
 export const WithMaxLengthAndWidth = Template.bind({});
 
@@ -64,9 +64,9 @@ WithAllLabelExtras.args = {
   },
 };
 
-WithMaxWidth.args = {
+WithFieldWidth.args = {
   ...Default.args,
-  maxWidth: 4,
+  fieldWidth: 4,
 };
 
 WithMaxLength.args = {
@@ -77,5 +77,5 @@ WithMaxLength.args = {
 WithMaxLengthAndWidth.args = {
   ...Default.args,
   maxLength: 4,
-  maxWidth: 4,
+  fieldWidth: 4,
 };

--- a/webapp/client/yarn.lock
+++ b/webapp/client/yarn.lock
@@ -8437,6 +8437,11 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+imask@^6.2.0:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/imask/-/imask-6.2.2.tgz#c72c0ce9a52f57539ecdc264eccc2407d20e13b5"
+  integrity sha512-oREITqngsjD0YxO62UpVQSxLNjIcb/mNO9hX2F8xQ282Kj3X9KXEAobipbUXz5R5NgtiL6nOPrWwo+AnLuz5AQ==
+
 immer@8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
@@ -12588,6 +12593,14 @@ react-i18next@^11.15.1:
     "@babel/runtime" "^7.14.5"
     html-escaper "^2.0.2"
     html-parse-stringify "^3.0.1"
+
+react-imask@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/react-imask/-/react-imask-6.2.2.tgz#1a6574828370158bfa7bf6bdf0db255206ef10c0"
+  integrity sha512-CKZhc3OrcMc+VjihSm4CLJlOXX1HIaVfTzLc498eN6RKveRUUqRAjqZWqLFoqg3D85p08WEl3NDLU7w5HdPcUw==
+  dependencies:
+    imask "^6.2.0"
+    prop-types "^15.7.2"
 
 react-inspector@^5.1.0:
   version "5.1.1"


### PR DESCRIPTION
# Short Description
- This adds a react field that only allows integers as input

# Changes
- Add mask plugin [imask](https://github.com/uNmAnNeR/imaskjs)
- Make `text` input type out of previous `number` - add inputmode + pattern to still support correct usage (as suggested by [gov.uk](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/)

- Did not change the previous usages of `numericInputMask` as this would have been a lot of work to me with the separated fields.

# Feedback
- What do you think of the WithLongPage story? As far as I know this is the first time we did something like this.
- What do you think of the plugin?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
