### PR TITLE
Remove margin-bottom from yesNo field

### DIFF
--- a/webapp/client/src/components/FormFieldYesNo.js
+++ b/webapp/client/src/components/FormFieldYesNo.js
@@ -65,6 +65,10 @@ const YesNo = styled.div`
     opacity: 0;
     position: absolute;
   }
+
+  label {
+    margin: 0; // Overwrite general label styling
+  }
 `;
 
 function FormFieldYesNo({


### PR DESCRIPTION
# Short Description
Nadine found a problem with the yesNo field [during QA for the MerkzeichenPage](https://steuerlotse.atlassian.net/browse/STL-1672?atlOrigin=eyJpIjoiY2M4MjA5NTY0MjQyNDZlMmI1NWU3ODBiNjYxMTQ4ZmIiLCJwIjoiaiJ9). We set a margin-bottom on every label and the yesNo field has a bottom margin because of that. This resulted in inconsistent margins between the different inputs on the MerkzeichenPage.

This should change that.

# Feedback
- Do you see a better solution than overwriting the css?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
