### PR TITLE
Remove space from Fahrkostenpauschale intro text

### DIFF
--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -148,7 +148,7 @@ const translations = {
     },
     fahrkostenpauschale: {
       introText:
-        "Auf Basis Ihrer Angaben haben Sie Anspruch auf die behinderungsbedingte Fahrtkostenpauschale von <bold>{{fahrkostenpauschaleAmount}} Euro abzüglich der zumutbaren Belastung</bold> . Einzelne Fahrten können Sie nicht mehr geltend machen.",
+        "Auf Basis Ihrer Angaben haben Sie Anspruch auf die behinderungsbedingte Fahrtkostenpauschale von <bold>{{fahrkostenpauschaleAmount}} Euro abzüglich der zumutbaren Belastung</bold>. Einzelne Fahrten können Sie nicht mehr geltend machen.",
       requestsFahrkostenpauschale: {
         yesLabel: "Pauschale beantragen",
         noLabel: "Pauschale nicht beantragen",


### PR DESCRIPTION
# Short Description
Nadine found an extra space in QA. This removes that

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
