### PR TITLE
Disable disability fields in aussergBela Step

### DIFF
--- a/webapp/app/forms/flows/lotse_step_chooser.py
+++ b/webapp/app/forms/flows/lotse_step_chooser.py
@@ -43,7 +43,7 @@ class LotseStepChooser(StepChooser):
         'person_a_beh_grad': 25,
         'person_a_blind': True,
         'person_a_gehbeh': True,
-        'person_a_has_disability': 'no',
+        'person_a_has_disability': 'yes',
 
         'person_b_idnr': '02293417683',
         'person_b_dob': datetime.date(1951, 2, 25),

--- a/webapp/app/forms/steps/lotse/steuerminderungen.py
+++ b/webapp/app/forms/steps/lotse/steuerminderungen.py
@@ -251,6 +251,8 @@ class StepAussergBela(LotseFormSteuerlotseStep):
             render_info=self.render_info,
             input_details_title=_('form.lotse.ausserg_bela.details-title'),
             input_details_text=_('form.lotse.ausserg_bela.details-text'),
+            show_disability_stmind_fields=self.stored_data.get('person_a_has_disability') == 'yes' or
+                                          self.stored_data.get('person_b_has_disability') == 'yes'
         )
 
 

--- a/webapp/app/model/form_data.py
+++ b/webapp/app/model/form_data.py
@@ -317,6 +317,12 @@ class FormDataDependencies(BaseModel):
             return None
         return v
 
+    @validator('stmind_beh_aufw_summe', 'stmind_beh_aufw_anspruch')
+    def delete_stmind_beh_if_no_disability(cls, v, values):
+        if values.get('person_a_has_disability') != 'yes' and values.get('person_b_has_disability') != 'yes':
+            return None
+        return v
+
     @validator('stmind_haushaltsnahe_entries', 'stmind_haushaltsnahe_summe',
                'stmind_handwerker_entries', 'stmind_handwerker_summe', 'stmind_handwerker_lohn_etc_summe',
                'stmind_gem_haushalt_count', 'stmind_gem_haushalt_entries')
@@ -348,6 +354,7 @@ class FormDataDependencies(BaseModel):
         if show_person_b(values):
             return None
         return v
+
 
 
 class InputDataInvalidError(ValueError):

--- a/webapp/app/templates/lotse/form_krankheitskosten.html
+++ b/webapp/app/templates/lotse/form_krankheitskosten.html
@@ -18,7 +18,6 @@
     {% endblock %}
     {% for field in form %}
         {% if show_disability_stmind_fields or (field.name != "stmind_beh_aufw_summe" and field.name != "stmind_beh_aufw_anspruch") %}
-            Tests
             <div class="form-row-center">
                 {{ macros.render_field(field, first_field=field == render_info.form.first_field if not render_info.form.errors) }}
             </div>

--- a/webapp/app/templates/lotse/form_krankheitskosten.html
+++ b/webapp/app/templates/lotse/form_krankheitskosten.html
@@ -1,4 +1,4 @@
-{% extends 'basis/form_standard.html' %}
+{% extends 'basis/base_step_form.html' %}
 {% import "macros.html" as macros %}
 {% import "components.html" as components %}
 
@@ -12,3 +12,18 @@
         {% endfor -%}
     </ul>
 {% endblock %}
+
+{% block form_content %}
+    {% block intro_list %}
+    {% endblock %}
+    {% for field in form %}
+        {% if show_disability_stmind_fields or (field.name != "stmind_beh_aufw_summe" and field.name != "stmind_beh_aufw_anspruch") %}
+            Tests
+            <div class="form-row-center">
+                {{ macros.render_field(field, first_field=field == render_info.form.first_field if not render_info.form.errors) }}
+            </div>
+        {% endif %}
+    {% endfor %}
+{% endblock %}
+
+

--- a/webapp/client/cypress/integration/aussergBela.spec.js
+++ b/webapp/client/cypress/integration/aussergBela.spec.js
@@ -100,7 +100,6 @@ describe("PersonAHasDisability", () => {
         familienstand: "married",
         familienstand_married_lived_separated: "no",
         familienstand_confirm_zusammenveranlagung: true,
-        person_a_has_disability: "yes",
 
         stmind_select_ausserg_bela: true,
         person_a_has_disability: "no",

--- a/webapp/client/cypress/integration/aussergBela.spec.js
+++ b/webapp/client/cypress/integration/aussergBela.spec.js
@@ -1,0 +1,118 @@
+describe("PersonAHasDisability", () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  context("with no data", () => {
+    beforeEach(() => {
+      cy.visit("/lotse/step/ausserg_bela");
+    });
+
+    it("Should redirect back to select_stmind page", () => {
+      cy.location().should((loc) => {
+        expect(loc.pathname.toString()).to.contain("/lotse/step/select_stmind");
+      });
+      cy.get("div[role=alert]").should("exist");
+    });
+  });
+
+  context("with aussergBela selected but no disability data", () => {
+    beforeEach(() => {
+      cy.request("POST", "/testing/set_data/form_data", {
+        stmind_select_ausserg_bela: true,
+      });
+
+      cy.visit("/lotse/step/ausserg_bela");
+    });
+
+    it("Should show standard Aufwendungs inputs", () => {
+      cy.get("#stmind_krankheitskosten_summe").should("exist");
+      cy.get("#stmind_krankheitskosten_anspruch").should("exist");
+
+      cy.get("#stmind_pflegekosten_summe").should("exist");
+      cy.get("#stmind_pflegekosten_anspruch").should("exist");
+
+      cy.get("#stmind_bestattung_summe").should("exist");
+      cy.get("#stmind_bestattung_anspruch").should("exist");
+
+      cy.get("#stmind_aussergbela_sonst_summe").should("exist");
+      cy.get("#stmind_aussergbela_sonst_anspruch").should("exist");
+
+      cy.get("#stmind_krankheitskosten_summe").should("exist");
+      cy.get("#stmind_krankheitskosten_anspruch").should("exist");
+    });
+
+    it("Should not show Behinderungsbedingte Aufwendungen inputs", () => {
+      cy.get("#stmind_beh_aufw_summe").should("not.exist");
+      cy.get("#stmind_beh_aufw_anspruch").should("not.exist");
+    });
+
+    it("Should link back to select_stmind page", () => {
+      cy.get("a").contains("Zurück").click();
+      cy.url().should("include", "/lotse/step/select_stmind");
+    });
+
+    it("Should link forward to summary page", () => {
+      cy.get("button[type=submit]").click();
+      cy.url().should("include", "/lotse/step/summary");
+    });
+  });
+
+  context(
+    "with aussergBela selected but person a and b have no disability",
+    () => {
+      beforeEach(() => {
+        cy.request("POST", "/testing/set_data/form_data", {
+          stmind_select_ausserg_bela: true,
+          person_a_has_disability: "no",
+          person_b_has_disability: "no",
+        });
+
+        cy.visit("/lotse/step/ausserg_bela");
+      });
+
+      it("Should not show Behinderungsbedingte Aufwendungen inputs", () => {
+        cy.get("#stmind_beh_aufw_summe").should("not.exist");
+        cy.get("#stmind_beh_aufw_anspruch").should("not.exist");
+      });
+    }
+  );
+
+  context("with aussergBela selected and person a has disability", () => {
+    beforeEach(() => {
+      cy.request("POST", "/testing/set_data/form_data", {
+        stmind_select_ausserg_bela: true,
+        person_a_has_disability: "yes",
+      });
+
+      cy.visit("/lotse/step/ausserg_bela");
+    });
+
+    it("Should show Behinderungsbedingte Aufwendungen Summe input", () => {
+      cy.get("#stmind_beh_aufw_summe").should("exist");
+      cy.get("#stmind_beh_aufw_anspruch").should("exist");
+    });
+  });
+
+  context("with aussergBela selected and person b has disability", () => {
+    beforeEach(() => {
+      cy.request("POST", "/testing/set_data/form_data", {
+        familienstand: "married",
+        familienstand_married_lived_separated: "no",
+        familienstand_confirm_zusammenveranlagung: true,
+        person_a_has_disability: "yes",
+
+        stmind_select_ausserg_bela: true,
+        person_a_has_disability: "no",
+        person_b_has_disability: "yes",
+      });
+
+      cy.visit("/lotse/step/ausserg_bela");
+    });
+
+    it("Should show Behinderungsbedingte Aufwendungen inputs", () => {
+      cy.get("#stmind_beh_aufw_summe").should("exist");
+      cy.get("#stmind_beh_aufw_anspruch").should("exist");
+    });
+  });
+});

--- a/webapp/tests/model/test_form_data.py
+++ b/webapp/tests/model/test_form_data.py
@@ -16,6 +16,8 @@ from app.model.form_data import FamilienstandModel, MandatoryFormData, FormDataD
 @pytest.fixture
 def valid_stmind_data():
     return {'familienstand': 'single',
+            'person_a_has_disability': 'yes',
+            'person_b_has_disability': 'yes',
             'stmind_select_vorsorge': True,
             'stmind_select_ausserg_bela': True,
             'stmind_select_handwerker': True,
@@ -353,6 +355,32 @@ class TestFormDataDependencies:
         input_data = valid_stmind_data
         input_data.pop('stmind_select_ausserg_bela')
         returned_data = FormDataDependencies.parse_obj(input_data).dict(exclude_none=True)
+        expected_data = input_data
+        for dependent_field in dependent_fields:
+            expected_data.pop(dependent_field)
+        assert returned_data == expected_data
+
+    def test_if_no_disability_person_a_and_person_b_then_delete_stmin_beh_fields(self, valid_stmind_data):
+        dependent_fields = ['stmind_beh_aufw_summe', 'stmind_beh_aufw_anspruch']
+        input_data = valid_stmind_data
+        input_data['person_a_has_disability'] = 'no'
+        input_data['person_b_has_disability'] = 'no'
+
+        returned_data = FormDataDependencies.parse_obj(input_data).dict(exclude_none=True)
+
+        expected_data = input_data
+        for dependent_field in dependent_fields:
+            expected_data.pop(dependent_field)
+        assert returned_data == expected_data
+
+    def test_if_disability_person_a_and_person_b_not_set_then_delete_stmin_beh_fields(self, valid_stmind_data):
+        dependent_fields = ['stmind_beh_aufw_summe', 'stmind_beh_aufw_anspruch']
+        input_data = valid_stmind_data
+        input_data.pop('person_a_has_disability', None)
+        input_data.pop('person_b_has_disability', None)
+
+        returned_data = FormDataDependencies.parse_obj(input_data).dict(exclude_none=True)
+
         expected_data = input_data
         for dependent_field in dependent_fields:
             expected_data.pop(dependent_field)


### PR DESCRIPTION
# Short Description
We want to disable the disability fields in the aussergBelaStep if no user has a disability. This does that by not showing the fields in the frontend. Furthermore, the corresponding fields are deleted, whenever the user has no disability.
Because this step is no reactified yet, I decided to implement it in the template.

# Changes
- Delete `stmind_beh_aufw_summe`, `stmind_beh_aufw_anspruch` if person A and person B have no disability
- Prevent the template from showing the fields if no disability has been selected
- Add functional test for this step

# Feedback
- Do you see any problem with that approach or anything I missed?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
