### PR TITLE
Fix errors with disability information on summary page

### DIFF
--- a/webapp/app/forms/steps/lotse/merkzeichen.py
+++ b/webapp/app/forms/steps/lotse/merkzeichen.py
@@ -53,12 +53,14 @@ class StepMerkzeichenPersonA(LotseFormSteuerlotseStep):
 
         def validate_person_a_disability_degree(self, field):
             if self.person_a_has_merkzeichen_g.data:
-                validators.InputRequired(_l('form.lotse.validation-disability_degree.merkzeichen_g_selected.required'))(self, field)
+                validators.InputRequired(_l('form.lotse.validation-disability_degree.merkzeichen_g_selected.required'))(
+                    self, field)
 
                 if field.data and field.data < 20:
                     raise ValidationError(_l('form.lotse.merkzeichen_g_selected.validation-disability_degree.min20'))
             elif self.person_a_has_merkzeichen_ag.data:
-                validators.InputRequired(_l('form.lotse.validation-disability_degree.merkzeichen_ag_selected.required'))(self, field)
+                validators.InputRequired(
+                    _l('form.lotse.validation-disability_degree.merkzeichen_ag_selected.required'))(self, field)
 
                 if field.data and field.data < 20:
                     raise ValidationError(_l('form.lotse.merkzeichen_ag_selected.validation-disability_degree.min20'))
@@ -69,7 +71,9 @@ class StepMerkzeichenPersonA(LotseFormSteuerlotseStep):
 
     @classmethod
     def get_label(cls, data):
-        return cls.label
+        return ngettext('form.lotse.merkzeichen_person_a.label',
+                        'form.lotse.merkzeichen_person_a.label',
+                        num=get_number_of_users(data))
 
     def _pre_handle(self):
         self._set_multiple_texts()
@@ -78,11 +82,11 @@ class StepMerkzeichenPersonA(LotseFormSteuerlotseStep):
     def _set_multiple_texts(self):
         number_of_users = get_number_of_users(self.stored_data)
         self.title = ngettext('form.lotse.merkzeichen_person_a.title',
-                                               'form.lotse.merkzeichen_person_a.title',
-                                               num=number_of_users)
+                              'form.lotse.merkzeichen_person_a.title',
+                              num=number_of_users)
         self.label = ngettext('form.lotse.merkzeichen_person_a.label',
-                                               'form.lotse.merkzeichen_person_a.label',
-                                               num=number_of_users)
+                              'form.lotse.merkzeichen_person_a.label',
+                              num=number_of_users)
 
     def render(self):
         props_dict = MerkzeichenProps(
@@ -142,12 +146,14 @@ class StepMerkzeichenPersonB(LotseFormSteuerlotseStep):
 
         def validate_person_b_disability_degree(self, field):
             if self.person_b_has_merkzeichen_g.data:
-                validators.InputRequired(_l('form.lotse.validation-disability_degree.merkzeichen_g_selected.required'))(self, field)
+                validators.InputRequired(_l('form.lotse.validation-disability_degree.merkzeichen_g_selected.required'))(
+                    self, field)
 
                 if field.data and field.data < 20:
                     raise ValidationError(_l('form.lotse.merkzeichen_g_selected.validation-disability_degree.min20'))
             elif self.person_b_has_merkzeichen_ag.data:
-                validators.InputRequired(_l('form.lotse.validation-disability_degree.merkzeichen_ag_selected.required'))(self, field)
+                validators.InputRequired(
+                    _l('form.lotse.validation-disability_degree.merkzeichen_ag_selected.required'))(self, field)
 
                 if field.data and field.data < 20:
                     raise ValidationError(_l('form.lotse.merkzeichen_ag_selected.validation-disability_degree.min20'))

--- a/webapp/app/forms/steps/lotse/pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/pauschbetrag.py
@@ -19,7 +19,8 @@ from app.forms.steps.lotse.utils import get_number_of_users
 from app.forms.steps.lotse.has_disability import HasDisabilityPersonAPrecondition, HasDisabilityPersonBPrecondition
 
 
-def calculate_pauschbetrag(has_pflegegrad=False, disability_degree=None, has_merkzeichen_bl=False, has_merkzeichen_tbl=False, has_merkzeichen_h=False):
+def calculate_pauschbetrag(has_pflegegrad=False, disability_degree=None, has_merkzeichen_bl=False,
+                           has_merkzeichen_tbl=False, has_merkzeichen_h=False):
     """
     Calculates the pauschbetrag given some information about the user.
 
@@ -31,7 +32,7 @@ def calculate_pauschbetrag(has_pflegegrad=False, disability_degree=None, has_mer
     """
     if has_pflegegrad or has_merkzeichen_bl or has_merkzeichen_tbl or has_merkzeichen_h:
         return 7400
-    
+
     if disability_degree is None:
         return 0
     if disability_degree == 100:
@@ -52,15 +53,15 @@ def calculate_pauschbetrag(has_pflegegrad=False, disability_degree=None, has_mer
         return 620
     elif disability_degree >= 20:
         return 384
-    
+
     return 0
 
 
 class StepPauschbetrag(LotseFormSteuerlotseStep):
-    
+
     def get_overview_value_representation(self, value):
         result = ''
-        
+
         if value == 'yes':
             result = str(self.get_pauschbetrag()) + ' ' + _('currency.euro')
             
@@ -97,24 +98,26 @@ class StepPauschbetragPersonA(StepPauschbetrag):
     name = 'person_a_requests_pauschbetrag'
     section_link = SectionLink('mandatory_data', StepFamilienstand.name, _l('form.lotse.mandatory_data.label'))
     preconditions = [HasDisabilityPersonAPrecondition, HasMerkzeichenPersonAPrecondition]
-    
+
     class InputForm(SteuerlotseBaseForm):
         person_a_requests_pauschbetrag = SelectField(
             # This mapping is for _generate_value_representation & get_overview_value_representation
-            choices=[('yes', 'yes'),('no', 'no')],
-            render_kw={'data_label':  _l('form.lotse.request_pauschbetrag.data_label')},         
+            choices=[('yes', 'yes'), ('no', 'no')],
+            render_kw={'data_label': _l('form.lotse.request_pauschbetrag.data_label')},
             validators=[InputRequired(_l('validate.input-required'))])
 
     @classmethod
     def get_label(cls, data=None):
-        return ngettext('form.lotse.person_a.request_pauschbetrag.label', 'form.lotse.person_a.request_pauschbetrag.label',
-                        num=get_number_of_users(data))        
+        return ngettext('form.lotse.person_a.request_pauschbetrag.label',
+                        'form.lotse.person_a.request_pauschbetrag.label',
+                        num=get_number_of_users(data))
 
     def render(self):
-        props_dict = PauschbetragProps(            
+        props_dict = PauschbetragProps(
             step_header={
-                'title': ngettext('form.lotse.person_a.request_pauschbetrag.title', 'form.lotse.person_a.request_pauschbetrag.title',
-                        num=get_number_of_users(self.stored_data))
+                'title': ngettext('form.lotse.person_a.request_pauschbetrag.title',
+                                  'form.lotse.person_a.request_pauschbetrag.title',
+                                  num=get_number_of_users(self.stored_data))
             },
             form={
                 'action': self.render_info.submit_url,
@@ -134,8 +137,8 @@ class StepPauschbetragPersonA(StepPauschbetrag):
 
     def get_pauschbetrag(self):
         return calculate_pauschbetrag(
-            has_pflegegrad=self.stored_data.get('person_a_has_pflegegrad', False),            
-            disability_degree=self.stored_data.get('person_a_disability_degree', None),   
+            has_pflegegrad=self.stored_data.get('person_a_has_pflegegrad', False),
+            disability_degree=self.stored_data.get('person_a_disability_degree', None),
             has_merkzeichen_bl=self.stored_data.get('person_a_has_merkzeichen_bl', False),
             has_merkzeichen_tbl=self.stored_data.get('person_a_has_merkzeichen_tbl', False),
             has_merkzeichen_h=self.stored_data.get('person_a_has_merkzeichen_h', False)
@@ -167,27 +170,27 @@ class HasMerkzeichenPersonBPrecondition(BaseModel):
             raise ValueError
         return v
 
-        
+
 class StepPauschbetragPersonB(StepPauschbetrag):
     name = 'person_b_requests_pauschbetrag'
     section_link = SectionLink('mandatory_data', StepFamilienstand.name, _l('form.lotse.mandatory_data.label'))
 
     label = _l('form.lotse.person_b.request_pauschbetrag.label')
     preconditions = [ShowPersonBPrecondition, HasDisabilityPersonBPrecondition, HasMerkzeichenPersonBPrecondition]
-        
+
     class InputForm(SteuerlotseBaseForm):
         person_b_requests_pauschbetrag = SelectField(
             # This mapping is for _generate_value_representation & get_overview_value_representation
-            choices=[('yes', 'yes'),('no', 'no')],
-            render_kw={'data_label':  _l('form.lotse.request_pauschbetrag.data_label')},         
+            choices=[('yes', 'yes'), ('no', 'no')],
+            render_kw={'data_label': _l('form.lotse.request_pauschbetrag.data_label')},
             validators=[InputRequired(_l('validate.input-required'))])
-    
+
     @classmethod
     def get_label(cls, data):
         return cls.label
 
     def render(self):
-        props_dict = PauschbetragProps(            
+        props_dict = PauschbetragProps(
             step_header={
                 'title': _('form.lotse.person_b.request_pauschbetrag.title')
             },
@@ -202,15 +205,15 @@ class StepPauschbetragPersonB(StepPauschbetrag):
         ).camelized_dict()
 
         return render_template('react_component.html',
-                            component='PauschbetragPersonBPage',
-                            props=props_dict,
-                            form=self.render_info.form,
-                            header_title=_('form.lotse.header-title'))
+                               component='PauschbetragPersonBPage',
+                               props=props_dict,
+                               form=self.render_info.form,
+                               header_title=_('form.lotse.header-title'))
 
     def get_pauschbetrag(self):
         return calculate_pauschbetrag(
-            has_pflegegrad=self.stored_data.get('person_b_has_pflegegrad', False),            
-            disability_degree=self.stored_data.get('person_b_disability_degree', None),   
+            has_pflegegrad=self.stored_data.get('person_b_has_pflegegrad', False),
+            disability_degree=self.stored_data.get('person_b_disability_degree', None),
             has_merkzeichen_bl=self.stored_data.get('person_b_has_merkzeichen_bl', False),
             has_merkzeichen_tbl=self.stored_data.get('person_b_has_merkzeichen_tbl', False),
             has_merkzeichen_h=self.stored_data.get('person_b_has_merkzeichen_h', False)

--- a/webapp/app/forms/steps/lotse/pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/pauschbetrag.py
@@ -64,7 +64,9 @@ class StepPauschbetrag(LotseFormSteuerlotseStep):
 
         if value == 'yes':
             result = str(self.get_pauschbetrag()) + ' ' + _('currency.euro')
-            
+        elif value == 'no':
+            result = _('form.lotse.summary.not-requested')
+
         return result
 
 

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-06 14:03+0100\n"
+"POT-Creation-Date: 2022-01-06 14:11+0100\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -1298,7 +1298,7 @@ msgid "currency.euro"
 msgstr "Euro"
 
 #: app/forms/steps/lotse/pauschbetrag.py:68
-msgid "form.lotse.request_pauschbetrag.no-pauschbetrag-summary-page"
+msgid "form.lotse.summary.not-requested"
 msgstr "Keine Beantragung"
 
 #: app/forms/steps/lotse/pauschbetrag.py:75

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-04 12:15+0100\n"
+"POT-Creation-Date: 2022-01-06 14:03+0100\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -287,9 +287,9 @@ msgstr "verwitwet"
 
 #: app/forms/steps/eligibility_steps.py:192
 #: app/forms/steps/lotse/has_disability.py:29
-#: app/forms/steps/lotse/has_disability.py:67
-#: app/forms/steps/lotse/pauschbetrag.py:106
-#: app/forms/steps/lotse/pauschbetrag.py:187
+#: app/forms/steps/lotse/has_disability.py:63
+#: app/forms/steps/lotse/pauschbetrag.py:109
+#: app/forms/steps/lotse/pauschbetrag.py:188
 msgid "validate.input-required"
 msgstr "Diese Angabe wird benötigt, um fortfahren zu können."
 
@@ -992,17 +992,17 @@ msgstr "Bestätigen Sie, dass Sie einverstanden sind, um fortfahren zu können."
 msgid "form.unlock-code-request.input-title"
 msgstr "Registrieren und persönlichen Freischaltcode beantragen"
 
-#: app/forms/steps/unlock_code_request_steps.py:64
-#: app/forms/steps/unlock_code_request_steps.py:77
-#: app/forms/steps/unlock_code_request_steps.py:90
+#: app/forms/steps/unlock_code_request_steps.py:60
+#: app/forms/steps/unlock_code_request_steps.py:73
+#: app/forms/steps/unlock_code_request_steps.py:86
 msgid "form.unlock-code-request.header-title"
 msgstr "Registrieren - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/unlock_code_request_steps.py:72
+#: app/forms/steps/unlock_code_request_steps.py:68
 msgid "form.unlock-code-request.success-title"
 msgstr "Ihre Registrierung war erfolgreich!"
 
-#: app/forms/steps/unlock_code_request_steps.py:73
+#: app/forms/steps/unlock_code_request_steps.py:69
 msgid "form.unlock-code-request.success-intro"
 msgstr ""
 "Wir haben Ihren Antrag an Ihre Finanzverwaltung weitergeleitet. Sie "
@@ -1010,11 +1010,11 @@ msgstr ""
 "Freischaltcode erhalten haben. Es kann bis zu zwei Wochen dauern bis Sie "
 "Ihren Brief erhalten."
 
-#: app/forms/steps/unlock_code_request_steps.py:85
+#: app/forms/steps/unlock_code_request_steps.py:81
 msgid "form.unlock-code-request.failure-title"
 msgstr "Registrierung fehlgeschlagen. Bitte prüfen Sie Ihre Angaben."
 
-#: app/forms/steps/unlock_code_request_steps.py:86
+#: app/forms/steps/unlock_code_request_steps.py:82
 msgid "form.unlock-code-request.failure-intro"
 msgstr ""
 "Haben Sie sich vielleicht bereits registriert? In diesem Fall können Sie "
@@ -1094,11 +1094,11 @@ msgid "form.lotse.has_disability.label_person_b"
 msgstr "Behinderung oder Pflegebedürftigkeit für Person B"
 
 #: app/forms/steps/lotse/has_disability.py:22
-#: app/forms/steps/lotse/has_disability.py:62
+#: app/forms/steps/lotse/has_disability.py:58
 #: app/forms/steps/lotse/merkzeichen.py:28
-#: app/forms/steps/lotse/merkzeichen.py:126
-#: app/forms/steps/lotse/pauschbetrag.py:98
-#: app/forms/steps/lotse/pauschbetrag.py:177
+#: app/forms/steps/lotse/merkzeichen.py:121
+#: app/forms/steps/lotse/pauschbetrag.py:101
+#: app/forms/steps/lotse/pauschbetrag.py:178
 #: app/forms/steps/lotse/personal_data.py:37
 #: app/forms/steps/lotse/personal_data.py:183
 #: app/forms/steps/lotse/personal_data.py:274
@@ -1111,7 +1111,7 @@ msgid "form.lotse.mandatory_data.label"
 msgstr "Pflichtangaben"
 
 #: app/forms/steps/lotse/has_disability.py:28
-#: app/forms/steps/lotse/has_disability.py:66
+#: app/forms/steps/lotse/has_disability.py:62
 msgid "form.lotse.has_disability.data_label"
 msgstr "Liegt eine Behinderung oder Pflegebedürftigkeit vor?"
 
@@ -1121,12 +1121,12 @@ msgstr ""
 "Möchten Sie Angaben zu einer Behinderung oder Pflegebedürftigkeit für "
 "Person B machen?"
 
-#: app/forms/steps/lotse/has_disability.py:57
-#: app/forms/steps/lotse/has_disability.py:98
-#: app/forms/steps/lotse/merkzeichen.py:115
-#: app/forms/steps/lotse/merkzeichen.py:200
-#: app/forms/steps/lotse/pauschbetrag.py:137
-#: app/forms/steps/lotse/pauschbetrag.py:216
+#: app/forms/steps/lotse/has_disability.py:53
+#: app/forms/steps/lotse/has_disability.py:90
+#: app/forms/steps/lotse/merkzeichen.py:110
+#: app/forms/steps/lotse/merkzeichen.py:188
+#: app/forms/steps/lotse/pauschbetrag.py:138
+#: app/forms/steps/lotse/pauschbetrag.py:213
 #: app/forms/steps/lotse/personal_data.py:395
 #: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:54
 #: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:74
@@ -1134,13 +1134,13 @@ msgstr ""
 msgid "form.lotse.header-title"
 msgstr "Steuerformular - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse/has_disability.py:72
+#: app/forms/steps/lotse/has_disability.py:68
 msgid "form.lotse.has_disability.label_person_a"
 msgid_plural "form.lotse.has_disability.label_person_a"
 msgstr[0] "Behinderung oder Pflegebedürftigkeit"
 msgstr[1] "Behinderung oder Pflegebedürftigkeit für Person A"
 
-#: app/forms/steps/lotse/has_disability.py:78
+#: app/forms/steps/lotse/has_disability.py:74
 msgid "form.lotse.has_disability.title"
 msgid_plural "form.lotse.has_disability.title"
 msgstr[0] "Möchten Sie Angaben zu einer Behinderung oder Pflegebedürftigkeit machen?"
@@ -1148,8 +1148,8 @@ msgstr[1] ""
 "Möchten Sie Angaben zu einer Behinderung oder Pflegebedürftigkeit für "
 "Person A machen?"
 
-#: app/forms/steps/lotse/has_disability.py:103
-#: app/forms/steps/lotse/has_disability.py:116
+#: app/forms/steps/lotse/has_disability.py:95
+#: app/forms/steps/lotse/has_disability.py:108
 msgid "form.lotse.skip_reason.has_no_disability"
 msgstr ""
 "Sie haben angegeben, dass Sie keine Angaben zu einer Behinderung oder "
@@ -1158,14 +1158,14 @@ msgstr ""
 "machen möchten."
 
 #: app/forms/steps/lotse/merkzeichen.py:22
-#: app/forms/steps/lotse/merkzeichen.py:80
+#: app/forms/steps/lotse/merkzeichen.py:84
 msgid "form.lotse.merkzeichen_person_a.title"
 msgid_plural "form.lotse.merkzeichen_person_a.title"
 msgstr[0] "Angaben zu Ihrer Behinderung oder Pflegebedürftigkeit"
 msgstr[1] "Angaben zu Behinderung oder Pflegebedürftigkeit von Person A"
 
 #: app/forms/steps/lotse/merkzeichen.py:23
-#: app/forms/steps/lotse/merkzeichen.py:121
+#: app/forms/steps/lotse/merkzeichen.py:116
 msgid "form.lotse.merkzeichen.intro"
 msgstr ""
 "Bei einer Behinderung besteht in der Regel Anspruch auf steuerliche "
@@ -1173,7 +1173,7 @@ msgstr ""
 "Anspruch auf die Pauschbeträge haben, ist von Ihren Angaben abhängig."
 
 #: app/forms/steps/lotse/merkzeichen.py:24
-#: app/forms/steps/lotse/merkzeichen.py:122
+#: app/forms/steps/lotse/merkzeichen.py:117
 #: app/forms/steps/lotse/personal_data.py:32
 #: app/forms/steps/lotse/personal_data.py:180
 #: app/forms/steps/lotse/personal_data.py:271
@@ -1185,20 +1185,20 @@ msgstr "Steuerformular - Pflichtangaben - Der Steuerlotse für Rente und Pension
 
 #: app/forms/steps/lotse/merkzeichen.py:27
 msgid "form.lotse.merkzeichen.label"
-msgstr "Angaben zur festgestellen Behinderung oder Pflegebedürftigkeit"
+msgstr "Angaben zur festgestellten Behinderung oder Pflegebedürftigkeit"
 
 #: app/forms/steps/lotse/merkzeichen.py:32
-#: app/forms/steps/lotse/merkzeichen.py:130
+#: app/forms/steps/lotse/merkzeichen.py:125
 msgid "form.lotse.merkzeichen.has_pflegegrad.required"
 msgstr "Diese Angabe wird benötigt, um fortfahren zu können."
 
 #: app/forms/steps/lotse/merkzeichen.py:33
-#: app/forms/steps/lotse/merkzeichen.py:131
+#: app/forms/steps/lotse/merkzeichen.py:126
 msgid "form.lotse.merkzeichen.has_pflegegrad.data_label"
 msgstr "Wurde ein Pflegegrad von 4 oder 5 festgestellt? "
 
 #: app/forms/steps/lotse/merkzeichen.py:36
-#: app/forms/steps/lotse/merkzeichen.py:134
+#: app/forms/steps/lotse/merkzeichen.py:129
 msgid "form.lotse.field_person_beh_grad-help"
 msgstr ""
 "Tragen Sie bitte hier den Grad der Behinderung ein. Der Grad der "
@@ -1213,86 +1213,87 @@ msgstr ""
 "typischen Berufskrankheit beruht.</li><ul>"
 
 #: app/forms/steps/lotse/merkzeichen.py:37
-#: app/forms/steps/lotse/merkzeichen.py:135
+#: app/forms/steps/lotse/merkzeichen.py:130
 msgid "form.lotse.merkzeichen.disability_degree"
 msgstr "Grad der Behinderung"
 
 #: app/forms/steps/lotse/merkzeichen.py:39
-#: app/forms/steps/lotse/merkzeichen.py:137
+#: app/forms/steps/lotse/merkzeichen.py:132
 msgid "form.lotse.merkzeichen.has_merkzeichen_g.data_label"
 msgstr "Merkzeichen G"
 
 #: app/forms/steps/lotse/merkzeichen.py:42
-#: app/forms/steps/lotse/merkzeichen.py:140
+#: app/forms/steps/lotse/merkzeichen.py:135
 msgid "form.lotse.merkzeichen.has_merkzeichen_ag.data_label"
 msgstr "Merkzeichen aG"
 
 #: app/forms/steps/lotse/merkzeichen.py:45
-#: app/forms/steps/lotse/merkzeichen.py:143
+#: app/forms/steps/lotse/merkzeichen.py:138
 msgid "form.lotse.merkzeichen.has_merkzeichen_bl.data_label"
 msgstr "Merkzeichen Bl"
 
 #: app/forms/steps/lotse/merkzeichen.py:48
-#: app/forms/steps/lotse/merkzeichen.py:146
+#: app/forms/steps/lotse/merkzeichen.py:141
 msgid "form.lotse.merkzeichen.has_merkzeichen_tbl.data_label"
 msgstr "Merkzeichen TBl"
 
 #: app/forms/steps/lotse/merkzeichen.py:51
-#: app/forms/steps/lotse/merkzeichen.py:149
+#: app/forms/steps/lotse/merkzeichen.py:144
 msgid "form.lotse.merkzeichen.has_merkzeichen_h.data_label"
 msgstr "Merkzeichen H"
 
 #: app/forms/steps/lotse/merkzeichen.py:56
-#: app/forms/steps/lotse/merkzeichen.py:154
+#: app/forms/steps/lotse/merkzeichen.py:149
 msgid "form.lotse.validation-disability_degree.merkzeichen_g_selected.required"
 msgstr ""
 "Es muss ein Grad der Behinderung angegeben werden, wenn Sie das "
 "Merkzeichen G auswählen."
 
-#: app/forms/steps/lotse/merkzeichen.py:59
-#: app/forms/steps/lotse/merkzeichen.py:157
+#: app/forms/steps/lotse/merkzeichen.py:60
+#: app/forms/steps/lotse/merkzeichen.py:153
 msgid "form.lotse.merkzeichen_g_selected.validation-disability_degree.min20"
 msgstr ""
 "Es muss ein Grad der Behinderung von mindestens 20 angegeben werden, wenn"
 " Sie das Merkzeichen G auswählen."
 
-#: app/forms/steps/lotse/merkzeichen.py:61
-#: app/forms/steps/lotse/merkzeichen.py:159
+#: app/forms/steps/lotse/merkzeichen.py:63
+#: app/forms/steps/lotse/merkzeichen.py:156
 msgid "form.lotse.validation-disability_degree.merkzeichen_ag_selected.required"
 msgstr ""
 "Es muss ein Grad der Behinderung angegeben werden, wenn Sie das "
 "Merkzeichen aG auswählen."
 
-#: app/forms/steps/lotse/merkzeichen.py:64
-#: app/forms/steps/lotse/merkzeichen.py:162
+#: app/forms/steps/lotse/merkzeichen.py:66
+#: app/forms/steps/lotse/merkzeichen.py:159
 msgid "form.lotse.merkzeichen_ag_selected.validation-disability_degree.min20"
 msgstr ""
 "Es muss ein Grad der Behinderung von mindestens 20 angegeben werden, wenn"
 " Sie das Merkzeichen aG auswählen."
 
-#: app/forms/steps/lotse/merkzeichen.py:68
-#: app/forms/steps/lotse/merkzeichen.py:166
+#: app/forms/steps/lotse/merkzeichen.py:70
+#: app/forms/steps/lotse/merkzeichen.py:163
 msgid "form.lotse.validation-disability_degree.min20"
 msgstr ""
 "Sie haben einen Anspruch auf den Pauschbetrag erst ab einem Grad der "
 "Behinderung von 20. Lassen Sie das Feld leer, falls der Wert unter 20 "
 "liegt."
 
-#: app/forms/steps/lotse/merkzeichen.py:83
+#: app/forms/steps/lotse/merkzeichen.py:76
+#: app/forms/steps/lotse/merkzeichen.py:87
 msgid "form.lotse.merkzeichen_person_a.label"
 msgid_plural "form.lotse.merkzeichen_person_a.label"
-msgstr[0] "Angaben zur festgestellen Behinderung oder Pflegebedürftigkeit"
-msgstr[1] "Angaben zur festgestellen Behinderung oder Pflegebedürftigkeit Person A"
+msgstr[0] "Angaben zur festgestellten Behinderung oder Pflegebedürftigkeit"
+msgstr[1] "Angaben zur festgestellten Behinderung oder Pflegebedürftigkeit Person A"
 
-#: app/forms/steps/lotse/merkzeichen.py:120
+#: app/forms/steps/lotse/merkzeichen.py:115
 msgid "form.lotse.merkzeichen_person_b.title"
 msgstr "Angaben zu Behinderung oder Pflegebedürftigkeit von Person B"
 
-#: app/forms/steps/lotse/merkzeichen.py:125
+#: app/forms/steps/lotse/merkzeichen.py:120
 msgid "form.lotse.merkzeichen_person_b.label"
-msgstr "Angaben zur festgestellen Behinderung oder Pflegebedürftigkeit Person B"
+msgstr "Angaben zur festgestellten Behinderung oder Pflegebedürftigkeit Person B"
 
-#: app/forms/steps/lotse/pauschbetrag.py:65
+#: app/forms/steps/lotse/pauschbetrag.py:66
 msgid "currency.euro"
 msgstr "Euro"
 
@@ -1305,28 +1306,28 @@ msgstr ""
 "ausstehend. Bitte machen Sie Angaben zu einer Behinderung oder "
 "Pflegebedürftigkeit."
 
-#: app/forms/steps/lotse/pauschbetrag.py:105
-#: app/forms/steps/lotse/pauschbetrag.py:186
+#: app/forms/steps/lotse/pauschbetrag.py:108
+#: app/forms/steps/lotse/pauschbetrag.py:187
 msgid "form.lotse.request_pauschbetrag.data_label"
 msgstr "Beantragung Pauschbetrag für Menschen mit Behinderung"
 
-#: app/forms/steps/lotse/pauschbetrag.py:111
+#: app/forms/steps/lotse/pauschbetrag.py:115
 msgid "form.lotse.person_a.request_pauschbetrag.label"
 msgid_plural "form.lotse.person_a.request_pauschbetrag.label"
 msgstr[0] "Beantragung Pauschbetrag für Menschen mit Behinderung"
 msgstr[1] "Beantragung Pauschbetrag für Menschen mit Behinderung Person A"
 
-#: app/forms/steps/lotse/pauschbetrag.py:117
+#: app/forms/steps/lotse/pauschbetrag.py:122
 msgid "form.lotse.person_a.request_pauschbetrag.title"
 msgid_plural "form.lotse.person_a.request_pauschbetrag.title"
 msgstr[0] "Pauschbetrag für Menschen mit Behinderung"
 msgstr[1] "Pauschbetrag für Menschen mit Behinderung für Person A"
 
-#: app/forms/steps/lotse/pauschbetrag.py:179
+#: app/forms/steps/lotse/pauschbetrag.py:180
 msgid "form.lotse.person_b.request_pauschbetrag.label"
 msgstr "Beantragung Pauschbetrag für Menschen mit Behinderung Person B"
 
-#: app/forms/steps/lotse/pauschbetrag.py:196
+#: app/forms/steps/lotse/pauschbetrag.py:197
 msgid "form.lotse.person_b.request_pauschbetrag.title"
 msgstr "Pauschbetrag für Menschen mit Behinderung für Person B"
 

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -1297,8 +1297,12 @@ msgstr "Angaben zur festgestellten Behinderung oder Pflegebedürftigkeit Person 
 msgid "currency.euro"
 msgstr "Euro"
 
-#: app/forms/steps/lotse/pauschbetrag.py:72
-#: app/forms/steps/lotse/pauschbetrag.py:151
+#: app/forms/steps/lotse/pauschbetrag.py:68
+msgid "form.lotse.request_pauschbetrag.no-pauschbetrag-summary-page"
+msgstr "Keine Beantragung"
+
+#: app/forms/steps/lotse/pauschbetrag.py:75
+#: app/forms/steps/lotse/pauschbetrag.py:152
 msgid "form.lotse.skip_reason.has_no_merkzeichen"
 msgstr ""
 "Sie haben ausgewählt, dass Sie Angaben zu einer Behinderung oder "

--- a/webapp/tests/forms/steps/lotse/test_pauschbetrag_steps.py
+++ b/webapp/tests/forms/steps/lotse/test_pauschbetrag_steps.py
@@ -77,7 +77,7 @@ class TestPauschbetragPersonAGetOverviewValueRepresentation:
     def test_if_merkzeichen_given_and_requests_pauschbetrag_yes_then_get_pauschbetrag_returns_result_of_calculate_pauschbetrag(self, new_test_request_context):
         stored_data = {
             'person_a_has_disability': 'yes',
-            'person_a_has_pflegegrad': True, 
+            'person_a_has_pflegegrad': 'yes', 
         }
         value = 'yes'
         pauschbetrag_result = 1
@@ -94,7 +94,7 @@ class TestPauschbetragPersonAGetOverviewValueRepresentation:
     def test_if_merkzeichen_given_and_requests_pauschbetrag_no_then_get_pauschbetrag_returns_no_request_label(self, new_test_request_context):
         stored_data = {
             'person_a_has_disability': 'yes',
-            'person_a_has_pflegegrad': True,
+            'person_a_has_pflegegrad': 'yes',
         }
         value = 'no'
 
@@ -202,7 +202,7 @@ class TestPauschbetragPersonBGetOverviewValueRepresentation:
             'familienstand_married_lived_separated': 'no',
             'familienstand_confirm_zusammenveranlagung': True,
             'person_b_has_disability': 'yes',
-            'person_b_has_pflegegrad': True, 
+            'person_b_has_pflegegrad': 'yes', 
         }
         value = 'yes'
         pauschbetrag_result = 1
@@ -222,7 +222,7 @@ class TestPauschbetragPersonBGetOverviewValueRepresentation:
             'familienstand_married_lived_separated': 'no',
             'familienstand_confirm_zusammenveranlagung': True,
             'person_b_has_disability': 'yes',
-            'person_b_has_pflegegrad': True,
+            'person_b_has_pflegegrad': 'yes',
         }
         value = 'no'
 

--- a/webapp/tests/forms/steps/lotse/test_pauschbetrag_steps.py
+++ b/webapp/tests/forms/steps/lotse/test_pauschbetrag_steps.py
@@ -1,4 +1,5 @@
 from werkzeug.datastructures import MultiDict, ImmutableMultiDict
+from flask_babel import _
 
 from app.forms.flows.lotse_step_chooser import LotseStepChooser
 from app.forms.steps.lotse.pauschbetrag import StepPauschbetragPersonA, StepPauschbetragPersonB, calculate_pauschbetrag
@@ -70,10 +71,12 @@ class TestPauschbetragPersonAGetPauschbetrag:
             
             assert pauschbetrag == expected_pauschbetrag
 
+
 class TestPauschbetragPersonAGetOverviewValueRepresentation:
-    def test_if_merkzeichen_given_then_get_pauschbetrag_returns_result_of_calculate_pauschbetrag(self, new_test_request_context):
+
+    def test_if_merkzeichen_given_and_requests_pauschbetrag_yes_then_get_pauschbetrag_returns_result_of_calculate_pauschbetrag(self, new_test_request_context):
         stored_data = {
-            'person_a_has_disability':'yes', 
+            'person_a_has_disability': 'yes',
             'person_a_has_pflegegrad': True, 
         }
         value = 'yes'
@@ -87,67 +90,41 @@ class TestPauschbetragPersonAGetOverviewValueRepresentation:
                 overview_value = step.get_overview_value_representation(value)
             
                 assert str(pauschbetrag_result) in overview_value
-            
-            
-class TestPauschbetragPersonBValidation:
-    def test_if_person_b_has_disability_is_given_then_validation_should_be_success(self, new_test_request_context):
-        data = MultiDict({
-            'familienstand': 'married',
-            'familienstand_married_lived_separated': 'no',
-            'familienstand_confirm_zusammenveranlagung': True,
-            'person_a_has_disability': 'no',
-            'person_b_has_disability': 'yes',
-            'person_b_requests_pauschbetrag': 'yes'
-        })
-        with new_test_request_context(stored_data=data):
-            step = LotseStepChooser().get_correct_step(
-                StepPauschbetragPersonB.name, True, ImmutableMultiDict(data))
-            form = step.render_info.form
-            assert form.validate() == True
 
-    def test_if_precondition_person_b_has_disability_is_yes_is_not_satisfied_return_should_be_a_redirect_to_person_a_has_disability(self, new_test_request_context):
-        data = MultiDict({
-            'familienstand': 'married',
-            'familienstand_married_lived_separated': 'no',
-            'familienstand_confirm_zusammenveranlagung': True,
-            'person_a_has_disability': 'no',
-            'person_b_has_disability': 'no',
-            'person_b_requests_pauschbetrag': 'yes'
-        })
-        with new_test_request_context(stored_data=data):
-            step = LotseStepChooser().get_correct_step(
-                StepPauschbetragPersonB.name, True, ImmutableMultiDict(data))
-            assert step.redirection_step_name == 'person_b_has_disability'
-            
-    
-    def test_if_precondition_show_person_b_is_not_satisfied_return_should_be_a_redirect_to_familienstand(self, new_test_request_context):
-        data = MultiDict({
-            'person_b_has_disability': 'yes',
-            'person_b_requests_pauschbetrag': 'yes'
-        })
-        with new_test_request_context(stored_data=data):
-            step = LotseStepChooser().get_correct_step(
-                StepPauschbetragPersonB.name, True, ImmutableMultiDict(data))
-            assert step.redirection_step_name == 'familienstand' 
-
-
-class TestPauschbetragPersonBValidation:
-
-    def test_if_person_b_has_disability_is_given_then_validation_should_be_success(self, new_test_request_context):
-        form_data = {'person_b_requests_pauschbetrag': 'no'}
+    def test_if_merkzeichen_given_and_requests_pauschbetrag_no_then_get_pauschbetrag_returns_no_request_label(self, new_test_request_context):
         stored_data = {
+            'person_a_has_disability': 'yes',
+            'person_a_has_pflegegrad': True,
+        }
+        value = 'no'
+
+        with new_test_request_context(stored_data=stored_data):
+            step = LotseStepChooser().get_correct_step(
+                    StepPauschbetragPersonA.name, True, ImmutableMultiDict({}))
+
+            overview_value = step.get_overview_value_representation(value)
+
+            assert overview_value == _('form.lotse.summary.not-requested')
+            
+            
+class TestPauschbetragPersonBValidation:
+
+    def test_if_person_b_has_disability_is_given_then_validation_should_be_success(self, new_test_request_context):
+        data = MultiDict({
             'familienstand': 'married',
             'familienstand_married_lived_separated': 'no',
             'familienstand_confirm_zusammenveranlagung': True,
+            'person_a_has_disability': 'no',
             'person_b_has_disability': 'yes',
             'person_b_has_pflegegrad': 'yes',
-        }
-        with new_test_request_context(form_data=form_data, stored_data=stored_data, method='POST'):
+            'person_b_requests_pauschbetrag': 'yes',
+        })
+        with new_test_request_context(stored_data=data):
             step = LotseStepChooser().get_correct_step(
-                StepPauschbetragPersonB.name, True, ImmutableMultiDict(form_data))
+                StepPauschbetragPersonB.name, True, ImmutableMultiDict(data))
             form = step.render_info.form
             assert form.validate() is True
-            
+
     def test_if_person_b_requests_pauschbetrag_is_not_given_then_validation_should_be_false(self, new_test_request_context):
         form_data = {}
         stored_data = {
@@ -165,6 +142,7 @@ class TestPauschbetragPersonBValidation:
             
 
 class TestPreconditionPauschbetragPersonBValidation:
+
     def test_if_empty_data_then_redirect_to_familienstand(self, new_test_request_context):
         data = {}
         with new_test_request_context(stored_data=data):
@@ -185,6 +163,7 @@ class TestPreconditionPauschbetragPersonBValidation:
             
     
 class TestPauschbetragPersonBGetPauschbetrag:
+
     def test_if_merkzeichen_given_then_get_pauschbetrag_returns_result_of_calculate_pauschbetrag(self, new_test_request_context):
         stored_data = MultiDict({
             'familienstand': 'married',
@@ -214,13 +193,15 @@ class TestPauschbetragPersonBGetPauschbetrag:
             
             assert pauschbetrag == expected_pauschbetrag
 
+
 class TestPauschbetragPersonBGetOverviewValueRepresentation:
+
     def test_if_merkzeichen_given_then_get_pauschbetrag_returns_result_of_calculate_pauschbetrag(self, new_test_request_context):
         stored_data = {
             'familienstand': 'married',
             'familienstand_married_lived_separated': 'no',
             'familienstand_confirm_zusammenveranlagung': True,
-            'person_b_has_disability':'yes', 
+            'person_b_has_disability': 'yes',
             'person_b_has_pflegegrad': True, 
         }
         value = 'yes'
@@ -234,3 +215,21 @@ class TestPauschbetragPersonBGetOverviewValueRepresentation:
                 overview_value = step.get_overview_value_representation(value)
         
                 assert str(pauschbetrag_result) in overview_value
+
+    def test_if_merkzeichen_given_and_requests_pauschbetrag_no_then_get_pauschbetrag_returns_no_request_label(self, new_test_request_context):
+        stored_data = {
+            'familienstand': 'married',
+            'familienstand_married_lived_separated': 'no',
+            'familienstand_confirm_zusammenveranlagung': True,
+            'person_b_has_disability': 'yes',
+            'person_b_has_pflegegrad': True,
+        }
+        value = 'no'
+
+        with new_test_request_context(stored_data=stored_data):
+            step = LotseStepChooser().get_correct_step(
+                    StepPauschbetragPersonB.name, True, ImmutableMultiDict({}))
+
+            overview_value = step.get_overview_value_representation(value)
+
+            assert overview_value == _('form.lotse.summary.not-requested')


### PR DESCRIPTION
# Short Description
Nadine found some problems with the Pauschbetrag step:
- One typo (`festgestellen`instead of `festgestellten`)
- Person A was not shown on the summary page
- If a user did not request the Pauschbetrag nothing was displayed on the summary page

# Changes
- Fix typos
- Update the `get_label` method to ensure that Person A is shown
- Display "Keine Beantragung" on summary page if no has been selected. 


# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
