### PR TITLE
Adapt css for pauschbetrag react pages

### DIFF
--- a/webapp/client/public/css/base.css
+++ b/webapp/client/public/css/base.css
@@ -300,7 +300,7 @@ ol li::before {
 }
 
 .text-input-field-label {
-  margin-top: var(--spacing-06);
+  margin-top: var(--spacing-07);
   font-size: var(--text-medium);
   font-weight: var(--font-bold);
 }

--- a/webapp/client/src/components/FieldLabelForSeparatedFields.js
+++ b/webapp/client/src/components/FieldLabelForSeparatedFields.js
@@ -5,6 +5,8 @@ import FieldLabelScaffolding from "./FieldLabelScaffolding";
 import { labelPropType } from "../lib/propTypes";
 
 const Legend = styled.legend`
+  margin-bottom: 0;
+
   & > span {
     display: block;
   }

--- a/webapp/client/src/components/FormFieldRadioGroup.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.js
@@ -110,7 +110,7 @@ function FormFieldRadioGroup({
                   htmlFor={fieldId + option.value}
                   key={`${fieldId}-label-${option.value}`}
                 >
-                  {option.displayName}
+                  <span>{option.displayName}</span>
                 </label>,
               ])}
             </div>

--- a/webapp/client/src/pages/PauschbetragPage.js
+++ b/webapp/client/src/pages/PauschbetragPage.js
@@ -11,6 +11,10 @@ import { extendedSelectionFieldPropType } from "../lib/propTypes";
 
 const DetailsDiv = styled.div`
   margin-bottom: var(--spacing-04);
+
+  @media (max-width: 500px) {
+    margin-bottom: 0;
+  }
 `;
 
 export default function PauschbetragPage({

--- a/webapp/client/src/pages/PersonAHasDisabilityPage.js
+++ b/webapp/client/src/pages/PersonAHasDisabilityPage.js
@@ -1,12 +1,21 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
+import styled from "styled-components";
 import FormHeader from "../components/FormHeader";
 import FormFieldRadioGroup from "../components/FormFieldRadioGroup";
 import StepForm from "../components/StepForm";
 import StepHeaderButtons from "../components/StepHeaderButtons";
 import Details from "../components/Details";
 import { fieldPropType } from "../lib/propTypes";
+
+const DetailsDiv = styled.div`
+  margin-bottom: var(--spacing-04);
+
+  @media (max-width: 500px) {
+    margin-bottom: 0;
+  }
+`;
 
 export default function PersonAHasDisabilityPage({
   form,
@@ -32,12 +41,14 @@ export default function PersonAHasDisabilityPage({
       <StepHeaderButtons url={prevUrl} />
       <FormHeader title={stepHeader.title} intro={headerIntro} />
       <StepForm {...form}>
-        <Details
-          title={t("lotse.hasDisability.details.title")}
-          detailsId="person_a_has_disability_detail"
-        >
-          {translationBold("lotse.hasDisability.details.text")}
-        </Details>
+        <DetailsDiv>
+          <Details
+            title={t("lotse.hasDisability.details.title")}
+            detailsId="person_a_has_disability_detail"
+          >
+            {translationBold("lotse.hasDisability.details.text")}
+          </Details>
+        </DetailsDiv>
         <FormFieldRadioGroup
           fieldId="person_a_has_disability"
           fieldName="person_a_has_disability"

--- a/webapp/client/src/pages/PersonBHasDisabilityPage.js
+++ b/webapp/client/src/pages/PersonBHasDisabilityPage.js
@@ -1,12 +1,21 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
+import styled from "styled-components";
 import FormHeader from "../components/FormHeader";
 import FormFieldRadioGroup from "../components/FormFieldRadioGroup";
 import StepForm from "../components/StepForm";
 import StepHeaderButtons from "../components/StepHeaderButtons";
 import Details from "../components/Details";
 import { fieldPropType } from "../lib/propTypes";
+
+const DetailsDiv = styled.div`
+  margin-bottom: var(--spacing-04);
+
+  @media (max-width: 500px) {
+    margin-bottom: 0;
+  }
+`;
 
 export default function PersonBHasDisabilityPage({
   form,
@@ -28,12 +37,14 @@ export default function PersonBHasDisabilityPage({
         intro={translationBold("lotse.hasDisability.intro_person_b")}
       />
       <StepForm {...form}>
-        <Details
-          title={t("lotse.hasDisability.details.title")}
-          detailsId="person_b_has_disability"
-        >
-          {translationBold("lotse.hasDisability.details.text")}
-        </Details>
+        <DetailsDiv>
+          <Details
+            title={t("lotse.hasDisability.details.title")}
+            detailsId="person_b_has_disability"
+          >
+            {translationBold("lotse.hasDisability.details.text")}
+          </Details>
+        </DetailsDiv>
         <FormFieldRadioGroup
           fieldId="person_b_has_disability"
           fieldName="person_b_has_disability"

--- a/webapp/client/src/storybook-assets/base.css
+++ b/webapp/client/src/storybook-assets/base.css
@@ -282,7 +282,7 @@ ol li::before {
 } */
 
 .text-input-field-label {
-  margin-top: var(--spacing-06);
+  margin-top: var(--spacing-07);
   font-size: var(--text-medium);
   font-weight: var(--font-bold);
 }


### PR DESCRIPTION
# Short Description
- In QA, there were some styling issues discovered for the new components. They're fixed with this PR.
- Everything has been discussed with Nadine already.

# Changes
- Fix whitespaces and wrapping for radio buttons (just using a span around the text and bold elements fixes both)
- Change spacing for all form input labels to 07 instead of 06
- Add margin to has_disability pages between details and radio buttons
- remove that margin on mobile (for has_disability and pauschbetrag pages)
- Decrease spacing of legend that was introduced by adding the span to fix the displayed margin (ironic, really. :D)

# Feedback
- Do you see an issue especially with the adapted margin-bottom of the legend? I just overwrote the default css for `legend` elements that was never defined by us anyways.

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
