### PR TITLE
Fix errors for radio group

### DIFF
--- a/webapp/client/src/components/FormFieldRadioGroup.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.js
@@ -64,7 +64,7 @@ function FormFieldRadioGroupGroup({
   onChangeHandler,
 }) {
   const [selectedValue, setSelectedValue] = useState(value);
-  const groupShouldHaveAutofocus = autofocus || errors;
+  const groupShouldHaveAutofocus = autofocus || (errors && errors.length !== 0);
 
   const toggleRadioButton = (event) => {
     setSelectedValue(event.target.value);

--- a/webapp/client/src/components/FormFieldRadioGroup.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.js
@@ -53,7 +53,7 @@ const Radio = styled.div`
 function FormFieldRadioGroupGroup({
   fieldName,
   fieldId,
-  options,
+  radioButtons,
   value,
   required,
   autofocus,
@@ -80,7 +80,7 @@ function FormFieldRadioGroupGroup({
           <fieldset id={fieldId} name={fieldId}>
             <FieldLabelForSeparatedFields {...{ label, fieldId, details }} />
             <div className="radio-button-list">
-              {options.map((option, i) => [
+              {radioButtons.map((option, i) => [
                 <input
                   type="radio"
                   id={fieldId + option.value}
@@ -111,7 +111,7 @@ function FormFieldRadioGroupGroup({
 FormFieldRadioGroupGroup.propTypes = {
   fieldName: PropTypes.string.isRequired,
   fieldId: PropTypes.string.isRequired,
-  options: optionsPropType.isRequired,
+  radioButtons: optionsPropType.isRequired,
   value: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   details: FieldLabelForSeparatedFields.propTypes.details,

--- a/webapp/client/src/components/FormFieldRadioGroup.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import FormFieldScaffolding from "./FormFieldScaffolding";
 import FieldLabelForSeparatedFields from "./FieldLabelForSeparatedFields";
 import { optionsPropType } from "../lib/propTypes";
+import FieldError from "./FieldError";
 
 const Radio = styled.div`
   input[type="radio"] {
@@ -75,6 +76,7 @@ function FormFieldRadioGroupGroup({
         errors,
       }}
       hideLabel
+      hideErrors
       render={() => (
         <Radio>
           <fieldset id={fieldId} name={fieldId}>
@@ -101,6 +103,13 @@ function FormFieldRadioGroupGroup({
                 </label>,
               ])}
             </div>
+            {errors.map((error, index) => (
+              // There is no natural key and the list is completely static, so using the index is fine.
+              // eslint-disable-next-line
+              <FieldError key={index} fieldName={fieldName}>
+                {error}
+              </FieldError>
+            ))}
           </fieldset>
         </Radio>
       )}

--- a/webapp/client/src/components/FormFieldRadioGroup.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.js
@@ -54,7 +54,7 @@ const Radio = styled.div`
 function FormFieldRadioGroup({
   fieldName,
   fieldId,
-  radioButtons,
+  options,
   value,
   required,
   autofocus,
@@ -83,7 +83,7 @@ function FormFieldRadioGroup({
           <fieldset id={fieldId} name={fieldId}>
             <FieldLabelForSeparatedFields {...{ label, fieldId, details }} />
             <div className="radio-button-list">
-              {radioButtons.map((option, i) => [
+              {options.map((option, i) => [
                 <input
                   type="radio"
                   id={fieldId + option.value}
@@ -121,7 +121,7 @@ function FormFieldRadioGroup({
 FormFieldRadioGroup.propTypes = {
   fieldName: PropTypes.string.isRequired,
   fieldId: PropTypes.string.isRequired,
-  radioButtons: optionsPropType.isRequired,
+  options: optionsPropType.isRequired,
   value: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   details: FieldLabelForSeparatedFields.propTypes.details,

--- a/webapp/client/src/components/FormFieldRadioGroup.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.js
@@ -51,7 +51,7 @@ const Radio = styled.div`
   }
 `;
 
-function FormFieldRadioGroupGroup({
+function FormFieldRadioGroup({
   fieldName,
   fieldId,
   radioButtons,
@@ -118,7 +118,7 @@ function FormFieldRadioGroupGroup({
   );
 }
 
-FormFieldRadioGroupGroup.propTypes = {
+FormFieldRadioGroup.propTypes = {
   fieldName: PropTypes.string.isRequired,
   fieldId: PropTypes.string.isRequired,
   radioButtons: optionsPropType.isRequired,
@@ -131,7 +131,7 @@ FormFieldRadioGroupGroup.propTypes = {
   onChangeHandler: PropTypes.func,
 };
 
-FormFieldRadioGroupGroup.defaultProps = {
+FormFieldRadioGroup.defaultProps = {
   value: undefined,
   required: false,
   autofocus: false,
@@ -139,4 +139,4 @@ FormFieldRadioGroupGroup.defaultProps = {
   onChangeHandler: undefined,
 };
 
-export default FormFieldRadioGroupGroup;
+export default FormFieldRadioGroup;

--- a/webapp/client/src/components/FormFieldRadioGroup.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.js
@@ -50,7 +50,7 @@ const Radio = styled.div`
   }
 `;
 
-function FormFieldRadio({
+function FormFieldRadioGroupGroup({
   fieldName,
   fieldId,
   options,
@@ -108,7 +108,7 @@ function FormFieldRadio({
   );
 }
 
-FormFieldRadio.propTypes = {
+FormFieldRadioGroupGroup.propTypes = {
   fieldName: PropTypes.string.isRequired,
   fieldId: PropTypes.string.isRequired,
   options: optionsPropType.isRequired,
@@ -121,7 +121,7 @@ FormFieldRadio.propTypes = {
   onChangeHandler: PropTypes.func,
 };
 
-FormFieldRadio.defaultProps = {
+FormFieldRadioGroupGroup.defaultProps = {
   value: undefined,
   required: false,
   autofocus: false,
@@ -129,4 +129,4 @@ FormFieldRadio.defaultProps = {
   onChangeHandler: undefined,
 };
 
-export default FormFieldRadio;
+export default FormFieldRadioGroupGroup;

--- a/webapp/client/src/components/FormFieldRadioGroup.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.js
@@ -64,6 +64,7 @@ function FormFieldRadioGroupGroup({
   onChangeHandler,
 }) {
   const [selectedValue, setSelectedValue] = useState(value);
+  const groupShouldHaveAutofocus = autofocus || errors;
 
   const toggleRadioButton = (event) => {
     setSelectedValue(event.target.value);
@@ -89,7 +90,7 @@ function FormFieldRadioGroupGroup({
                   key={`${fieldId}-${option.value}`}
                   name={fieldId}
                   required={required}
-                  autoFocus={autofocus && i === 0}
+                  autoFocus={groupShouldHaveAutofocus && i === 0}
                   value={option.value}
                   defaultChecked={selectedValue === option.value}
                   onClick={toggleRadioButton}

--- a/webapp/client/src/components/FormFieldRadioGroup.test.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.test.js
@@ -74,7 +74,6 @@ describe("FormFieldRadioGroup", () => {
 
   it("When pressing tab and arrow right it should check second radio button", () => {
     userEvent.tab();
-    // This is currently the only way to trigger an arrow event. userEvent.keyboard('{ArrowRight}'); is not supported yet.
     userEvent.type(
       screen.getByRole("radio", { name: "Terra" }),
       "{arrowright}"
@@ -84,7 +83,6 @@ describe("FormFieldRadioGroup", () => {
 
   it("When pressing tab and arrow right two times it should check third radio button", () => {
     userEvent.tab();
-    // This is currently the only way to trigger an arrow event. userEvent.keyboard('{ArrowRight}'); is not supported yet.
     userEvent.type(
       screen.getByRole("radio", { name: "Terra" }),
       "{arrowright}"
@@ -98,7 +96,6 @@ describe("FormFieldRadioGroup", () => {
 
   it("When pressing tab and arrow right two times and arrow left it should check second radio button", () => {
     userEvent.tab();
-    // This is currently the only way to trigger an arrow event. userEvent.keyboard('{ArrowRight}'); is not supported yet.
     userEvent.type(
       screen.getByRole("radio", { name: "Terra" }),
       "{arrowright}"

--- a/webapp/client/src/components/FormFieldRadioGroup.test.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.test.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import FormFieldRadio from "./FormFieldRadio";
+import FormFieldRadioGroup from "./FormFieldRadioGroup";
 
-describe("FormFieldRadio", () => {
+describe("FormFieldRadioGroup", () => {
   let props;
   const onChangeHandler = jest.fn();
 
@@ -22,7 +22,7 @@ describe("FormFieldRadio", () => {
       ],
       onChangeHandler: onChangeHandler,
     };
-    render(<FormFieldRadio {...props} />);
+    render(<FormFieldRadioGroup {...props} />);
   });
 
   it("When label is clicked, correct input is selected ", () => {

--- a/webapp/client/src/components/FormFieldRadioGroup.test.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.test.js
@@ -16,7 +16,7 @@ describe("FormFieldRadioGroup", () => {
         text: "foo",
       },
       errors: [],
-      radioButtons: [
+      options: [
         { value: "A", displayName: "Vulcan" },
         { value: "B", displayName: "Terra" },
         { value: "C", displayName: "Earth" },
@@ -122,7 +122,7 @@ describe("FormFieldRadioGroup with errors", () => {
         text: "foo",
       },
       errors: ["Error!"],
-      radioButtons: [
+      options: [
         { value: "A", displayName: "Vulcan" },
         { value: "B", displayName: "Terra" },
         { value: "C", displayName: "Earth" },

--- a/webapp/client/src/components/FormFieldRadioGroup.test.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.test.js
@@ -15,7 +15,7 @@ describe("FormFieldRadioGroup", () => {
         text: "foo",
       },
       errors: [],
-      options: [
+      radioButtons: [
         { value: "A", displayName: "Vulcan" },
         { value: "B", displayName: "Terra" },
         { value: "C", displayName: "Earth" },

--- a/webapp/client/src/components/FormFieldRadioGroup.test.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { within } from "@testing-library/dom";
 import FormFieldRadioGroup from "./FormFieldRadioGroup";
 
 describe("FormFieldRadioGroup", () => {
@@ -106,5 +107,37 @@ describe("FormFieldRadioGroup", () => {
     );
     userEvent.type(screen.getByRole("radio", { name: "Terra" }), "{arrowleft}");
     expect(screen.getByRole("radio", { name: "Terra" }).checked).toBe(true);
+  });
+});
+
+describe("FormFieldRadioGroup with errors", () => {
+  let props;
+  const onChangeHandler = jest.fn();
+
+  beforeEach(() => {
+    props = {
+      fieldName: "fooName",
+      fieldId: "fooId",
+      label: {
+        text: "foo",
+      },
+      errors: ["Error!"],
+      radioButtons: [
+        { value: "A", displayName: "Vulcan" },
+        { value: "B", displayName: "Terra" },
+        { value: "C", displayName: "Earth" },
+      ],
+      onChangeHandler: onChangeHandler,
+    };
+    render(<FormFieldRadioGroup {...props} />);
+  });
+
+  it("Should show error inside of fieldset", () => {
+    const fieldset = screen.getByRole("group");
+    expect(within(fieldset).getByText("Error!")).toBeTruthy();
+  });
+
+  it("Should have autofocus on first radio button", () => {
+    expect(screen.getByRole("radio", { name: "Vulcan" })).toHaveFocus();
   });
 });

--- a/webapp/client/src/components/FormFieldYesNo.test.js
+++ b/webapp/client/src/components/FormFieldYesNo.test.js
@@ -96,21 +96,18 @@ describe("FormFieldYesNo", () => {
 
     it("Should focus Nein Field when pressing tab and then right arrow key", () => {
       userEvent.tab();
-      // This is currently the only way to trigger an arrow event. userEvent.keyboard('{ArrowRight}'); is not supported yet.
       userEvent.type(screen.getByLabelText("Nein"), "{arrowright}");
       expect(screen.getByLabelText("Nein")).toHaveFocus();
     });
 
     it("Should activate Nein Field when focussing on Nein field and pressing space", () => {
       userEvent.tab();
-      // This is currently the only way to trigger an arrow event. userEvent.keyboard('{ArrowRight}'); is not supported yet.
       userEvent.type(screen.getByLabelText("Nein"), "{arrowright}");
       expect(screen.getByText("Nein")).toHaveClass("active");
     });
 
     it("Should check Nein Field when focussing on  Nein field and pressing space", () => {
       userEvent.tab();
-      // This is currently the only way to trigger an arrow event. userEvent.keyboard('{ArrowRight}'); is not supported yet.
       userEvent.type(screen.getByLabelText("Nein"), "{arrowright}");
       expect(screen.getByLabelText("Nein")).toBeChecked();
     });

--- a/webapp/client/src/stories/FormFieldRadioGroup.stories.js
+++ b/webapp/client/src/stories/FormFieldRadioGroup.stories.js
@@ -1,18 +1,18 @@
 import React from "react";
 
-import FormFieldRadio from "../components/FormFieldRadio";
+import FormFieldRadioGroup from "../components/FormFieldRadioGroup";
 import StepForm from "../components/StepForm";
 import { Default as StepFormDefault } from "./StepForm.stories";
 
 export default {
-  title: "Form Fields/Radio",
-  component: FormFieldRadio,
+  title: "Form Fields/RadioGroup",
+  component: FormFieldRadioGroup,
 };
 
 function Template(args) {
   return (
     <StepForm {...StepFormDefault.args}>
-      <FormFieldRadio {...args} />
+      <FormFieldRadioGroup {...args} />
     </StepForm>
   );
 }

--- a/webapp/client/src/stories/FormFieldRadioGroup.stories.js
+++ b/webapp/client/src/stories/FormFieldRadioGroup.stories.js
@@ -22,12 +22,12 @@ export const WithError = Template.bind({});
 export const WithAutofocus = Template.bind({});
 export const WithPreselectedValue = Template.bind({});
 export const WithDetails = Template.bind({});
-export const WithMoreOptions = Template.bind({});
+export const WithMoreRadioButtons = Template.bind({});
 
 Default.args = {
   fieldId: "radio",
   fieldName: "radio",
-  options: [
+  radioButtons: [
     { value: "yes", displayName: "Ja, ich zahle oder beziehe Unterhalt." },
     {
       value: "no",
@@ -63,9 +63,9 @@ WithDetails.args = {
   },
 };
 
-WithMoreOptions.args = {
+WithMoreRadioButtons.args = {
   ...Default.args,
-  options: [
+  radioButtons: [
     { value: "yes", displayName: "Ja, ich zahle oder beziehe Unterhalt." },
     {
       value: "no",

--- a/webapp/client/src/stories/FormFieldRadioGroup.stories.js
+++ b/webapp/client/src/stories/FormFieldRadioGroup.stories.js
@@ -27,7 +27,7 @@ export const WithMoreRadioButtons = Template.bind({});
 Default.args = {
   fieldId: "radio",
   fieldName: "radio",
-  radioButtons: [
+  options: [
     { value: "yes", displayName: "Ja, ich zahle oder beziehe Unterhalt." },
     {
       value: "no",
@@ -65,7 +65,7 @@ WithDetails.args = {
 
 WithMoreRadioButtons.args = {
   ...Default.args,
-  radioButtons: [
+  options: [
     { value: "yes", displayName: "Ja, ich zahle oder beziehe Unterhalt." },
     {
       value: "no",


### PR DESCRIPTION
# Short Description
- Niko pointed out some great stuff about my radio button PR: #492 

# Changes
- Correctly use radio button group and radio button
- Remove duplicated comments
- Move error message inside of fieldset for better accessibility
- Set autofocus if the field has errors

# Feedback
- I'm still using the optionsPropType that is also used for the selection field instead of creating a new one that is essentially the same with different naming (options -> radioFields). Do you think that is okay?
- 

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
