### PR TITLE
Ignore boto3 patch updates for erica

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: "/erica_app"
     schedule:
       interval: "daily"
+    ignore:
+      # For boto3, ignore all patch updates
+      - dependency-name: "boto3"
+        update-types: ["version-update:semver-patch"]
 
   - package-ecosystem: "docker"
     directory: "/webapp"
@@ -27,6 +31,3 @@ updates:
     ignore:
       # For storybook, ignore all updates. We update storybook manually
       - dependency-name: "@storybook/*"
-      # For boto3, ignore all patch updates
-      - dependency-name: "boto3"
-        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
# Short Description
We want to ignore boto3 patch updates from dependabot. We already had a setting for that. However, the ignore option was added for the `webapp/client` not for erica_app. This changes that.
Note: Ignoring the patch updates does not ignore patch updates because of security.

# Changes
- Delete ignore option for boto3 in `webapp/client`
- Add it to erica_app

# Feedback
- Which parts of the code would you like feedback on?
- Questions that are open are also good (e. g. "Do you see any tests missing for class x?")

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
