### PR TITLE
Add no pauschbetrag react page

### DIFF
--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -65,6 +65,12 @@ const translations = {
         label: "Merkzeichen aG",
       },
     },
+    noPauschbetrag: {
+      intro: {
+        p1: "Ein Pauschbetrag wird erst ab einem Grad der Behinderung von 20 gewährt. Liegt der Grad der Behinderung darunter, gibt es keinen Anspruch auf einen Pauschbetrag.",
+        p2: "<bold>Hinweis:</bold> Auch ohne Pauschbetrag können Sie behinderungsbedingte Aufwendungen absetzen. Und zwar im Bereich Krankheitskosten und weitere außergewöhnliche Belastungen.",
+      },
+    },
     pauschbetrag: {
       intro:
         "Auf Basis Ihrer Angaben haben Sie Anspruch auf den Pauschbetrag für Menschen mit Behinderung. <bold>Alternativ können die tatsächlichen Kosten</bold>, die in Zusammenhang mit Ihrer Behinderung entstanden sind, einzeln angegeben werden. Wählen Sie aus, ob Sie den Pauschbetrag in Anspruch nehmen möchten.",

--- a/webapp/client/src/pages/NoPauschbetragPage.js
+++ b/webapp/client/src/pages/NoPauschbetragPage.js
@@ -15,7 +15,8 @@ export default function NoPauschbetragPage({ stepHeader, prevUrl, nextUrl }) {
         title={stepHeader.title}
         intro={
           <>
-            <p>{t("lotse.noPauschbetrag.intro.p1")}</p>
+            {t("lotse.noPauschbetrag.intro.p1")}
+            <br />
             <Trans
               t={t}
               i18nKey="lotse.noPauschbetrag.intro.p2"
@@ -32,9 +33,8 @@ export default function NoPauschbetragPage({ stepHeader, prevUrl, nextUrl }) {
 }
 
 NoPauschbetragPage.propTypes = {
-  stepHeader: PropTypes.exact({
+  stepHeader: PropTypes.shape({
     title: PropTypes.string,
-    intro: PropTypes.string,
   }).isRequired,
   prevUrl: PropTypes.string.isRequired,
   nextUrl: PropTypes.string.isRequired,

--- a/webapp/client/src/pages/NoPauschbetragPage.js
+++ b/webapp/client/src/pages/NoPauschbetragPage.js
@@ -1,0 +1,41 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { Trans, useTranslation } from "react-i18next";
+import FormHeader from "../components/FormHeader";
+import StepHeaderButtons from "../components/StepHeaderButtons";
+import StepNavButtons from "../components/StepNavButtons";
+
+export default function NoPauschbetragPage({ stepHeader, prevUrl, nextUrl }) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <StepHeaderButtons url={prevUrl} />
+      <FormHeader
+        title={stepHeader.title}
+        intro={
+          <>
+            <p>{t("lotse.noPauschbetrag.intro.p1")}</p>
+            <Trans
+              t={t}
+              i18nKey="lotse.noPauschbetrag.intro.p2"
+              components={{
+                bold: <b />,
+              }}
+            />
+          </>
+        }
+      />
+      <StepNavButtons isForm={false} nextUrl={nextUrl} />
+    </>
+  );
+}
+
+NoPauschbetragPage.propTypes = {
+  stepHeader: PropTypes.exact({
+    title: PropTypes.string,
+    intro: PropTypes.string,
+  }).isRequired,
+  prevUrl: PropTypes.string.isRequired,
+  nextUrl: PropTypes.string.isRequired,
+};

--- a/webapp/client/src/pages/NoPauschbetragPage.test.js
+++ b/webapp/client/src/pages/NoPauschbetragPage.test.js
@@ -16,11 +16,6 @@ it("should render step header title", () => {
   expect(screen.getByText("Title")).toBeInTheDocument();
 });
 
-it("should ignore step header intro", () => {
-  render(<NoPauschbetragPage {...props} />);
-  expect(screen.queryByText("Intro")).not.toBeInTheDocument();
-});
-
 it("should link to the previous page", () => {
   render(<NoPauschbetragPage {...props} />);
   expect(screen.getByText("Zurück").closest("a")).toHaveAttribute(

--- a/webapp/client/src/pages/NoPauschbetragPage.test.js
+++ b/webapp/client/src/pages/NoPauschbetragPage.test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import NoPauschbetragPage from "./NoPauschbetragPage";
-import { Default as StepFormDefault } from "../stories/StepForm.stories";
 
 let props = {
   stepHeader: {

--- a/webapp/client/src/pages/NoPauschbetragPage.test.js
+++ b/webapp/client/src/pages/NoPauschbetragPage.test.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import NoPauschbetragPage from "./NoPauschbetragPage";
+import { Default as StepFormDefault } from "../stories/StepForm.stories";
+
+let props = {
+  stepHeader: {
+    title: "Title",
+    intro: "Intro",
+  },
+  prevUrl: "/some/prev/path",
+  nextUrl: "/some/next/path",
+};
+
+it("should render step header title", () => {
+  render(<NoPauschbetragPage {...props} />);
+  expect(screen.getByText("Title")).toBeInTheDocument();
+});
+
+it("should ignore step header intro", () => {
+  render(<NoPauschbetragPage {...props} />);
+  expect(screen.queryByText("Intro")).not.toBeInTheDocument();
+});
+
+it("should link to the previous page", () => {
+  render(<NoPauschbetragPage {...props} />);
+  expect(screen.getByText("Zurück").closest("a")).toHaveAttribute(
+    "href",
+    expect.stringContaining("/some/prev/path")
+  );
+});
+
+it("should link to the next page", () => {
+  render(<NoPauschbetragPage {...props} />);
+  expect(screen.getByText("Weiter").closest("a")).toHaveAttribute(
+    "href",
+    expect.stringContaining("/some/next/path")
+  );
+});

--- a/webapp/client/src/pages/PauschbetragPage.test.js
+++ b/webapp/client/src/pages/PauschbetragPage.test.js
@@ -41,10 +41,6 @@ describe("With default props", () => {
     expect(screen.getByText("Title")).toBeInTheDocument();
   });
 
-  it("should ignore step intro text", () => {
-    expect(screen.queryByText("Intro")).not.toBeInTheDocument();
-  });
-
   it("should ignore field option texts", () => {
     expect(screen.queryByLabelText("Ja")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Nein")).not.toBeInTheDocument();

--- a/webapp/client/src/stories/NoPauschbetragPage.stories.js
+++ b/webapp/client/src/stories/NoPauschbetragPage.stories.js
@@ -1,0 +1,22 @@
+import React from "react";
+
+import NoPauschbetragPage from "../pages/NoPauschbetragPage";
+
+export default {
+  title: "Pages/NoPauschbetrag",
+  component: NoPauschbetragPage,
+};
+
+function Template(args) {
+  return <NoPauschbetragPage {...args} />;
+}
+
+export const Default = Template.bind({});
+Default.args = {
+  stepHeader: {
+    title:
+      "Leider haben Sie keinen Anspruch auf behinderungsbedingte Pauschbeträge.",
+  },
+  prevUrl: "/previous/step",
+  nextUrl: "/next/step",
+};


### PR DESCRIPTION
# Short Description
- Adds the page if person is not eligible for pauschbeträge

# Changes
- Add page and story and tests
- Only added one page that can be called by both steps: person A and B

# Feedback
- Do you see a problem with just adding one page?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
