### PR TITLE
Add backlink to confirmation page

### DIFF
--- a/webapp/app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py
+++ b/webapp/app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py
@@ -42,6 +42,7 @@ class StepConfirmation(FormStep):
             fields=form_fields_dict(render_info.form),
             terms_of_service_link=url_for('agb'),
             data_privacy_link=url_for('data_privacy'),
+            prev_url=render_info.prev_url,
         ).camelized_dict()
 
         return render_template('react_component.html',

--- a/webapp/client/src/pages/ConfirmationPage.js
+++ b/webapp/client/src/pages/ConfirmationPage.js
@@ -13,11 +13,13 @@ export default function ConfirmationPage({
   fields,
   dataPrivacyLink,
   termsOfServiceLink,
+  prevUrl,
 }) {
   const { t } = useTranslation();
 
   return (
     <>
+      <StepHeaderButtons url={prevUrl} />
       <StepHeaderButtons />
       <FormHeader {...stepHeader} />
       <StepForm {...form} nextButtonLabel={t("lotse.confirmation.finish")}>
@@ -87,4 +89,5 @@ ConfirmationPage.propTypes = {
   }).isRequired,
   dataPrivacyLink: PropTypes.string.isRequired,
   termsOfServiceLink: PropTypes.string.isRequired,
+  prevUrl: PropTypes.string.isRequired,
 };

--- a/webapp/client/src/stories/ConfirmationPage.stories.js
+++ b/webapp/client/src/stories/ConfirmationPage.stories.js
@@ -32,6 +32,7 @@ Default.args = {
   },
   termsOfServiceLink: "/agb",
   dataPrivacyLink: "/datenschutz",
+  prevUrl: "/prevUrl",
 };
 
 export const WithErrors = Template.bind({});


### PR DESCRIPTION
# Short Description
During QA, Nadine found a missing backlink on the confirmation page. The reason for that bug was that we did not set the corresponding previous Url prop in the React component. This adds the prop and sets the url in the corresponding step.

# Feedback
- Do you have any problem with that

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
