### PR TITLE
Fix error with FahrkostenPauschalePage

### DIFF
--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -148,7 +148,7 @@ const translations = {
     },
     fahrkostenpauschale: {
       introText:
-        "Auf Basis Ihrer Angaben haben Sie Anspruch auf die behinderungsbedingte Fahrtkostenpauschale von <bold>{{fahrkostenpauschaleAmount}}</bold> Euro abzüglich der zumutbaren Belastung. Einzelne Fahrten können Sie nicht mehr geltend machen.",
+        "Auf Basis Ihrer Angaben haben Sie Anspruch auf die behinderungsbedingte Fahrtkostenpauschale von <bold>{{fahrkostenpauschaleAmount}} Euro abzüglich der zumutbaren Belastung</bold> . Einzelne Fahrten können Sie nicht mehr geltend machen.",
       requestsFahrkostenpauschale: {
         yesLabel: "Pauschale beantragen",
         noLabel: "Pauschale nicht beantragen",
@@ -272,16 +272,6 @@ const translations = {
     yesNoSwitch: {
       Yes: "Ja",
       No: "Nein",
-    },
-  },
-  stories: {
-    fahrkostenpauschale: {
-      introText:
-        "Auf Basis Ihrer Angaben haben Sie Anspruch auf die behinderungsbedingte Fahrtkostenpauschale von <bold>{{fahrkostenpauschaleAmount}}</bold> Euro abzüglich der zumutbaren Belastung. Einzelne Fahrten können Sie nicht mehr geltend machen.",
-      requestsFahrkostenpauschale: {
-        yesLabel: "Pauschale beantragen",
-        noLabel: "Pauschale nicht beantragen",
-      },
     },
   },
 };

--- a/webapp/client/src/pages/FahrkostenpauschalePage.js
+++ b/webapp/client/src/pages/FahrkostenpauschalePage.js
@@ -36,7 +36,7 @@ export default function FahrkostenpauschalePage({
         title={stepHeader.title}
         intro={
           <Trans
-            i18nKey="stories.fahrkostenpauschale.introText"
+            i18nKey="lotse.fahrkostenpauschale.introText"
             values={{ fahrkostenpauschaleAmount }}
             components={{ bold: <b /> }}
           />

--- a/webapp/client/src/pages/FahrkostenpauschalePage.js
+++ b/webapp/client/src/pages/FahrkostenpauschalePage.js
@@ -14,6 +14,10 @@ import FormFieldRadioGroup from "../components/FormFieldRadioGroup";
 
 const DetailsDiv = styled.div`
   margin-bottom: var(--spacing-04);
+
+  @media (max-width: 500px) {
+    margin-bottom: 0;
+  }
 `;
 
 export default function FahrkostenpauschalePage({

--- a/webapp/client/src/stories/FahrkostenpauschalePersonBPage.stories.js
+++ b/webapp/client/src/stories/FahrkostenpauschalePersonBPage.stories.js
@@ -20,7 +20,7 @@ Default.args = {
     ...StepFormDefault.args,
   },
   fields: {
-    personARequestsFahrkostenpauschale: {
+    personBRequestsFahrkostenpauschale: {
       errors: [],
     },
   },


### PR DESCRIPTION
# Short Description
The FahrkostenpauschalePersonBPage did show an error. This was because an attribute was named incorrectly. Furthermore, QA saw that the margins of the details component are not correct on mobile and the wrong text was marked in bold. This changes all that.

# Changes
- Fix PersonBPage and correct styling
- I deleted old translation texts for the storybook that are no longer needed

# Feedback
- Any?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
