### PR TITLE
Add fahrkostenpausch Erica

### DIFF
--- a/erica_app/erica/elster_xml/est_mapping.py
+++ b/erica_app/erica/elster_xml/est_mapping.py
@@ -23,6 +23,8 @@ _ALL_FIELDS = {
     'person_a_pauschbetrag_disability_degree': 'E0109708',
     'person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': 'E0109706',
     'person_a_pauschbetrag_has_merkzeichen_g_ag': 'E0109707',
+    'person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad': 'E0161806',
+    'person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80': 'E0161706',
 
     'married_since': 'E0100701',
     'widowed_since': 'E0100702',
@@ -44,6 +46,8 @@ _ALL_FIELDS = {
     'person_b_pauschbetrag_disability_degree': 'E0109708',
     'person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': 'E0109706',
     'person_b_pauschbetrag_has_merkzeichen_g_ag': 'E0109707',
+    'person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad': 'E0161806',
+    'person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80': 'E0161706',
 
     'telephone_number': 'E0100008',
     
@@ -138,9 +142,13 @@ _PERSON_SPECIFIC_FIELDS = {
     'person_a_pauschbetrag_disability_degree': 'PersonA',
     'person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': 'PersonA',
     'person_a_pauschbetrag_has_merkzeichen_g_ag': 'PersonA',
+    'person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad': 'PersonA',
+    'person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80': 'PersonA',
     'person_b_pauschbetrag_disability_degree': 'PersonB',
     'person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': 'PersonB',
     'person_b_pauschbetrag_has_merkzeichen_g_ag': 'PersonB',
+    'person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad': 'PersonB',
+    'person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80': 'PersonB',
 }
 
 BUNDESLAND_BUFANR_MAPPING = {

--- a/erica_app/erica/elster_xml/est_mapping.py
+++ b/erica_app/erica/elster_xml/est_mapping.py
@@ -20,9 +20,9 @@ _ALL_FIELDS = {
     'person_a_address_ext': 'E0101301',
     'person_a_plz': 'E0100601',
     'person_a_town': 'E0100602',
-    'person_a_disability_degree': 'E0109708',
-    'person_a_has_merkzeichen_bl_tbl_h_pflegegrad': 'E0109706',
-    'person_a_has_merkzeichen_g_ag': 'E0109707',
+    'person_a_pauschbetrag_disability_degree': 'E0109708',
+    'person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': 'E0109706',
+    'person_a_pauschbetrag_has_merkzeichen_g_ag': 'E0109707',
 
     'married_since': 'E0100701',
     'widowed_since': 'E0100702',
@@ -41,9 +41,9 @@ _ALL_FIELDS = {
     'person_b_address_ext': 'E0102301',
     'person_b_plz': 'E0101701',
     'person_b_town': 'E0101702',
-    'person_b_disability_degree': 'E0109708',
-    'person_b_has_merkzeichen_bl_tbl_h_pflegegrad': 'E0109706',
-    'person_b_has_merkzeichen_g_ag': 'E0109707',
+    'person_b_pauschbetrag_disability_degree': 'E0109708',
+    'person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': 'E0109706',
+    'person_b_pauschbetrag_has_merkzeichen_g_ag': 'E0109707',
 
     'telephone_number': 'E0100008',
     
@@ -135,12 +135,12 @@ _FULL_EURO_FIELDS = [
 ]
 
 _PERSON_SPECIFIC_FIELDS = {
-    'person_a_disability_degree': 'PersonA',
-    'person_a_has_merkzeichen_bl_tbl_h_pflegegrad': 'PersonA',
-    'person_a_has_merkzeichen_g_ag': 'PersonA',
-    'person_b_disability_degree': 'PersonB',
-    'person_b_has_merkzeichen_bl_tbl_h_pflegegrad': 'PersonB',
-    'person_b_has_merkzeichen_g_ag': 'PersonB',
+    'person_a_pauschbetrag_disability_degree': 'PersonA',
+    'person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': 'PersonA',
+    'person_a_pauschbetrag_has_merkzeichen_g_ag': 'PersonA',
+    'person_b_pauschbetrag_disability_degree': 'PersonB',
+    'person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': 'PersonB',
+    'person_b_pauschbetrag_has_merkzeichen_g_ag': 'PersonB',
 }
 
 BUNDESLAND_BUFANR_MAPPING = {

--- a/erica_app/erica/request_processing/eric_mapper.py
+++ b/erica_app/erica/request_processing/eric_mapper.py
@@ -1,0 +1,186 @@
+from datetime import date
+from decimal import Decimal
+from typing import Optional, List
+
+from pydantic import BaseModel, root_validator, validator
+
+from erica.request_processing.erica_input import AccountHolder, MetaDataEst
+
+
+class EstEricMapping(BaseModel):
+
+    steuernummer: Optional[str]
+    submission_without_tax_nr: Optional[bool]
+    bufa_nr: Optional[str]
+    bundesland: str
+    iban: str
+    account_holder: AccountHolder
+
+    telephone_number: Optional[str]
+
+    familienstand: str  # potentially enum
+    familienstand_date: Optional[date]
+    familienstand_married_lived_separated: Optional[bool]
+    familienstand_married_lived_separated_since: Optional[date]
+    familienstand_widowed_lived_separated: Optional[bool]
+    familienstand_widowed_lived_separated_since: Optional[date]
+
+    person_a_idnr: str
+    person_a_dob: date
+    person_a_last_name: str
+    person_a_first_name: str
+    person_a_religion: str
+    person_a_street: str
+    person_a_street_number: str
+    person_a_street_number_ext: Optional[str]
+    person_a_address_ext: Optional[str]
+    person_a_plz: str
+    person_a_town: str
+
+    person_a_pauschbetrag_disability_degree: Optional[int]
+    person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad: Optional[bool]
+    person_a_pauschbetrag_has_merkzeichen_g_ag: Optional[bool]
+    person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad: Optional[bool]
+    person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80: Optional[bool]
+
+    person_b_same_address: Optional[bool]
+    person_b_idnr: Optional[str]
+    person_b_dob: Optional[date]
+    person_b_last_name: Optional[str]
+    person_b_first_name: Optional[str]
+    person_b_religion: Optional[str]
+    person_b_street: Optional[str]
+    person_b_street_number: Optional[str]
+    person_b_street_number_ext: Optional[str]
+    person_b_address_ext: Optional[str]
+    person_b_plz: Optional[str]
+    person_b_town: Optional[str]
+
+    person_b_pauschbetrag_disability_degree: Optional[int]
+    person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad: Optional[bool]
+    person_b_pauschbetrag_has_merkzeichen_g_ag: Optional[bool]
+    person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad: Optional[bool]
+    person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80: Optional[bool]
+
+    stmind_haushaltsnahe_entries: Optional[List[str]]
+    stmind_haushaltsnahe_summe: Optional[Decimal]
+    stmind_handwerker_entries: Optional[List[str]]
+    stmind_handwerker_summe: Optional[Decimal]
+    stmind_handwerker_lohn_etc_summe: Optional[Decimal]
+
+    stmind_vorsorge_summe: Optional[Decimal]
+    stmind_spenden_inland: Optional[Decimal]
+    stmind_spenden_inland_parteien: Optional[Decimal]
+    stmind_religion_paid_summe: Optional[Decimal]
+    stmind_religion_reimbursed_summe: Optional[Decimal]
+
+    stmind_krankheitskosten_summe: Optional[Decimal]
+    stmind_krankheitskosten_anspruch: Optional[Decimal]
+    stmind_pflegekosten_summe: Optional[Decimal]
+    stmind_pflegekosten_anspruch: Optional[Decimal]
+    stmind_beh_aufw_summe: Optional[Decimal]
+    stmind_beh_aufw_anspruch: Optional[Decimal]
+    stmind_bestattung_summe: Optional[Decimal]
+    stmind_bestattung_anspruch: Optional[Decimal]
+    stmind_aussergbela_sonst_summe: Optional[Decimal]
+    stmind_aussergbela_sonst_anspruch: Optional[Decimal]
+
+    stmind_gem_haushalt_count: Optional[int]
+    stmind_gem_haushalt_entries: Optional[List[str]]
+
+    @root_validator(pre=True)
+    def set_pauschbetrag_disability_degrees(cls, values):
+        values['person_a_pauschbetrag_disability_degree'] = values.get('person_a_disability_degree')
+        values['person_b_pauschbetrag_disability_degree'] = values.get('person_b_disability_degree')
+
+        return values
+
+    @root_validator(pre=True)
+    def set_person_a_merkzeichen_bl_tbl_h_pflegegrad(cls, values):
+        merkzeichen_values = [
+           values.get('person_a_has_pflegegrad'),
+           values.get('person_a_has_merkzeichen_bl'),
+           values.get('person_a_has_merkzeichen_tbl'),
+           values.get('person_a_has_merkzeichen_h')
+        ]
+        if any(merkzeichen_values):
+            values['person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad'] = True
+        return values
+
+    @root_validator(pre=True)
+    def set_person_a_merkzeichen_g_ag(cls, values):
+        merkzeichen_values = [
+           values.get('person_a_has_merkzeichen_g'),
+           values.get('person_a_has_merkzeichen_ag')
+        ]
+        if any(merkzeichen_values):
+            values['person_a_pauschbetrag_has_merkzeichen_g_ag'] = True
+        return values
+
+    @root_validator(pre=True)
+    def set_person_a_fahrkostenpauschale(cls, values):
+        merkzeichen_for_higher_fahrkostenpauschale = [
+            values.get('person_a_has_pflegegrad'),
+            values.get('person_a_has_merkzeichen_bl'),
+            values.get('person_a_has_merkzeichen_tbl'),
+            values.get('person_a_has_merkzeichen_tbl'),
+            values.get('person_a_has_merkzeichen_h'),
+            values.get('person_a_has_merkzeichen_ag')
+        ]
+        if values.get('person_a_requests_fahrkostenpauschale'):
+            if any(merkzeichen_for_higher_fahrkostenpauschale):
+                values['person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad'] = True
+            elif values.get('person_a_disability_degree') >= 80 or (values.get('person_a_has_merkzeichen_g') and values.get('person_a_disability_degree') >= 70):
+                values['person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80'] = True
+        return values
+
+    @root_validator(pre=True)
+    def set_person_b_merkzeichen_bl_tbl_h_pflegegrad(cls,values):
+        merkzeichen_values = [
+           values.get('person_b_has_pflegegrad'),
+           values.get('person_b_has_merkzeichen_bl'),
+           values.get('person_b_has_merkzeichen_tbl'),
+           values.get('person_b_has_merkzeichen_h')
+        ]
+        if any(merkzeichen_values):
+            values['person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad'] = True
+        return values
+
+    @root_validator(pre=True)
+    def set_person_b_merkzeichen_g_ag(cls, values):
+        merkzeichen_values = [
+           values.get('person_b_has_merkzeichen_g'),
+           values.get('person_b_has_merkzeichen_ag')
+        ]
+        if any(merkzeichen_values):
+            values['person_b_pauschbetrag_has_merkzeichen_g_ag'] = True
+        return values
+
+    @root_validator(pre=True)
+    def set_person_b_fahrkostenpauschale(cls, values):
+        merkzeichen_for_higher_fahrkostenpauschale = [
+            values.get('person_b_has_pflegegrad'),
+            values.get('person_b_has_merkzeichen_bl'),
+            values.get('person_b_has_merkzeichen_tbl'),
+            values.get('person_b_has_merkzeichen_tbl'),
+            values.get('person_b_has_merkzeichen_h'),
+            values.get('person_b_has_merkzeichen_ag')
+        ]
+        if values.get('person_b_requests_fahrkostenpauschale'):
+            if any(merkzeichen_for_higher_fahrkostenpauschale):
+                values['person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad'] = True
+            elif values.get('person_b_disability_degree') >= 80 or (values.get('person_b_has_merkzeichen_g') and values.get('person_b_disability_degree') >= 70):
+                values['person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80'] = True
+        return values
+
+    @validator('person_a_dob', 'person_b_dob', 'familienstand_date')
+    def convert_datetime_to_d_m_y(cls, v):
+        if v:
+            return v.strftime('%d.%m.%Y')
+        return None
+
+    @validator('person_a_pauschbetrag_disability_degree', 'person_b_pauschbetrag_disability_degree')
+    def set_disability_degree_only_if_above_20(cls, v):
+        if v and v < 20:
+            return None
+        return v

--- a/erica_app/erica/request_processing/eric_mapper.py
+++ b/erica_app/erica/request_processing/eric_mapper.py
@@ -19,14 +19,14 @@ class EstEricMapping(BaseModel):
     telephone_number: Optional[str]
 
     familienstand: str  # potentially enum
-    familienstand_date: Optional[date]
+    familienstand_date: Optional[str]
     familienstand_married_lived_separated: Optional[bool]
     familienstand_married_lived_separated_since: Optional[date]
     familienstand_widowed_lived_separated: Optional[bool]
     familienstand_widowed_lived_separated_since: Optional[date]
 
     person_a_idnr: str
-    person_a_dob: date
+    person_a_dob: str
     person_a_last_name: str
     person_a_first_name: str
     person_a_religion: str
@@ -45,7 +45,7 @@ class EstEricMapping(BaseModel):
 
     person_b_same_address: Optional[bool]
     person_b_idnr: Optional[str]
-    person_b_dob: Optional[date]
+    person_b_dob: Optional[str]
     person_b_last_name: Optional[str]
     person_b_first_name: Optional[str]
     person_b_religion: Optional[str]
@@ -173,7 +173,7 @@ class EstEricMapping(BaseModel):
                 values['person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80'] = True
         return values
 
-    @validator('person_a_dob', 'person_b_dob', 'familienstand_date')
+    @validator('person_a_dob', 'person_b_dob', 'familienstand_date', pre=True)
     def convert_datetime_to_d_m_y(cls, v):
         if v:
             return v.strftime('%d.%m.%Y')
@@ -184,3 +184,14 @@ class EstEricMapping(BaseModel):
         if v and v < 20:
             return None
         return v
+
+
+class UnlockCodeRequestEricMapper(BaseModel):
+    idnr: str
+    dob: str
+
+    @validator('dob', pre=True)
+    def convert_datetime_to_y_m_d(cls, v):
+        if v:
+            return v.strftime('%Y-%m-%d')
+        return None

--- a/erica_app/erica/request_processing/eric_mapper.py
+++ b/erica_app/erica/request_processing/eric_mapper.py
@@ -94,6 +94,8 @@ class EstEricMapping(BaseModel):
     def set_pauschbetrag_disability_degrees(cls, values):
         if values.get('person_a_requests_pauschbetrag'):
             values['person_a_pauschbetrag_disability_degree'] = values.get('person_a_disability_degree')
+
+        if values.get('person_b_requests_pauschbetrag'):
             values['person_b_pauschbetrag_disability_degree'] = values.get('person_b_disability_degree')
 
         return values

--- a/erica_app/erica/request_processing/erica_input.py
+++ b/erica_app/erica/request_processing/erica_input.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional, List
 
-from pydantic import BaseModel, validator, ValidationError, root_validator
+from pydantic import BaseModel, validator, root_validator
 
 from erica.elster_xml.elster_xml_generator import VERANLAGUNGSJAHR
 from erica.elster_xml.est_validation import is_valid_bufa
@@ -44,8 +44,14 @@ class FormDataEst(BaseModel):
     person_a_plz: str
     person_a_town: str
     person_a_disability_degree: Optional[int]
-    person_a_has_merkzeichen_bl_tbl_h_pflegegrad: Optional[bool]
-    person_a_has_merkzeichen_g_ag: Optional[bool]
+    person_a_has_pflegegrad: Optional[bool]
+    person_a_has_merkzeichen_bl: Optional[bool]
+    person_a_has_merkzeichen_tbl: Optional[bool]
+    person_a_has_merkzeichen_h: Optional[bool]
+    person_a_has_merkzeichen_g: Optional[bool]
+    person_a_has_merkzeichen_ag: Optional[bool]
+    person_a_requests_pauschbetrag: Optional[bool]
+    person_a_requests_fahrkostenpauschale: Optional[bool]
 
     person_b_same_address: Optional[bool]
     person_b_idnr: Optional[str]
@@ -60,8 +66,14 @@ class FormDataEst(BaseModel):
     person_b_plz: Optional[str]
     person_b_town: Optional[str]
     person_b_disability_degree: Optional[int]
-    person_b_has_merkzeichen_bl_tbl_h_pflegegrad: Optional[bool]
-    person_b_has_merkzeichen_g_ag: Optional[bool]
+    person_b_has_pflegegrad: Optional[bool]
+    person_b_has_merkzeichen_bl: Optional[bool]
+    person_b_has_merkzeichen_tbl: Optional[bool]
+    person_b_has_merkzeichen_h: Optional[bool]
+    person_b_has_merkzeichen_g: Optional[bool]
+    person_b_has_merkzeichen_ag: Optional[bool]
+    person_b_requests_pauschbetrag: Optional[bool]
+    person_b_requests_fahrkostenpauschale: Optional[bool]
 
     stmind_haushaltsnahe_entries: Optional[List[str]]
     stmind_haushaltsnahe_summe: Optional[Decimal]
@@ -89,90 +101,24 @@ class FormDataEst(BaseModel):
     stmind_gem_haushalt_count: Optional[int]
     stmind_gem_haushalt_entries: Optional[List[str]]
 
-    @root_validator(pre=True)
-    def disability_merkzeichen_and_pflegegrad_flags_must_be_boolean(cls, values):
-        merkzeichen_names = [
-            'person_a_has_pflegegrad',
-            'person_a_has_merkzeichen_bl',
-            'person_a_has_merkzeichen_tbl',
-            'person_a_has_merkzeichen_h',
-            'person_a_has_merkzeichen_g',
-            'person_a_has_merkzeichen_ag',
-            'person_b_has_pflegegrad',
-            'person_b_has_merkzeichen_bl',
-            'person_b_has_merkzeichen_tbl',
-            'person_b_has_merkzeichen_h',
-            'person_b_has_merkzeichen_g',
-            'person_b_has_merkzeichen_ag',
-        ]
-        for merkzeichen_name in merkzeichen_names:
-            merkzeichen_value = values.get(merkzeichen_name)
-            if merkzeichen_value is not None and not isinstance(merkzeichen_value, bool):
-                raise ValueError(f"{merkzeichen_name} is not a boolean. {merkzeichen_value} was given")
-        return values
-
-    @root_validator(pre=True)
-    def set_person_a_merkzeichen_bl_tbl_h_pflegegrad(cls, values):
-        merkzeichen_values = [
-           values.get('person_a_has_pflegegrad'),
-           values.get('person_a_has_merkzeichen_bl'),
-           values.get('person_a_has_merkzeichen_tbl'),
-           values.get('person_a_has_merkzeichen_h')
-        ]
-        if any(merkzeichen_values):
-            values['person_a_has_merkzeichen_bl_tbl_h_pflegegrad'] = True
-        return values
-
-    @root_validator(pre=True)
-    def set_person_a_merkzeichen_g_ag(cls, values):
-        merkzeichen_values = [
-           values.get('person_a_has_merkzeichen_g'),
-           values.get('person_a_has_merkzeichen_ag')
-        ]
-        if any(merkzeichen_values):
-            values['person_a_has_merkzeichen_g_ag'] = True
-        return values
-
-    @root_validator(pre=True)
-    def set_person_b_merkzeichen_bl_tbl_h_pflegegrad(cls, values):
-        merkzeichen_values = [
-           values.get('person_b_has_pflegegrad'),
-           values.get('person_b_has_merkzeichen_bl'),
-           values.get('person_b_has_merkzeichen_tbl'),
-           values.get('person_b_has_merkzeichen_h')
-        ]
-        if any(merkzeichen_values):
-            values['person_b_has_merkzeichen_bl_tbl_h_pflegegrad'] = True
-        return values
-
-    @root_validator(pre=True)
-    def set_person_b_merkzeichen_g_ag(cls, values):
-        merkzeichen_values = [
-           values.get('person_b_has_merkzeichen_g'),
-           values.get('person_b_has_merkzeichen_ag')
-        ]
-        if any(merkzeichen_values):
-            values['person_b_has_merkzeichen_g_ag'] = True
-        return values
-
     @validator('submission_without_tax_nr', always=True)
     def if_no_tax_number_must_be_submission_without_tax_nr(cls, v, values):
         if values.get('steuernummer') and v:
-            raise ValidationError('can not be a new admission if tax number given')
+            raise ValueError('can not be a new admission if tax number given')
         if not v and not values.get('steuernummer'):
-            raise ValidationError('must be new admission if no tax number given')
+            raise ValueError('must be new admission if no tax number given')
         return v
 
     @validator('steuernummer')
     def must_be_correct_length(cls, v):
         if v and not 10 <= len(v) <= 11:
-            raise ValidationError('must be 10 or 11 numbers long')
+            raise ValueError('must be 10 or 11 numbers long')
         return v
 
     @validator('bufa_nr', always=True)
     def if_submission_without_tax_nr_bufa_nr_must_be_set_correctly(cls, v, values):
         if values.get('submission_without_tax_nr') and (not v or not len(v) == 4):
-            raise ValidationError('must be 4 numbers long for new admission')
+            raise ValueError('must be 4 numbers long for new admission')
         if values.get('submission_without_tax_nr') and not is_valid_bufa(v):
             raise InvalidBufaNumberError
         return v
@@ -180,16 +126,70 @@ class FormDataEst(BaseModel):
     @validator('familienstand_married_lived_separated_since', always=True)
     def must_be_set_if_familienstand_married_lived_separated_set(cls, v, values, **kwargs):
         if values.get('familienstand_married_lived_separated') and not v:
-            raise ValidationError('must be set if familienstand_married_lived_separated set')
+            raise ValueError('must be set if familienstand_married_lived_separated set')
         return v
 
     @validator('familienstand_widowed_lived_separated_since', always=True)
     def must_be_set_if_familienstand_widowed_lived_separated_set(cls, v, values, **kwargs):
         if values.get('familienstand_widowed_lived_separated') and not v:
-            raise ValidationError('must be set if familienstand_widowed_lived_separated set')
+            raise ValueError('must be set if familienstand_widowed_lived_separated set')
         return v
 
+    @validator('person_a_requests_pauschbetrag')
+    def pauschbetrag_for_person_a_should_not_be_requested_if_no_disability_information_given(cls, v, values):
+        disability_information = [
+            values.get('person_a_disability_degree'),
+            values.get('person_a_has_pflegegrad'),
+            values.get('person_a_has_merkzeichen_bl'),
+            values.get('person_a_has_merkzeichen_tbl'),
+            values.get('person_a_has_merkzeichen_h'),
+            values.get('person_a_has_merkzeichen_g'),
+            values.get('person_a_has_merkzeichen_ag'),
+        ]
+        if not any(disability_information) and v is True:
+            raise ValueError('Person A can not request Pauschbetrag if no disability information given')
 
+    @validator('person_a_requests_fahrkostenpauschale')
+    def fahrkostenpauschale_for_person_a_should_not_be_requested_if_no_disability_information_given(cls, v, values):
+        disability_information = [
+            values.get('person_a_disability_degree'),
+            values.get('person_a_has_pflegegrad'),
+            values.get('person_a_has_merkzeichen_bl'),
+            values.get('person_a_has_merkzeichen_tbl'),
+            values.get('person_a_has_merkzeichen_h'),
+            values.get('person_a_has_merkzeichen_g'),
+            values.get('person_a_has_merkzeichen_ag'),
+        ]
+        if not any(disability_information) and v is True:
+            raise ValueError('Person A can not request Fahrkostenpauschale if no disability information given')
+
+    @validator('person_b_requests_pauschbetrag')
+    def pauschbetrag_for_person_b_should_not_be_requested_if_no_disability_information_given(cls, v, values):
+        disability_information = [
+            values.get('person_b_disability_degree'),
+            values.get('person_b_has_pflegegrad'),
+            values.get('person_b_has_merkzeichen_bl'),
+            values.get('person_b_has_merkzeichen_tbl'),
+            values.get('person_b_has_merkzeichen_h'),
+            values.get('person_b_has_merkzeichen_g'),
+            values.get('person_b_has_merkzeichen_ag'),
+        ]
+        if not any(disability_information) and v is True:
+            raise ValueError('Person B can not request Pauschbetrag if no disability information given')
+
+    @validator('person_b_requests_fahrkostenpauschale')
+    def fahrkostenpauschale_for_person_b_should_not_be_requested_if_no_disability_information_given(cls, v, values):
+        disability_information = [
+            values.get('person_b_disability_degree'),
+            values.get('person_b_has_pflegegrad'),
+            values.get('person_b_has_merkzeichen_bl'),
+            values.get('person_b_has_merkzeichen_tbl'),
+            values.get('person_b_has_merkzeichen_h'),
+            values.get('person_b_has_merkzeichen_g'),
+            values.get('person_b_has_merkzeichen_ag'),
+        ]
+        if not any(disability_information) and v is True:
+            raise ValueError('Person B can not request Fahrkostenpauschale if no disability information given')
 
 
 class MetaDataEst(BaseModel):
@@ -198,7 +198,7 @@ class MetaDataEst(BaseModel):
     @validator('year')
     def year_must_be_supported(cls, v):
         if not v == VERANLAGUNGSJAHR:
-            raise ValidationError("must be a supported year")
+            raise ValueError("must be a supported year")
         return v
 
 

--- a/erica_app/erica/request_processing/requests_controller.py
+++ b/erica_app/erica/request_processing/requests_controller.py
@@ -15,6 +15,7 @@ from erica.pyeric.pyeric_controller import EstPyericProcessController, EstValida
     UnlockCodeRevocationPyericProcessController, \
     DecryptBelegePyericController, BelegIdRequestPyericProcessController, \
     BelegRequestPyericProcessController, CheckTaxNumberPyericController
+from erica.request_processing.eric_mapper import EstEricMapping
 from erica.request_processing.erica_input import UnlockCodeRequestData, EstData
 
 SPECIAL_TESTMERKER_IDNR = '04452397687'
@@ -79,9 +80,6 @@ class EstValidationRequestController(TransferTicketRequestController):
 
     def __init__(self, input_data: EstData, include_elster_responses: bool = False):
         super().__init__(input_data, include_elster_responses)
-        self.input_data.est_data.person_a_dob = self._reformat_date(self.input_data.est_data.person_a_dob)
-        self.input_data.est_data.person_b_dob = self._reformat_date(self.input_data.est_data.person_b_dob)
-        self.input_data.est_data.familienstand_date = self._reformat_date(self.input_data.est_data.familienstand_date)
 
     def _is_testmerker_used(self):
         return self.input_data.est_data.person_a_idnr == SPECIAL_TESTMERKER_IDNR
@@ -89,7 +87,8 @@ class EstValidationRequestController(TransferTicketRequestController):
     def process(self):
         # Translate our form data structure into the fields from
         # the Elster specification (see `Jahresdokumentation_10_2021.xml`)
-        fields = est_mapping.check_and_generate_entries(self.input_data.est_data.__dict__)
+        est_with_eric_mapping = EstEricMapping.parse_obj(self.input_data.est_data)
+        fields = est_mapping.check_and_generate_entries(est_with_eric_mapping.__dict__)
 
         common_vorsatz_args = (
                 self.input_data.meta_data.year,

--- a/erica_app/erica/request_processing/requests_controller.py
+++ b/erica_app/erica/request_processing/requests_controller.py
@@ -15,7 +15,7 @@ from erica.pyeric.pyeric_controller import EstPyericProcessController, EstValida
     UnlockCodeRevocationPyericProcessController, \
     DecryptBelegePyericController, BelegIdRequestPyericProcessController, \
     BelegRequestPyericProcessController, CheckTaxNumberPyericController
-from erica.request_processing.eric_mapper import EstEricMapping
+from erica.request_processing.eric_mapper import EstEricMapping, UnlockCodeRequestEricMapper
 from erica.request_processing.erica_input import UnlockCodeRequestData, EstData
 
 SPECIAL_TESTMERKER_IDNR = '04452397687'
@@ -133,14 +133,12 @@ class EstRequestController(EstValidationRequestController):
 class UnlockCodeRequestController(TransferTicketRequestController):
     _PYERIC_CONTROLLER = UnlockCodeRequestPyericProcessController
 
-    standard_date_format = "%Y-%m-%d"
-
     def __init__(self, input_data: UnlockCodeRequestData, include_elster_responses: bool = False):
         super().__init__(input_data, include_elster_responses)
-        self.input_data.dob = self._reformat_date(self.input_data.dob)
 
     def generate_full_xml(self, use_testmerker):
-        return elster_xml_generator.generate_full_vast_request_xml(self.input_data.__dict__,
+        return elster_xml_generator.generate_full_vast_request_xml(
+            UnlockCodeRequestEricMapper.parse_obj(self.input_data).__dict__,
                                                                    use_testmerker=use_testmerker)
 
     def generate_json(self, pyeric_response: PyericResponse):

--- a/erica_app/erica/request_processing/requests_controller.py
+++ b/erica_app/erica/request_processing/requests_controller.py
@@ -27,7 +27,6 @@ class EricaRequestController(object):
     performing the needed procedures and generating the response. Any request should inherit from this function.
     """
 
-    standard_date_format = "%d.%m.%Y"
     _PYERIC_CONTROLLER = None
 
     def __init__(self, input_data, include_elster_responses: bool = False):
@@ -48,12 +47,6 @@ class EricaRequestController(object):
 
     def generate_full_xml(self, use_testmerker):
         raise NotImplementedError
-
-    def _reformat_date(self, date_attribute):
-        if date_attribute:
-            return date_attribute.strftime(self.standard_date_format)
-        else:
-            return None
 
     def _is_testmerker_used(self):
         return self.input_data.idnr == SPECIAL_TESTMERKER_IDNR

--- a/erica_app/tests/elster_xml/test_est_mapping.py
+++ b/erica_app/tests/elster_xml/test_est_mapping.py
@@ -368,6 +368,34 @@ class TestEstMapping(unittest.TestCase):
         self.assertNotIn(PersonSpecificFieldId('E0109706', 'PersonB'), results.keys())
         self.assertEqual('1', results[PersonSpecificFieldId('E0109707', 'PersonB')])
 
+    def test_if_fahrkostenpauschale_requested_then_check_and_generate_entries(self):
+        form_data = {
+            'person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad': True,
+            'person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80': True,
+            'person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad': True,
+            'person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80': True,
+        }
+        results = check_and_generate_entries(form_data)
+
+        self.assertEqual('1', results[PersonSpecificFieldId('E0161706', 'PersonA')])
+        self.assertEqual('1', results[PersonSpecificFieldId('E0161806', 'PersonA')])
+        self.assertEqual('1', results[PersonSpecificFieldId('E0161706', 'PersonB')])
+        self.assertEqual('1', results[PersonSpecificFieldId('E0161806', 'PersonB')])
+
+    def test_if_fahrkostenpauschale_partially_requested_then_check_and_generate_entries(self):
+        form_data = {
+            'person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad': True,
+            'person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80': False,
+            'person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad': False,
+            'person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80': True,
+        }
+        results = check_and_generate_entries(form_data)
+
+        self.assertEqual('1', results[PersonSpecificFieldId('E0161806', 'PersonA')])
+        self.assertNotIn(PersonSpecificFieldId('E0161706', 'PersonA'), results.keys())
+        self.assertEqual('1', results[PersonSpecificFieldId('E0161706', 'PersonB')])
+        self.assertNotIn(PersonSpecificFieldId('E0161806', 'PersonB'), results.keys())
+
     def test_if_empty_fields_then_not_in_result(self):
         form_data = {
             'stmind_krankheitskosten_summe': None,

--- a/erica_app/tests/elster_xml/test_est_mapping.py
+++ b/erica_app/tests/elster_xml/test_est_mapping.py
@@ -129,7 +129,7 @@ class TestConvertToElsterIdentifiers(unittest.TestCase):
 
     def test_converts_person_specific_form_ids_to_elster_ids(self):
         form_data = {
-            'person_a_has_merkzeichen_bl_tbl_h_pflegegrad': True
+            'person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': True
         }
         expected_result = {
             PersonSpecificFieldId('E0109706', 'PersonA'): '1'
@@ -343,10 +343,10 @@ class TestEstMapping(unittest.TestCase):
 
     def test_if_beh_filled_out_then_check_and_generate_entries(self):
         form_data = {
-            'person_a_has_merkzeichen_bl_tbl_h_pflegegrad': True,
-            'person_a_has_merkzeichen_g_ag': True,
-            'person_b_has_merkzeichen_bl_tbl_h_pflegegrad': True,
-            'person_b_has_merkzeichen_g_ag': True,
+            'person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': True,
+            'person_a_pauschbetrag_has_merkzeichen_g_ag': True,
+            'person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': True,
+            'person_b_pauschbetrag_has_merkzeichen_g_ag': True,
         }
         results = check_and_generate_entries(form_data)
 
@@ -356,10 +356,10 @@ class TestEstMapping(unittest.TestCase):
         self.assertEqual('1', results[PersonSpecificFieldId('E0109707', 'PersonB')])
 
         form_data = {
-            'person_a_has_merkzeichen_bl_tbl_h_pflegegrad': True,
-            'person_a_has_merkzeichen_g_ag': False,
-            'person_b_has_merkzeichen_bl_tbl_h_pflegegrad': False,
-            'person_b_has_merkzeichen_g_ag': True,
+            'person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': True,
+            'person_a_pauschbetrag_has_merkzeichen_g_ag': False,
+            'person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad': False,
+            'person_b_pauschbetrag_has_merkzeichen_g_ag': True,
         }
         results = check_and_generate_entries(form_data)
 

--- a/erica_app/tests/request_processing/test_eric_mapper.py
+++ b/erica_app/tests/request_processing/test_eric_mapper.py
@@ -702,7 +702,7 @@ class TestEstDataDisabilityDegree:
 
     def test_if_person_b_disability_degree_below_20_then_do_not_set_disability_degree(self, standard_est_input_data):
         standard_est_input_data.person_b_disability_degree = 15
-        standard_est_input_data.person_a_requests_pauschbetrag = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
 
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 
@@ -718,7 +718,7 @@ class TestEstDataDisabilityDegree:
 
     def test_if_person_b_disability_degree_20_then_set_disability_degree(self, standard_est_input_data):
         standard_est_input_data.person_b_disability_degree = 20
-        standard_est_input_data.person_a_requests_pauschbetrag = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
 
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 

--- a/erica_app/tests/request_processing/test_eric_mapper.py
+++ b/erica_app/tests/request_processing/test_eric_mapper.py
@@ -9,29 +9,6 @@ from erica.request_processing.eric_mapper import EstEricMapping
 from erica.request_processing.erica_input import FormDataEst
 
 
-class DummyInput(BaseModel):
-
-    person_a_disability_degree: Optional[int]
-    person_a_has_pflegegrad: Optional[bool]
-    person_a_has_merkzeichen_bl: Optional[bool]
-    person_a_has_merkzeichen_tbl: Optional[bool]
-    person_a_has_merkzeichen_h: Optional[bool]
-    person_a_has_merkzeichen_g: Optional[bool]
-    person_a_has_merkzeichen_ag: Optional[bool]
-    person_a_requests_pauschbetrag: Optional[bool]
-    person_a_requests_fahrkostenpauschale: Optional[bool]
-
-    person_b_disability_degree: Optional[int]
-    person_b_has_pflegegrad: Optional[bool]
-    person_b_has_merkzeichen_bl: Optional[bool]
-    person_b_has_merkzeichen_tbl: Optional[bool]
-    person_b_has_merkzeichen_h: Optional[bool]
-    person_b_has_merkzeichen_g: Optional[bool]
-    person_b_has_merkzeichen_ag: Optional[bool]
-    person_b_requests_pauschbetrag: Optional[bool]
-    person_b_requests_fahrkostenpauschale: Optional[bool]
-
-
 @pytest.fixture
 def standard_est_input_data():
 
@@ -271,64 +248,114 @@ class TestEstDataPersonAFahrkostenPauschale:
 
 class TestEstDataPersonAPauschbetrag:
 
-    def test_if_person_a_has_merkzeichen_bl_then_set_correct_field(self, standard_est_input_data):
-        standard_est_input_data.person_a_has_merkzeichen_bl = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_a_has_merkzeichen_bl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
-        standard_est_input_data.person_a_has_merkzeichen_bl = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
-
-    def test_if_person_a_has_merkzeichen_tbl_then_set_correct_field(self, standard_est_input_data):
-        standard_est_input_data.person_a_has_merkzeichen_tbl = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_a_has_merkzeichen_tbl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
-        standard_est_input_data.person_a_has_merkzeichen_tbl = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
-
-    def test_if_person_a_has_merkzeichen_h_then_set_correct_field(self, standard_est_input_data):
-        standard_est_input_data.person_a_has_merkzeichen_h = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_a_has_merkzeichen_h_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
-        standard_est_input_data.person_a_has_merkzeichen_h = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
-
-    def test_if_person_a_has_pflegegrad_then_set_correct_field(self, standard_est_input_data):
+    def test_if_person_a_does_not_request_pauschbetrag_and_has_all_merkzeichen_then_do_not_set_pauschbetrag_fields(self, standard_est_input_data):
+        standard_est_input_data.person_a_requests_pauschbetrag = False
         standard_est_input_data.person_a_has_pflegegrad = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_a_has_pflegegrad_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
-        standard_est_input_data.person_a_has_pflegegrad = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
-
-    def test_if_person_a_has_merkzeichen_g_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_bl = True
+        standard_est_input_data.person_a_has_merkzeichen_tbl = True
+        standard_est_input_data.person_a_has_merkzeichen_h = True
         standard_est_input_data.person_a_has_merkzeichen_g = True
+        standard_est_input_data.person_a_has_merkzeichen_ag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is None
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_bl_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_bl = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_bl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_bl = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_tbl_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_tbl = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_tbl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_tbl = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_h_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_h = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_h_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_h = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_a_requests_pauschbetrag_and_has_pflegegrad_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_pflegegrad = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_a_requests_pauschbetrag_and_has_pflegegrad_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_pflegegrad = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_g_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_g = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is True
 
-    def test_if_person_a_has_merkzeichen_g_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_g_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
         standard_est_input_data.person_a_has_merkzeichen_g = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is None
 
-    def test_if_person_a_has_merkzeichen_ag_then_set_correct_field(self, standard_est_input_data):
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_ag_then_set_correct_field(self, standard_est_input_data):
         standard_est_input_data.person_a_has_merkzeichen_ag = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is True
 
-    def test_if_person_a_has_merkzeichen_ag_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_ag_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
         standard_est_input_data.person_a_has_merkzeichen_ag = True
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is None
 
 
@@ -414,207 +441,285 @@ class TestEstDataPersonBFahrkostenPauschale:
 
     def test_if_person_b_has_merkzeichen_h_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
         disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
-        standard_est_input_data.person_a_has_merkzeichen_h = True
-        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+        standard_est_input_data.person_b_has_merkzeichen_h = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = True
 
         for disability_degree in disability_degrees:
-            standard_est_input_data.person_a_disability_degree = disability_degree
+            standard_est_input_data.person_b_disability_degree = disability_degree
 
             resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 
-            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
-            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
 
-    def test_if_person_a_has_merkzeichen_h_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+    def test_if_person_b_has_merkzeichen_h_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
         disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
-        standard_est_input_data.person_a_has_merkzeichen_h = True
-        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+        standard_est_input_data.person_b_has_merkzeichen_h = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = False
 
         for disability_degree in disability_degrees:
-            standard_est_input_data.person_a_disability_degree = disability_degree
+            standard_est_input_data.person_b_disability_degree = disability_degree
 
             resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 
-            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
-            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
 
-    def test_if_person_a_has_merkzeichen_ag_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+    def test_if_person_b_has_merkzeichen_ag_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
         disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
-        standard_est_input_data.person_a_has_merkzeichen_ag = True
-        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+        standard_est_input_data.person_b_has_merkzeichen_ag = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = True
 
         for disability_degree in disability_degrees:
-            standard_est_input_data.person_a_disability_degree = disability_degree
+            standard_est_input_data.person_b_disability_degree = disability_degree
 
             resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 
-            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
-            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
 
-    def test_if_person_a_has_merkzeichen_ag_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+    def test_if_person_b_has_merkzeichen_ag_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
         disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
-        standard_est_input_data.person_a_has_merkzeichen_ag = True
-        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+        standard_est_input_data.person_b_has_merkzeichen_ag = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = False
 
         for disability_degree in disability_degrees:
-            standard_est_input_data.person_a_disability_degree = disability_degree
+            standard_est_input_data.person_b_disability_degree = disability_degree
 
             resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 
-            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
-            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
 
-    def test_if_person_a_has_merkzeichen_g_and_disability_degree_70_and_requests_fahrkostenpauschale_then_set_lower_fahrkostenpauschale(self, standard_est_input_data):
+    def test_if_person_b_has_merkzeichen_g_and_disability_degree_70_and_requests_fahrkostenpauschale_then_set_lower_fahrkostenpauschale(self, standard_est_input_data):
         disability_degree = 70
-        standard_est_input_data.person_a_has_merkzeichen_g = True
-        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+        standard_est_input_data.person_b_has_merkzeichen_g = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = True
 
-        standard_est_input_data.person_a_disability_degree = disability_degree
+        standard_est_input_data.person_b_disability_degree = disability_degree
 
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is True
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is True
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
 
-    def test_if_person_a_has_merkzeichen_g_and_disability_degree_70_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
+    def test_if_person_b_has_merkzeichen_g_and_disability_degree_70_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
         disability_degree = 70
-        standard_est_input_data.person_a_has_merkzeichen_g = True
-        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+        standard_est_input_data.person_b_has_merkzeichen_g = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = False
 
-        standard_est_input_data.person_a_disability_degree = disability_degree
+        standard_est_input_data.person_b_disability_degree = disability_degree
 
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
 
-    def test_if_person_a_has_merkzeichen_g_and_disability_degree_below_70_and_requests_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
+    def test_if_person_b_has_merkzeichen_g_and_disability_degree_below_70_and_requests_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
         disability_degree = 65
-        standard_est_input_data.person_a_has_merkzeichen_g = True
-        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+        standard_est_input_data.person_b_has_merkzeichen_g = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = True
 
-        standard_est_input_data.person_a_disability_degree = disability_degree
+        standard_est_input_data.person_b_disability_degree = disability_degree
 
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
 
     def test_if_a_has_no_merkzeichen_and_disability_degree_80_and_requests_fahrkostenpauschale_then_set_lower_fahrkostenpauschale(self, standard_est_input_data):
         disability_degree = 80
-        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = True
 
-        standard_est_input_data.person_a_disability_degree = disability_degree
+        standard_est_input_data.person_b_disability_degree = disability_degree
 
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is True
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is True
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
 
     def test_if_a_has_no_merkzeichen_and_disability_degree_80_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
         disability_degree = 80
-        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = False
 
-        standard_est_input_data.person_a_disability_degree = disability_degree
+        standard_est_input_data.person_b_disability_degree = disability_degree
 
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
 
     def test_if_a_has_no_merkzeichen_and_disability_degree_below_80_and_requests_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
         disability_degree = 75
-        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = True
 
-        standard_est_input_data.person_a_disability_degree = disability_degree
+        standard_est_input_data.person_b_disability_degree = disability_degree
 
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
 
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
-        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
 
 
 class TestEstDataPersonBPauschbetrag:
 
-    def test_if_person_b_has_merkzeichen_bl_then_set_correct_field(self, standard_est_input_data):
-        standard_est_input_data.person_b_has_merkzeichen_bl = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_b_has_merkzeichen_bl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
-        standard_est_input_data.person_b_has_merkzeichen_bl = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
-
-    def test_if_person_b_has_merkzeichen_tbl_then_set_correct_field(self, standard_est_input_data):
-        standard_est_input_data.person_b_has_merkzeichen_tbl = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_b_has_merkzeichen_tbl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
-        standard_est_input_data.person_b_has_merkzeichen_tbl = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
-
-    def test_if_person_b_has_merkzeichen_h_then_set_correct_field(self, standard_est_input_data):
-        standard_est_input_data.person_b_has_merkzeichen_h = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_b_has_merkzeichen_h_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
-        standard_est_input_data.person_b_has_merkzeichen_h = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
-
-    def test_if_person_b_has_pflegegrad_then_set_correct_field(self, standard_est_input_data):
+    def test_if_person_b_does_not_request_pauschbetrag_and_has_all_merkzeichen_then_do_not_set_pauschbetrag_fields(self, standard_est_input_data):
+        standard_est_input_data.person_b_requests_pauschbetrag = False
         standard_est_input_data.person_b_has_pflegegrad = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_b_has_pflegegrad_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
-        standard_est_input_data.person_b_has_pflegegrad = True
-        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
-        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
-
-    def test_if_person_b_has_merkzeichen_g_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_bl = True
+        standard_est_input_data.person_b_has_merkzeichen_tbl = True
+        standard_est_input_data.person_b_has_merkzeichen_h = True
         standard_est_input_data.person_b_has_merkzeichen_g = True
+        standard_est_input_data.person_b_has_merkzeichen_ag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is None
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_bl_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_bl = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_bl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_bl = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_tbl_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_tbl = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_tbl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_tbl = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_h_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_h = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_h_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_h = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_b_requests_pauschbetrag_and_has_pflegegrad_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_pflegegrad = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_b_requests_pauschbetrag_and_has_pflegegrad_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_pflegegrad = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_g_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_g = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is True
 
-    def test_if_person_b_has_merkzeichen_g_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_g_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
         standard_est_input_data.person_b_has_merkzeichen_g = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is None
 
-    def test_if_person_b_has_merkzeichen_ag_then_set_correct_field(self, standard_est_input_data):
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_ag_then_set_correct_field(self, standard_est_input_data):
         standard_est_input_data.person_b_has_merkzeichen_ag = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is True
 
-    def test_if_person_b_has_merkzeichen_ag_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_ag_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
         standard_est_input_data.person_b_has_merkzeichen_ag = True
+        standard_est_input_data.person_b_requests_pauschbetrag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is None
 
 
 class TestEstDataDisabilityDegree:
 
+    def test_if_person_a_does_not_request_pauschbetrag_and_has_disability_degree_then_do_not_set_disability_degree(self, standard_est_input_data):
+        standard_est_input_data.person_a_requests_pauschbetrag = False
+        standard_est_input_data.person_a_disability_degree = 80
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_pauschbetrag_disability_degree is None
+
+    def test_if_person_b_does_not_request_pauschbetrag_and_has_disability_degree_then_do_not_set_disability_degree(self, standard_est_input_data):
+        standard_est_input_data.person_b_requests_pauschbetrag = False
+        standard_est_input_data.person_b_disability_degree = 80
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_b_pauschbetrag_disability_degree is None
+
     def test_if_person_a_disability_degree_below_20_then_do_not_set_disability_degree(self, standard_est_input_data):
         standard_est_input_data.person_a_disability_degree = 15
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_a_pauschbetrag_disability_degree is None
 
     def test_if_person_b_disability_degree_below_20_then_do_not_set_disability_degree(self, standard_est_input_data):
         standard_est_input_data.person_b_disability_degree = 15
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_b_pauschbetrag_disability_degree is None
 
     def test_if_person_a_disability_degree_20_then_set_disability_degree(self, standard_est_input_data):
         standard_est_input_data.person_a_disability_degree = 20
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_a_pauschbetrag_disability_degree == 20
 
     def test_if_person_b_disability_degree_20_then_set_disability_degree(self, standard_est_input_data):
         standard_est_input_data.person_b_disability_degree = 20
+        standard_est_input_data.person_a_requests_pauschbetrag = True
+
         resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
         assert resulting_input_data.person_b_pauschbetrag_disability_degree == 20

--- a/erica_app/tests/request_processing/test_eric_mapper.py
+++ b/erica_app/tests/request_processing/test_eric_mapper.py
@@ -1,0 +1,620 @@
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+import pytest
+from pydantic.main import BaseModel
+
+from erica.request_processing.eric_mapper import EstEricMapping
+from erica.request_processing.erica_input import FormDataEst
+
+
+class DummyInput(BaseModel):
+
+    person_a_disability_degree: Optional[int]
+    person_a_has_pflegegrad: Optional[bool]
+    person_a_has_merkzeichen_bl: Optional[bool]
+    person_a_has_merkzeichen_tbl: Optional[bool]
+    person_a_has_merkzeichen_h: Optional[bool]
+    person_a_has_merkzeichen_g: Optional[bool]
+    person_a_has_merkzeichen_ag: Optional[bool]
+    person_a_requests_pauschbetrag: Optional[bool]
+    person_a_requests_fahrkostenpauschale: Optional[bool]
+
+    person_b_disability_degree: Optional[int]
+    person_b_has_pflegegrad: Optional[bool]
+    person_b_has_merkzeichen_bl: Optional[bool]
+    person_b_has_merkzeichen_tbl: Optional[bool]
+    person_b_has_merkzeichen_h: Optional[bool]
+    person_b_has_merkzeichen_g: Optional[bool]
+    person_b_has_merkzeichen_ag: Optional[bool]
+    person_b_requests_pauschbetrag: Optional[bool]
+    person_b_requests_fahrkostenpauschale: Optional[bool]
+
+
+@pytest.fixture
+def standard_est_input_data():
+
+    return FormDataEst(
+            submission_without_tax_nr=True,
+            bufa_nr='9198',
+            bundesland='BY',
+            familienstand='married',
+            familienstand_date=date(2000, 1, 31),
+
+            person_a_idnr='04452397687',
+            person_a_dob=date(1950, 8, 16),
+            person_a_first_name='Manfred',
+            person_a_last_name='Mustername',
+            person_a_street='Steuerweg',
+            person_a_street_number=42,
+            person_a_plz=20354,
+            person_a_town='Hamburg',
+            person_a_religion='none',
+
+            person_b_idnr='02293417683',
+            person_b_dob=date(1951, 2, 25),
+            person_b_first_name='Gerta',
+            person_b_last_name='Mustername',
+            person_b_same_address=True,
+            person_b_religion='rk',
+
+            iban='DE35133713370000012345',
+            account_holder='person_a',
+
+            confirm_complete_correct=True,
+            confirm_send=True
+        )
+
+
+class TestEstDataPersonAFahrkostenPauschale:
+
+    def test_if_person_a_has_pflegegrad_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_pflegegrad = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_pflegegrad_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_pflegegrad = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_bl_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_bl = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_bl_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_bl = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_tbl_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_tbl = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_tbl_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_tbl = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_h_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_h = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_h_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_h = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_ag_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_ag = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_ag_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_ag = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_g_and_disability_degree_70_and_requests_fahrkostenpauschale_then_set_lower_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 70
+        standard_est_input_data.person_a_has_merkzeichen_g = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is True
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+
+    def test_if_person_a_has_merkzeichen_g_and_disability_degree_70_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 70
+        standard_est_input_data.person_a_has_merkzeichen_g = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_g_and_disability_degree_below_70_and_requests_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 65
+        standard_est_input_data.person_a_has_merkzeichen_g = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_a_has_no_merkzeichen_and_disability_degree_80_and_requests_fahrkostenpauschale_then_set_lower_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 80
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is True
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+
+    def test_if_a_has_no_merkzeichen_and_disability_degree_80_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 80
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_a_has_no_merkzeichen_and_disability_degree_below_80_and_requests_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 75
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+
+class TestEstDataPersonAPauschbetrag:
+
+    def test_if_person_a_has_merkzeichen_bl_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_bl = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_a_has_merkzeichen_bl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_bl = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_a_has_merkzeichen_tbl_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_tbl = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_a_has_merkzeichen_tbl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_tbl = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_a_has_merkzeichen_h_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_h = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_a_has_merkzeichen_h_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_h = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_a_has_pflegegrad_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_pflegegrad = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_a_has_pflegegrad_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_pflegegrad = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_a_has_merkzeichen_g_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_g = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is True
+
+    def test_if_person_a_has_merkzeichen_g_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_g = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is None
+
+    def test_if_person_a_has_merkzeichen_ag_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_ag = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_g_ag is True
+
+    def test_if_person_a_has_merkzeichen_ag_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_a_has_merkzeichen_ag = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is None
+
+
+class TestEstDataPersonBFahrkostenPauschale:
+
+    def test_if_person_b_has_pflegegrad_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_b_has_pflegegrad = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = True
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_b_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_b_has_pflegegrad_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_b_has_pflegegrad = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = False
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_b_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_b_has_merkzeichen_bl_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_b_has_merkzeichen_bl = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = True
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_b_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_b_has_merkzeichen_bl_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_b_has_merkzeichen_bl = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = False
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_b_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_b_has_merkzeichen_tbl_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_b_has_merkzeichen_tbl = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = True
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_b_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_b_has_merkzeichen_tbl_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_b_has_merkzeichen_tbl = True
+        standard_est_input_data.person_b_requests_fahrkostenpauschale = False
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_b_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_b_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_b_has_merkzeichen_h_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_h = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_h_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_h = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_ag_and_requests_fahrkostenpauschale_then_set_higher_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_ag = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is True
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_ag_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale_for_all_disability_degrees(self, standard_est_input_data):
+        disability_degrees = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100]
+        standard_est_input_data.person_a_has_merkzeichen_ag = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+
+        for disability_degree in disability_degrees:
+            standard_est_input_data.person_a_disability_degree = disability_degree
+
+            resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+            assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_g_and_disability_degree_70_and_requests_fahrkostenpauschale_then_set_lower_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 70
+        standard_est_input_data.person_a_has_merkzeichen_g = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is True
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+
+    def test_if_person_a_has_merkzeichen_g_and_disability_degree_70_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 70
+        standard_est_input_data.person_a_has_merkzeichen_g = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_person_a_has_merkzeichen_g_and_disability_degree_below_70_and_requests_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 65
+        standard_est_input_data.person_a_has_merkzeichen_g = True
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_a_has_no_merkzeichen_and_disability_degree_80_and_requests_fahrkostenpauschale_then_set_lower_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 80
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is True
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_bl_tbl_h_ag_pflegegrad is None
+
+    def test_if_a_has_no_merkzeichen_and_disability_degree_80_and_does_not_want_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 80
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = False
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+    def test_if_a_has_no_merkzeichen_and_disability_degree_below_80_and_requests_fahrkostenpauschale_then_set_no_fahrkostenpauschale(self, standard_est_input_data):
+        disability_degree = 75
+        standard_est_input_data.person_a_requests_fahrkostenpauschale = True
+
+        standard_est_input_data.person_a_disability_degree = disability_degree
+
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+        assert resulting_input_data.person_a_fahrkostenpauschale_has_merkzeichen_g_and_degree_70_degree_80 is None
+
+
+class TestEstDataPersonBPauschbetrag:
+
+    def test_if_person_b_has_merkzeichen_bl_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_bl = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_b_has_merkzeichen_bl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_bl = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_b_has_merkzeichen_tbl_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_tbl = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_b_has_merkzeichen_tbl_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_tbl = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_b_has_merkzeichen_h_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_h = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_b_has_merkzeichen_h_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_h = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_b_has_pflegegrad_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_pflegegrad = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is True
+
+    def test_if_person_b_has_pflegegrad_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_pflegegrad = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is None
+
+    def test_if_person_b_has_merkzeichen_g_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_g = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is True
+
+    def test_if_person_b_has_merkzeichen_g_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_g = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is None
+
+    def test_if_person_b_has_merkzeichen_ag_then_set_correct_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_ag = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_g_ag is True
+
+    def test_if_person_b_has_merkzeichen_ag_then_do_not_set_other_merkzeichen_field(self, standard_est_input_data):
+        standard_est_input_data.person_b_has_merkzeichen_ag = True
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_has_merkzeichen_bl_tbl_h_pflegegrad is None
+
+
+class TestEstDataDisabilityDegree:
+
+    def test_if_person_a_disability_degree_below_20_then_do_not_set_disability_degree(self, standard_est_input_data):
+        standard_est_input_data.person_a_disability_degree = 15
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_disability_degree is None
+
+    def test_if_person_b_disability_degree_below_20_then_do_not_set_disability_degree(self, standard_est_input_data):
+        standard_est_input_data.person_b_disability_degree = 15
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_disability_degree is None
+
+    def test_if_person_a_disability_degree_20_then_set_disability_degree(self, standard_est_input_data):
+        standard_est_input_data.person_a_disability_degree = 20
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_a_pauschbetrag_disability_degree == 20
+
+    def test_if_person_b_disability_degree_20_then_set_disability_degree(self, standard_est_input_data):
+        standard_est_input_data.person_b_disability_degree = 20
+        resulting_input_data = EstEricMapping.parse_obj(standard_est_input_data)
+        assert resulting_input_data.person_b_pauschbetrag_disability_degree == 20

--- a/erica_app/tests/request_processing/test_erica_input.py
+++ b/erica_app/tests/request_processing/test_erica_input.py
@@ -353,110 +353,25 @@ class TestFormDataEstPersonAFahrkostenpauschale:
         with pytest.raises(ValidationError):
             FormDataEst.parse_obj(standard_est_data)
 
-    def test_if_person_a_requests_fahrkostenpauschale_and_disability_degree_set_then_raise_no_validation_error(self, standard_est_data):
+    def test_if_person_a_requests_fahrkostenpauschale_and_any_merkzeichen_set_then_raise_no_validation_error(self, standard_est_data):
         standard_est_data['person_a_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_a_disability_degree'] = 25
-        standard_est_data['person_a_has_pflegegrad'] = None
-        standard_est_data['person_a_has_merkzeichen_bl'] = None
-        standard_est_data['person_a_has_merkzeichen_tbl'] = None
-        standard_est_data['person_a_has_merkzeichen_h'] = None
-        standard_est_data['person_a_has_merkzeichen_g'] = None
-        standard_est_data['person_a_has_merkzeichen_ag'] = None
 
-        try:
+        merkzeichen_keys = ['person_a_disability_degree', 'person_a_has_pflegegrad', 'person_a_has_merkzeichen_bl',
+                         'person_a_has_merkzeichen_tbl', 'person_a_has_merkzeichen_h', 'person_a_has_merkzeichen_g',
+                         'person_a_has_merkzeichen_ag']
+
+        for merkzeichen_key in merkzeichen_keys:
+            standard_est_data['person_a_disability_degree'] = None
+            standard_est_data['person_a_has_pflegegrad'] = None
+            standard_est_data['person_a_has_merkzeichen_bl'] = None
+            standard_est_data['person_a_has_merkzeichen_tbl'] = None
+            standard_est_data['person_a_has_merkzeichen_h'] = None
+            standard_est_data['person_a_has_merkzeichen_g'] = None
+            standard_est_data['person_a_has_merkzeichen_ag'] = None
+
+            standard_est_data[merkzeichen_key] = True
+
             FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_a_requests_fahrkostenpauschale_and_has_pflegegrad_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_a_disability_degree'] = None
-        standard_est_data['person_a_has_pflegegrad'] = True
-        standard_est_data['person_a_has_merkzeichen_bl'] = None
-        standard_est_data['person_a_has_merkzeichen_tbl'] = None
-        standard_est_data['person_a_has_merkzeichen_h'] = None
-        standard_est_data['person_a_has_merkzeichen_g'] = None
-        standard_est_data['person_a_has_merkzeichen_ag'] = None
-
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_a_requests_fahrkostenpauschale_and_has_merkzeichen_bl_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_a_disability_degree'] = None
-        standard_est_data['person_a_has_pflegegrad'] = None
-        standard_est_data['person_a_has_merkzeichen_bl'] = True
-        standard_est_data['person_a_has_merkzeichen_tbl'] = None
-        standard_est_data['person_a_has_merkzeichen_h'] = None
-        standard_est_data['person_a_has_merkzeichen_g'] = None
-        standard_est_data['person_a_has_merkzeichen_ag'] = None
-
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_a_requests_fahrkostenpauschale_and_has_merkzeichen_tbl_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_a_disability_degree'] = None
-        standard_est_data['person_a_has_pflegegrad'] = None
-        standard_est_data['person_a_has_merkzeichen_bl'] = None
-        standard_est_data['person_a_has_merkzeichen_tbl'] = True
-        standard_est_data['person_a_has_merkzeichen_h'] = None
-        standard_est_data['person_a_has_merkzeichen_g'] = None
-        standard_est_data['person_a_has_merkzeichen_ag'] = None
-
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_a_requests_fahrkostenpauschale_and_has_merkzeichen_h_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_a_disability_degree'] = None
-        standard_est_data['person_a_has_pflegegrad'] = None
-        standard_est_data['person_a_has_merkzeichen_bl'] = None
-        standard_est_data['person_a_has_merkzeichen_tbl'] = None
-        standard_est_data['person_a_has_merkzeichen_h'] = True
-        standard_est_data['person_a_has_merkzeichen_g'] = None
-        standard_est_data['person_a_has_merkzeichen_ag'] = None
-
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_a_requests_fahrkostenpauschale_and_has_merkzeichen_g_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_a_disability_degree'] = None
-        standard_est_data['person_a_has_pflegegrad'] = None
-        standard_est_data['person_a_has_merkzeichen_bl'] = None
-        standard_est_data['person_a_has_merkzeichen_tbl'] = None
-        standard_est_data['person_a_has_merkzeichen_h'] = None
-        standard_est_data['person_a_has_merkzeichen_g'] = True
-        standard_est_data['person_a_has_merkzeichen_ag'] = None
-
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_a_requests_fahrkostenpauschale_and_has_merkzeichen_ag_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_a_disability_degree'] = None
-        standard_est_data['person_a_has_pflegegrad'] = None
-        standard_est_data['person_a_has_merkzeichen_bl'] = None
-        standard_est_data['person_a_has_merkzeichen_tbl'] = None
-        standard_est_data['person_a_has_merkzeichen_h'] = None
-        standard_est_data['person_a_has_merkzeichen_g'] = None
-        standard_est_data['person_a_has_merkzeichen_ag'] = True
-
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
 
 class TestFormDataEstPersonBPauschbetrag:
@@ -595,107 +510,25 @@ class TestFormDataEstPersonBFahrkostenpauschale:
         with pytest.raises(ValidationError):
             FormDataEst.parse_obj(standard_est_data)
 
-    def test_if_person_b_requests_fahrkostenpauschale_and_disability_degree_set_then_raise_no_validation_error(self, standard_est_data):
+    def test_if_person_b_requests_fahrkostenpauschale_and_any_merkzeichen_set_then_raise_no_validation_error(self, standard_est_data):
         standard_est_data['person_b_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_b_disability_degree'] = 25
-        standard_est_data['person_b_has_pflegegrad'] = None
-        standard_est_data['person_b_has_merkzeichen_bl'] = None
-        standard_est_data['person_b_has_merkzeichen_tbl'] = None
-        standard_est_data['person_b_has_merkzeichen_h'] = None
-        standard_est_data['person_b_has_merkzeichen_g'] = None
-        standard_est_data['person_b_has_merkzeichen_ag'] = None
 
-        try:
+        merkzeichen_keys = ['person_b_disability_degree', 'person_b_has_pflegegrad', 'person_b_has_merkzeichen_bl',
+                         'person_b_has_merkzeichen_tbl', 'person_b_has_merkzeichen_h', 'person_b_has_merkzeichen_g',
+                         'person_b_has_merkzeichen_ag']
+
+        for merkzeichen_key in merkzeichen_keys:
+            standard_est_data['person_b_disability_degree'] = None
+            standard_est_data['person_b_has_pflegegrad'] = None
+            standard_est_data['person_b_has_merkzeichen_bl'] = None
+            standard_est_data['person_b_has_merkzeichen_tbl'] = None
+            standard_est_data['person_b_has_merkzeichen_h'] = None
+            standard_est_data['person_b_has_merkzeichen_g'] = None
+            standard_est_data['person_b_has_merkzeichen_ag'] = None
+
+            standard_est_data[merkzeichen_key] = True
+
             FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_b_requests_fahrkostenpauschale_and_has_pflegegrad_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_b_disability_degree'] = None
-        standard_est_data['person_b_has_pflegegrad'] = True
-        standard_est_data['person_b_has_merkzeichen_bl'] = None
-        standard_est_data['person_b_has_merkzeichen_tbl'] = None
-        standard_est_data['person_b_has_merkzeichen_h'] = None
-        standard_est_data['person_b_has_merkzeichen_g'] = None
-        standard_est_data['person_b_has_merkzeichen_ag'] = None
-
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_b_requests_fahrkostenpauschale_and_has_merkzeichen_bl_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_b_disability_degree'] = None
-        standard_est_data['person_b_has_pflegegrad'] = None
-        standard_est_data['person_b_has_merkzeichen_bl'] = True
-        standard_est_data['person_b_has_merkzeichen_tbl'] = None
-        standard_est_data['person_b_has_merkzeichen_h'] = None
-        standard_est_data['person_b_has_merkzeichen_g'] = None
-        standard_est_data['person_b_has_merkzeichen_ag'] = None
-
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_b_requests_fahrkostenpauschale_and_has_merkzeichen_tbl_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_b_disability_degree'] = None
-        standard_est_data['person_b_has_pflegegrad'] = None
-        standard_est_data['person_b_has_merkzeichen_bl'] = None
-        standard_est_data['person_b_has_merkzeichen_tbl'] = True
-        standard_est_data['person_b_has_merkzeichen_h'] = None
-        standard_est_data['person_b_has_merkzeichen_g'] = None
-        standard_est_data['person_b_has_merkzeichen_ag'] = None
-
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_b_requests_fahrkostenpauschale_and_has_merkzeichen_h_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_b_disability_degree'] = None
-        standard_est_data['person_b_has_pflegegrad'] = None
-        standard_est_data['person_b_has_merkzeichen_bl'] = None
-        standard_est_data['person_b_has_merkzeichen_tbl'] = None
-        standard_est_data['person_b_has_merkzeichen_h'] = True
-        standard_est_data['person_b_has_merkzeichen_g'] = None
-        standard_est_data['person_b_has_merkzeichen_ag'] = None
-
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_b_requests_fahrkostenpauschale_and_has_merkzeichen_g_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_b_disability_degree'] = None
-        standard_est_data['person_b_has_pflegegrad'] = None
-        standard_est_data['person_b_has_merkzeichen_bl'] = None
-        standard_est_data['person_b_has_merkzeichen_tbl'] = None
-        standard_est_data['person_b_has_merkzeichen_h'] = None
-        standard_est_data['person_b_has_merkzeichen_g'] = True
-        standard_est_data['person_b_has_merkzeichen_ag'] = None
-
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
-
-    def test_if_person_b_requests_fahrkostenpauschale_and_has_merkzeichen_ag_set_then_raise_no_validation_error(self, standard_est_data):
-        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
-        standard_est_data['person_b_disability_degree'] = None
-        standard_est_data['person_b_has_pflegegrad'] = None
-        standard_est_data['person_b_has_merkzeichen_bl'] = None
-        standard_est_data['person_b_has_merkzeichen_tbl'] = None
-        standard_est_data['person_b_has_merkzeichen_h'] = None
-        standard_est_data['person_b_has_merkzeichen_g'] = None
-        standard_est_data['person_b_has_merkzeichen_ag'] = True
-
-        FormDataEst.parse_obj(standard_est_data)
 
 
 class TestMetaDataYear:

--- a/erica_app/tests/request_processing/test_erica_input.py
+++ b/erica_app/tests/request_processing/test_erica_input.py
@@ -695,10 +695,7 @@ class TestFormDataEstPersonBFahrkostenpauschale:
         standard_est_data['person_b_has_merkzeichen_g'] = None
         standard_est_data['person_b_has_merkzeichen_ag'] = True
 
-        try:
-            FormDataEst.parse_obj(standard_est_data)
-        except ValidationError as e:
-            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+        FormDataEst.parse_obj(standard_est_data)
 
 
 class TestMetaDataYear:

--- a/erica_app/tests/request_processing/test_erica_input.py
+++ b/erica_app/tests/request_processing/test_erica_input.py
@@ -217,214 +217,488 @@ class TestFormDataEstFamilienstand:
             pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
 
-class TestFormDataPersonAMerkzeichen:
+class TestFormDataEstPersonAPauschbetrag:
 
-    def test_if_person_a_has_merkzeichen_bl_no_boolean_then_raise_validation_error(self, standard_est_data):
-        standard_est_data['person_a_has_merkzeichen_bl'] = 'yes'
-
-        with pytest.raises(ValidationError):
-            FormDataEst.parse_obj(standard_est_data)
-
-    def test_if_person_a_has_merkzeichen_tbl_no_boolean_then_raise_validation_error(self, standard_est_data):
-        standard_est_data['person_a_has_merkzeichen_tbl'] = 'yes'
-
-        with pytest.raises(ValidationError):
-            FormDataEst.parse_obj(standard_est_data)
-
-    def test_if_person_a_has_merkzeichen_h_no_boolean_then_raise_validation_error(self, standard_est_data):
-        standard_est_data['person_a_has_merkzeichen_h'] = 'yes'
+    def test_if_person_a_requests_pauschbetrag_and_no_disability_information_set_then_raise_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_pauschbetrag'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
 
         with pytest.raises(ValidationError):
             FormDataEst.parse_obj(standard_est_data)
 
-    def test_if_person_a_has_merkzeichen_ag_no_boolean_then_raise_validation_error(self, standard_est_data):
-        standard_est_data['person_a_has_merkzeichen_ag'] = 'yes'
+    def test_if_person_a_requests_pauschbetrag_and_disability_degree_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_pauschbetrag'] = True
+        standard_est_data['person_a_disability_degree'] = 25
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
 
-        with pytest.raises(ValidationError):
+        try:
             FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-    def test_if_person_a_has_pflegegrad_no_boolean_then_raise_validation_error(self, standard_est_data):
-        standard_est_data['person_a_has_pflegegrad'] = 'yes'
-
-        with pytest.raises(ValidationError):
-            FormDataEst.parse_obj(standard_est_data)
-
-    def test_if_person_a_has_merkzeichen_bl_then_set_correct_field(self, standard_est_data):
-        standard_est_data['person_a_has_merkzeichen_bl'] = True
-
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-
-        assert resulting_input_data.person_a_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_a_has_merkzeichen_bl_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
-        standard_est_data['person_a_has_merkzeichen_bl'] = True
-
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-
-        assert resulting_input_data.person_a_has_merkzeichen_g_ag is None
-
-    def test_if_person_a_has_merkzeichen_tbl_then_set_correct_field(self, standard_est_data):
-        standard_est_data['person_a_has_merkzeichen_tbl'] = True
-
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-
-        assert resulting_input_data.person_a_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_a_has_merkzeichen_tbl_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
-        standard_est_data['person_a_has_merkzeichen_tbl'] = True
-
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-
-        assert resulting_input_data.person_a_has_merkzeichen_g_ag is None
-
-    def test_if_person_a_has_merkzeichen_h_then_set_correct_field(self, standard_est_data):
-        standard_est_data['person_a_has_merkzeichen_h'] = True
-
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-
-        assert resulting_input_data.person_a_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_a_has_merkzeichen_h_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
-        standard_est_data['person_a_has_merkzeichen_h'] = True
-
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-
-        assert resulting_input_data.person_a_has_merkzeichen_g_ag is None
-
-    def test_if_person_a_has_pflegegrad_then_set_correct_field(self, standard_est_data):
+    def test_if_person_a_requests_pauschbetrag_and_has_pflegegrad_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_pauschbetrag'] = True
+        standard_est_data['person_a_disability_degree'] = None
         standard_est_data['person_a_has_pflegegrad'] = True
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
 
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-        assert resulting_input_data.person_a_has_merkzeichen_bl_tbl_h_pflegegrad is True
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_bl_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_pauschbetrag'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = True
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
 
-    def test_if_person_a_has_pflegegrad_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
-        standard_est_data['person_a_has_pflegegrad'] = True
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_tbl_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_pauschbetrag'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = True
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
 
-        assert resulting_input_data.person_a_has_merkzeichen_g_ag is None
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-    def test_if_person_a_has_merkzeichen_g_then_set_correct_field(self, standard_est_data):
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_h_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_pauschbetrag'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = True
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_g_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_pauschbetrag'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
         standard_est_data['person_a_has_merkzeichen_g'] = True
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
 
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-        assert resulting_input_data.person_a_has_merkzeichen_g_ag is True
-
-    def test_if_person_a_has_merkzeichen_g_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
-        standard_est_data['person_a_has_merkzeichen_g'] = True
-
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-
-        assert resulting_input_data.person_a_has_merkzeichen_bl_tbl_h_pflegegrad is None
-
-    def test_if_person_a_has_merkzeichen_ag_then_set_correct_field(self, standard_est_data):
+    def test_if_person_a_requests_pauschbetrag_and_has_merkzeichen_ag_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_pauschbetrag'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
         standard_est_data['person_a_has_merkzeichen_ag'] = True
 
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-        assert resulting_input_data.person_a_has_merkzeichen_g_ag is True
 
-    def test_if_person_a_has_merkzeichen_ag_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
+class TestFormDataEstPersonAFahrkostenpauschale:
+
+    def test_if_person_a_requests_fahrkostenpauschale_and_no_disability_information_set_then_raise_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
+
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
+
+    def test_if_person_a_requests_fahrkostenpauschale_and_disability_degree_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_a_disability_degree'] = 25
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_a_requests_fahrkostenpauschale_and_has_pflegegrad_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = True
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_a_requests_fahrkostenpauschale_and_has_merkzeichen_bl_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = True
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_a_requests_fahrkostenpauschale_and_has_merkzeichen_tbl_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = True
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_a_requests_fahrkostenpauschale_and_has_merkzeichen_h_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = True
+        standard_est_data['person_a_has_merkzeichen_g'] = None
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_a_requests_fahrkostenpauschale_and_has_merkzeichen_g_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = True
+        standard_est_data['person_a_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_a_requests_fahrkostenpauschale_and_has_merkzeichen_ag_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_a_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_a_disability_degree'] = None
+        standard_est_data['person_a_has_pflegegrad'] = None
+        standard_est_data['person_a_has_merkzeichen_bl'] = None
+        standard_est_data['person_a_has_merkzeichen_tbl'] = None
+        standard_est_data['person_a_has_merkzeichen_h'] = None
+        standard_est_data['person_a_has_merkzeichen_g'] = None
         standard_est_data['person_a_has_merkzeichen_ag'] = True
 
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-        assert resulting_input_data.person_a_has_merkzeichen_bl_tbl_h_pflegegrad is None
 
+class TestFormDataEstPersonBPauschbetrag:
 
-class TestFormDataPersonBMerkzeichen:
-
-    def test_if_person_b_has_merkzeichen_bl_no_boolean_then_raise_validation_error(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_bl'] = 'yes'
+    def test_if_person_b_requests_pauschbetrag_and_no_disability_information_set_then_raise_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_pauschbetrag'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
 
         with pytest.raises(ValidationError):
             FormDataEst.parse_obj(standard_est_data)
 
-    def test_if_person_b_has_merkzeichen_tbl_no_boolean_then_raise_validation_error(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_tbl'] = 'yes'
+    def test_if_person_b_requests_pauschbetrag_and_disability_degree_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_pauschbetrag'] = True
+        standard_est_data['person_b_disability_degree'] = 25
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
 
-        with pytest.raises(ValidationError):
+        try:
             FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-    def test_if_person_b_has_merkzeichen_h_no_boolean_then_raise_validation_error(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_h'] = 'yes'
-
-        with pytest.raises(ValidationError):
-            FormDataEst.parse_obj(standard_est_data)
-
-    def test_if_person_b_has_merkzeichen_ag_no_boolean_then_raise_validation_error(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_ag'] = 'yes'
-
-        with pytest.raises(ValidationError):
-            FormDataEst.parse_obj(standard_est_data)
-
-    def test_if_person_b_has_pflegegrad_no_boolean_then_raise_validation_error(self, standard_est_data):
-        standard_est_data['person_b_has_pflegegrad'] = 'yes'
-
-        with pytest.raises(ValidationError):
-            FormDataEst.parse_obj(standard_est_data)
-
-    def test_if_person_b_has_merkzeichen_bl_then_set_correct_field(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_bl'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_b_has_merkzeichen_bl_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_bl'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_g_ag is None
-
-    def test_if_person_b_has_merkzeichen_tbl_then_set_correct_field(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_tbl'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_b_has_merkzeichen_tbl_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_tbl'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_g_ag is None
-
-    def test_if_person_b_has_merkzeichen_h_then_set_correct_field(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_h'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_bl_tbl_h_pflegegrad is True
-
-    def test_if_person_b_has_merkzeichen_h_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_h'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_g_ag is None
-
-    def test_if_person_b_has_pflegegrad_then_set_correct_field(self, standard_est_data):
+    def test_if_person_b_requests_pauschbetrag_and_has_pflegegrad_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_pauschbetrag'] = True
+        standard_est_data['person_b_disability_degree'] = None
         standard_est_data['person_b_has_pflegegrad'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_bl_tbl_h_pflegegrad is True
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
 
-    def test_if_person_b_has_pflegegrad_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_bl_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_pauschbetrag'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = True
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_tbl_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_pauschbetrag'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = True
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_h_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_pauschbetrag'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = True
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_g_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_pauschbetrag'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = True
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_b_requests_pauschbetrag_and_has_merkzeichen_ag_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_pauschbetrag'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = True
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+
+class TestFormDataEstPersonBFahrkostenpauschale:
+
+    def test_if_person_b_requests_fahrkostenpauschale_and_no_disability_information_set_then_raise_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
+
+        with pytest.raises(ValidationError):
+            FormDataEst.parse_obj(standard_est_data)
+
+    def test_if_person_b_requests_fahrkostenpauschale_and_disability_degree_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_b_disability_degree'] = 25
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_b_requests_fahrkostenpauschale_and_has_pflegegrad_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_b_disability_degree'] = None
         standard_est_data['person_b_has_pflegegrad'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_g_ag is None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
 
-    def test_if_person_b_has_merkzeichen_g_then_set_correct_field(self, standard_est_data):
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_b_requests_fahrkostenpauschale_and_has_merkzeichen_bl_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = True
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_b_requests_fahrkostenpauschale_and_has_merkzeichen_tbl_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = True
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_b_requests_fahrkostenpauschale_and_has_merkzeichen_h_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = True
+        standard_est_data['person_b_has_merkzeichen_g'] = None
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
+
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
+
+    def test_if_person_b_requests_fahrkostenpauschale_and_has_merkzeichen_g_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
         standard_est_data['person_b_has_merkzeichen_g'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_g_ag is True
+        standard_est_data['person_b_has_merkzeichen_ag'] = None
 
-    def test_if_person_b_has_merkzeichen_g_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_g'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_bl_tbl_h_pflegegrad is None
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
-    def test_if_person_b_has_merkzeichen_ag_then_set_correct_field(self, standard_est_data):
+    def test_if_person_b_requests_fahrkostenpauschale_and_has_merkzeichen_ag_set_then_raise_no_validation_error(self, standard_est_data):
+        standard_est_data['person_b_requests_fahrkostenpauschale'] = True
+        standard_est_data['person_b_disability_degree'] = None
+        standard_est_data['person_b_has_pflegegrad'] = None
+        standard_est_data['person_b_has_merkzeichen_bl'] = None
+        standard_est_data['person_b_has_merkzeichen_tbl'] = None
+        standard_est_data['person_b_has_merkzeichen_h'] = None
+        standard_est_data['person_b_has_merkzeichen_g'] = None
         standard_est_data['person_b_has_merkzeichen_ag'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_g_ag is True
 
-    def test_if_person_b_has_merkzeichen_ag_then_do_not_set_other_merkzeichen_field(self, standard_est_data):
-        standard_est_data['person_b_has_merkzeichen_ag'] = True
-        resulting_input_data = FormDataEst.parse_obj(standard_est_data)
-        assert resulting_input_data.person_b_has_merkzeichen_bl_tbl_h_pflegegrad is None
+        try:
+            FormDataEst.parse_obj(standard_est_data)
+        except ValidationError as e:
+            pytest.fail("parse_obj failed with unexpected ValidationError " + str(e))
 
 
 class TestMetaDataYear:

--- a/erica_app/tests/request_processing/test_requests_controller.py
+++ b/erica_app/tests/request_processing/test_requests_controller.py
@@ -112,9 +112,7 @@ class TestEstRequestProcess(unittest.TestCase):
         correct_est = create_est(correct_form_data=True)
         correct_est.est_data.person_a_idnr = SPECIAL_TESTMERKER_IDNR
 
-        with patch('erica.request_processing.requests_controller.EstValidationRequestController._reformat_date',
-                   MagicMock(side_effect=lambda _: _)), \
-                patch('erica.elster_xml.elster_xml_generator.generate_full_est_xml') as generate_xml_fun, \
+        with patch('erica.elster_xml.elster_xml_generator.generate_full_est_xml') as generate_xml_fun, \
                 patch('erica.pyeric.pyeric_controller.EstPyericProcessController.get_eric_response'), \
                 patch('erica.request_processing.requests_controller.EstRequestController.generate_json'):
             est_request = EstRequestController(correct_est)
@@ -127,9 +125,7 @@ class TestEstRequestProcess(unittest.TestCase):
         correct_est = create_est(correct_form_data=True)
         correct_est.est_data.person_a_idnr = '02293417683'
 
-        with patch('erica.request_processing.requests_controller.EstValidationRequestController._reformat_date',
-                   MagicMock(side_effect=lambda _: _)), \
-                patch('erica.elster_xml.elster_xml_generator.generate_full_est_xml') as generate_xml_fun, \
+        with patch('erica.elster_xml.elster_xml_generator.generate_full_est_xml') as generate_xml_fun, \
                 patch('erica.pyeric.pyeric_controller.EstPyericProcessController.get_eric_response'), \
                 patch('erica.request_processing.requests_controller.EstRequestController.generate_json'):
             est_request = EstRequestController(correct_est)
@@ -142,9 +138,7 @@ class TestEstRequestProcess(unittest.TestCase):
         correct_est = create_est(correct_form_data=True, with_tax_number=False)
         correct_est.est_data.bufa_nr = empfaenger
 
-        with patch('erica.request_processing.requests_controller.EstValidationRequestController._reformat_date',
-                   MagicMock(side_effect=lambda _: _)), \
-                patch('erica.request_processing.requests_controller.generate_vorsatz_without_tax_number') as generate_vorsatz_without_tax_number, \
+        with patch('erica.request_processing.requests_controller.generate_vorsatz_without_tax_number') as generate_vorsatz_without_tax_number, \
                 patch('erica.elster_xml.elster_xml_generator.generate_full_est_xml') as generate_xml_fun, \
                 patch('erica.pyeric.pyeric_controller.EstPyericProcessController.get_eric_response'), \
                 patch('erica.request_processing.requests_controller.EstRequestController.generate_json'):
@@ -299,9 +293,7 @@ class TestUnlockCodeRequestProcess(unittest.TestCase):
             pyeric_controller_get_response.assert_called()
 
     def test_if_special_idnr_then_create_xml_is_called_with_use_testmerker_set_true(self):
-        with patch('erica.request_processing.requests_controller.EricaRequestController._reformat_date',
-                   MagicMock(side_effect=lambda _: _)), \
-                patch('erica.elster_xml.elster_xml_generator.generate_full_vast_request_xml') as generate_xml_fun, \
+        with patch('erica.elster_xml.elster_xml_generator.generate_full_vast_request_xml') as generate_xml_fun, \
                 patch('erica.pyeric.pyeric_controller.UnlockCodeRequestPyericProcessController.get_eric_response'), \
                 patch('erica.request_processing.requests_controller.UnlockCodeRequestController.generate_json'):
             self.unlock_request_with_valid_input_with_special_idnr.process()
@@ -309,9 +301,7 @@ class TestUnlockCodeRequestProcess(unittest.TestCase):
             self.assertTrue(generate_xml_fun.call_args.kwargs['use_testmerker'])
 
     def test_if_not_special_idnr_then_create_xml_is_called_with_use_testmerker_set_false(self):
-        with patch('erica.request_processing.requests_controller.EricaRequestController._reformat_date',
-                   MagicMock(side_effect=lambda _: _)), \
-                patch('erica.elster_xml.elster_xml_generator.generate_full_vast_request_xml') as generate_xml_fun, \
+        with patch('erica.elster_xml.elster_xml_generator.generate_full_vast_request_xml') as generate_xml_fun, \
                 patch('erica.pyeric.pyeric_controller.UnlockCodeRequestPyericProcessController.get_eric_response'), \
                 patch('erica.request_processing.requests_controller.UnlockCodeRequestController.generate_json'):
             self.unlock_request_with_valid_input.process()
@@ -460,9 +450,7 @@ class TestUnlockCodeActivationProcess(unittest.TestCase):
             pyeric_controller_get_response.assert_called()
 
     def test_if_special_idnr_then_create_xml_is_called_with_use_testmerker_set_true(self):
-        with patch('erica.request_processing.requests_controller.EricaRequestController._reformat_date',
-                   MagicMock(side_effect=lambda _: _)), \
-                patch('erica.elster_xml.elster_xml_generator.generate_full_vast_activation_xml') as generate_xml_fun, \
+        with patch('erica.elster_xml.elster_xml_generator.generate_full_vast_activation_xml') as generate_xml_fun, \
                 patch('erica.pyeric.pyeric_controller.UnlockCodeActivationPyericProcessController.get_eric_response'), \
                 patch(
                     'erica.request_processing.requests_controller.UnlockCodeActivationRequestController.generate_json'):
@@ -471,9 +459,7 @@ class TestUnlockCodeActivationProcess(unittest.TestCase):
             self.assertTrue(generate_xml_fun.call_args.kwargs['use_testmerker'])
 
     def test_if_not_special_idnr_then_create_xml_is_called_with_use_testmerker_set_false(self):
-        with patch('erica.request_processing.requests_controller.EricaRequestController._reformat_date',
-                   MagicMock(side_effect=lambda _: _)), \
-                patch('erica.elster_xml.elster_xml_generator.generate_full_vast_activation_xml') as generate_xml_fun, \
+        with patch('erica.elster_xml.elster_xml_generator.generate_full_vast_activation_xml') as generate_xml_fun, \
                 patch('erica.pyeric.pyeric_controller.UnlockCodeActivationPyericProcessController.get_eric_response'), \
                 patch(
                     'erica.request_processing.requests_controller.UnlockCodeActivationRequestController.generate_json'):
@@ -595,9 +581,7 @@ class TestUnlockCodeRevocationProcess(unittest.TestCase):
             pyeric_controller_get_response.assert_called()
 
     def test_if_special_idnr_then_create_xml_is_called_with_use_testmerker_set_true(self):
-        with patch('erica.request_processing.requests_controller.EricaRequestController._reformat_date',
-                   MagicMock(side_effect=lambda _: _)), \
-                patch('erica.elster_xml.elster_xml_generator.generate_full_vast_revocation_xml') as generate_xml_fun, \
+        with patch('erica.elster_xml.elster_xml_generator.generate_full_vast_revocation_xml') as generate_xml_fun, \
                 patch('erica.pyeric.pyeric_controller.UnlockCodeRevocationPyericProcessController.get_eric_response'), \
                 patch(
                     'erica.request_processing.requests_controller.UnlockCodeRevocationRequestController.generate_json'):
@@ -606,9 +590,7 @@ class TestUnlockCodeRevocationProcess(unittest.TestCase):
             self.assertTrue(generate_xml_fun.call_args.kwargs['use_testmerker'])
 
     def test_if_not_special_idnr_then_create_xml_is_called_with_use_testmerker_set_false(self):
-        with patch('erica.request_processing.requests_controller.EricaRequestController._reformat_date',
-                   MagicMock(side_effect=lambda _: _)), \
-                patch('erica.elster_xml.elster_xml_generator.generate_full_vast_revocation_xml') as generate_xml_fun, \
+        with patch('erica.elster_xml.elster_xml_generator.generate_full_vast_revocation_xml') as generate_xml_fun, \
                 patch('erica.pyeric.pyeric_controller.UnlockCodeRevocationPyericProcessController.get_eric_response'), \
                 patch(
                     'erica.request_processing.requests_controller.UnlockCodeRevocationRequestController.generate_json'):

--- a/erica_app/tests/request_processing/test_requests_controller.py
+++ b/erica_app/tests/request_processing/test_requests_controller.py
@@ -1,11 +1,12 @@
 import unittest
 from datetime import date
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 import pytest
 
 from erica.pyeric.eric_errors import InvalidBufaNumberError
 from erica.pyeric.pyeric_response import PyericResponse
+from erica.request_processing.eric_mapper import EstEricMapping
 from erica.request_processing.erica_input import UnlockCodeRequestData, UnlockCodeActivationData, \
     UnlockCodeRevocationData, GetAddressData
 from erica.request_processing.requests_controller import UnlockCodeRequestController, \
@@ -52,21 +53,6 @@ class TestEstValidationRequestProcess(unittest.TestCase):
 
 class TestEstRequestInit(unittest.TestCase):
 
-    def test_if_dates_given_then_set_as_string_with_correct_format(self):
-        input_data = create_est(correct_form_data=True)
-        correct_format_dates = [input_data.est_data.person_a_dob.strftime("%d.%m.%Y"),
-                                input_data.est_data.person_b_dob.strftime("%d.%m.%Y"),
-                                input_data.est_data.familienstand_date.strftime("%d.%m.%Y")]
-
-        created_request = EstRequestController(create_est(correct_form_data=True))
-
-        actual_dates = [created_request.input_data.est_data.person_a_dob,
-                        created_request.input_data.est_data.person_b_dob,
-                        created_request.input_data.est_data.familienstand_date]
-
-        for expected_date, actual_date in zip(correct_format_dates, actual_dates):
-            self.assertEqual(expected_date, actual_date)
-
     def test_if_no_include_param_given_then_set_include_false(self):
         created_request = EstRequestController(create_est(correct_form_data=True), include_elster_responses=False)
 
@@ -79,6 +65,18 @@ class TestEstRequestInit(unittest.TestCase):
 
 
 class TestEstRequestProcess(unittest.TestCase):
+
+    def test_check_and_generate_entries_is_called_with_eric_mapped_object(self):
+        eric_mapped_object = EstEricMapping.parse_obj(create_est(correct_form_data=True).est_data)
+        with patch('erica.request_processing.eric_mapper', MagicMock(return_value=eric_mapped_object)), \
+                patch('erica.request_processing.requests_controller.est_mapping.check_and_generate_entries') as generate_entries, \
+                patch('erica.pyeric.pyeric_controller.EstPyericProcessController.get_eric_response'), \
+                patch('erica.request_processing.requests_controller.EstRequestController.generate_json'), \
+                patch('erica.elster_xml.elster_xml_generator.generate_full_est_xml'):
+            EstRequestController(create_est(correct_form_data=True)).process()
+
+        assert generate_entries.mock_calls == [call(eric_mapped_object.__dict__)]
+
 
     def test_pyeric_controller_is_initialised_with_correct_arguments(self):
         est_request = EstRequestController(create_est(correct_form_data=True))

--- a/erica_app/tests/request_processing/test_requests_controller.py
+++ b/erica_app/tests/request_processing/test_requests_controller.py
@@ -6,7 +6,7 @@ import pytest
 
 from erica.pyeric.eric_errors import InvalidBufaNumberError
 from erica.pyeric.pyeric_response import PyericResponse
-from erica.request_processing.eric_mapper import EstEricMapping
+from erica.request_processing.eric_mapper import EstEricMapping, UnlockCodeRequestEricMapper
 from erica.request_processing.erica_input import UnlockCodeRequestData, UnlockCodeActivationData, \
     UnlockCodeRevocationData, GetAddressData
 from erica.request_processing.requests_controller import UnlockCodeRequestController, \
@@ -240,13 +240,6 @@ class TestEstRequestGenerateJson(unittest.TestCase):
 
 class TestUnlockCodeRequestInit(unittest.TestCase):
 
-    def test_if_dob_date_given_then_set_as_string_with_correct_format(self):
-        correct_format_dob = "1969-07-20"
-
-        created_request = UnlockCodeRequestController(UnlockCodeRequestData(idnr="09952417688", dob=date(1969, 7, 20)))
-
-        self.assertEqual(correct_format_dob, created_request.input_data.dob)
-
     def test_if_idnr_given_then_set_idnr_as_attribute_correctly(self):
         expected_idnr = "09952417688"
         created_request = UnlockCodeRequestController(UnlockCodeRequestData(idnr=expected_idnr, dob=date(1969, 7, 20)))
@@ -324,6 +317,19 @@ class TestUnlockCodeRequestProcess(unittest.TestCase):
             self.unlock_request_with_valid_input.process()
 
             self.assertFalse(generate_xml_fun.call_args.kwargs['use_testmerker'])
+
+
+class TestUnlockCodeRequestGenerateFullXml(unittest.TestCase):
+
+    def test_if_dob_date_given_then_call_generate_full_xml_with_unlock_code_eric_mapping(self):
+        unlock_code_eric_mapping = UnlockCodeRequestEricMapper(idnr="09952417688", dob=date(1969, 7, 20))
+
+        created_request = UnlockCodeRequestController(UnlockCodeRequestData(idnr="09952417688", dob=date(1969, 7, 20)))
+
+        with patch('erica.request_processing.requests_controller.elster_xml_generator.generate_full_vast_request_xml') as generate_full_xml:
+            created_request.generate_full_xml(use_testmerker=True)
+
+        assert generate_full_xml.mock_calls == [call(unlock_code_eric_mapping.__dict__, use_testmerker=True)]
 
 
 class TestUnlockCodeRequestGenerateJson(unittest.TestCase):

--- a/erica_app/tests/utils.py
+++ b/erica_app/tests/utils.py
@@ -75,6 +75,8 @@ def create_form_data(correct=True, with_tax_number=True):
             person_a_has_merkzeichen_h=False,
             person_a_has_merkzeichen_ag=False,
             person_a_has_merkzeichen_g=False,
+            person_a_requests_pauschbetrag=False,
+            person_a_requests_fahrkostenpauschale=False,
             telephone_number='01715151',
 
             person_b_idnr='02293417683',
@@ -83,8 +85,14 @@ def create_form_data(correct=True, with_tax_number=True):
             person_b_last_name='Mustername',
             person_b_same_address=True,
             person_b_religion='rk',
-            person_b_blind=False,
-            person_b_gehbeh=False,
+            person_b_has_pflegegrad=False,
+            person_b_has_merkzeichen_bl=False,
+            person_b_has_merkzeichen_tbl=False,
+            person_b_has_merkzeichen_h=False,
+            person_b_has_merkzeichen_ag=False,
+            person_b_has_merkzeichen_g=False,
+            person_b_requests_pauschbetrag=False,
+            person_b_requests_fahrkostenpauschale=False,
 
             iban='DE35133713370000012345',
             account_holder='person_a',
@@ -124,6 +132,8 @@ def create_form_data(correct=True, with_tax_number=True):
             person_a_has_merkzeichen_h=False,
             person_a_has_merkzeichen_ag=False,
             person_a_has_merkzeichen_g=True,
+            person_a_requests_pauschbetrag=True,
+            person_a_requests_fahrkostenpauschale=False,
             telephone_number='01715151',
         )
 
@@ -154,6 +164,8 @@ def create_form_data_single(correct=True, with_tax_number=True):
             person_a_has_merkzeichen_h=False,
             person_a_has_merkzeichen_ag=False,
             person_a_has_merkzeichen_g=False,
+            person_a_requests_pauschbetrag=False,
+            person_a_requests_fahrkostenpauschale=False,
             telephone_number='01715151',
 
             iban='DE35133713370000012345',
@@ -185,6 +197,8 @@ def create_form_data_single(correct=True, with_tax_number=True):
             person_a_has_merkzeichen_h=False,
             person_a_has_merkzeichen_ag=False,
             person_a_has_merkzeichen_g=False,
+            person_a_requests_pauschbetrag=False,
+            person_a_requests_fahrkostenpauschale=False,
             telephone_number='01715151',
 
             iban='DE35133713370000012345',

--- a/webapp/app/elster_client/elster_client.py
+++ b/webapp/app/elster_client/elster_client.py
@@ -269,7 +269,7 @@ def _set_names_for_merkzeichen(adapted_form_data):
     ]
 
     adapted_form_data['person_a_requests_pauschbetrag'] = any(merkzeichen_person_a)
-    adapted_form_data['person_a_requests_pauschbetrag'] = any(merkzeichen_person_b)
+    adapted_form_data['person_b_requests_pauschbetrag'] = any(merkzeichen_person_b)
 
     return adapted_form_data
 

--- a/webapp/app/elster_client/elster_client.py
+++ b/webapp/app/elster_client/elster_client.py
@@ -256,6 +256,21 @@ def _set_names_for_merkzeichen(adapted_form_data):
 
     adapted_form_data['person_b_has_merkzeichen_g'] = adapted_form_data.pop('person_b_gehbeh', None)
 
+    merkzeichen_person_a = [
+        adapted_form_data.get('person_a_disability_degree'),
+        adapted_form_data.get('person_a_has_merkzeichen_bl'),
+        adapted_form_data.get('person_a_has_merkzeichen_g'),
+    ]
+
+    merkzeichen_person_b = [
+        adapted_form_data.get('person_b_disability_degree'),
+        adapted_form_data.get('person_b_has_merkzeichen_bl'),
+        adapted_form_data.get('person_b_has_merkzeichen_g'),
+    ]
+
+    adapted_form_data['person_a_requests_pauschbetrag'] = any(merkzeichen_person_a)
+    adapted_form_data['person_a_requests_pauschbetrag'] = any(merkzeichen_person_b)
+
     return adapted_form_data
 
 

--- a/webapp/app/forms/steps/lotse/fahrkostenpauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/fahrkostenpauschbetrag.py
@@ -2,10 +2,7 @@ def calculate_fahrkostenpauschbetrag(has_pflegegrad=False, disability_degree=Non
                                      has_merkzeichen_h=False, has_merkzeichen_ag=False, has_merkzeichen_g=False):
     if has_pflegegrad or has_merkzeichen_bl or has_merkzeichen_tbl or has_merkzeichen_tbl or has_merkzeichen_h or has_merkzeichen_ag:
         return 4500
-
-    elif disability_degree >= 80:
-        return 900
-    elif has_merkzeichen_g and disability_degree >= 70:
+    elif disability_degree >= 80 or (has_merkzeichen_g and disability_degree >= 70):
         return 900
 
     else:


### PR DESCRIPTION
# Short Description
This adds the ability to Erica to accept the Fahrkostenpauschale. This introduces a new translation layer that maps to the Erica fields. We would propose that in the future this will be merged with the XML generation.

# Changes
- Add the EstEricMapper and use it to translate the Pauschbetrag and Fahrkosten fields to the field schema that the xml generation needs
- Add an UnlockCodeRequestEricMapper that reformats the date 
- Adapt the elster_client to be able to send est request to Erica

# Feedback
- Do you think that we should adapt the MockErica?
- Do you think I overlooked something (tests or fields)?
- Are you okay with the naming?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
