### PR TITLE
Use correct values in fahrkostenpauschalen precondtion

### DIFF
--- a/webapp/app/forms/steps/lotse/fahrkostenpauschale.py
+++ b/webapp/app/forms/steps/lotse/fahrkostenpauschale.py
@@ -20,6 +20,7 @@ from app.forms.steps.step import SectionLink
 from app.forms.steps.lotse.lotse_step import LotseFormSteuerlotseStep
 from app.model.disability_data import DisabilityModel
 
+
 def calculate_fahrkostenpauschale(has_pflegegrad: str = None, disability_degree: int = None,
                                   has_merkzeichen_bl: bool = False, has_merkzeichen_tbl: bool = False,
                                   has_merkzeichen_h: bool = False, has_merkzeichen_ag: bool = False,
@@ -34,7 +35,6 @@ def calculate_fahrkostenpauschale(has_pflegegrad: str = None, disability_degree:
     return 0
 
 
-
 class HasFahrkostenpauschaleClaimPersonAPrecondition(DisabilityModel):
     _step_to_redirect_to = StepMerkzeichenPersonA.name
     _message_to_flash = _l('form.lotse.skip_reason.has_fahrkostenpauschale_claim')
@@ -45,10 +45,10 @@ class HasFahrkostenpauschaleClaimPersonAPrecondition(DisabilityModel):
             has_pflegegrad=values.get('person_a_has_pflegegrad', None),
             disability_degree=values.get('person_a_disability_degree', None),
             has_merkzeichen_bl=values.get('person_a_has_merkzeichen_bl', False),
-            has_merkzeichen_tbl=values.get('person_a_has_merkzeichen_bl', False),
-            has_merkzeichen_h=values.get('person_a_has_merkzeichen_bl', False),
-            has_merkzeichen_ag=values.get('person_a_has_merkzeichen_tbl', False),
-            has_merkzeichen_g=values.get('person_a_has_merkzeichen_h', False)
+            has_merkzeichen_tbl=values.get('person_a_has_merkzeichen_tbl', False),
+            has_merkzeichen_h=values.get('person_a_has_merkzeichen_h', False),
+            has_merkzeichen_ag=values.get('person_a_has_merkzeichen_ag', False),
+            has_merkzeichen_g=values.get('person_a_has_merkzeichen_g', False)
         )
 
         if fahrkostenpauschale_claim == 0:

--- a/webapp/app/forms/steps/lotse/no_pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/no_pauschbetrag.py
@@ -13,7 +13,6 @@ from app.forms.steps.lotse.pauschbetrag import DisabilityModel, calculate_pausch
 from app.model.components import NoPauschbetragProps
 
 
-
 class HasNoPauschbetragOrFahrkostenpauschbetragClaimPersonAPrecondition(DisabilityModel):
     _step_to_redirect_to = StepMerkzeichenPersonA.name
     _message_to_flash = _l('form.lotse.skip_reason.has_pauschbetrag_claim')
@@ -31,10 +30,10 @@ class HasNoPauschbetragOrFahrkostenpauschbetragClaimPersonAPrecondition(Disabili
             has_pflegegrad=values.get('person_a_has_pflegegrad', None),
             disability_degree=values.get('person_a_disability_degree', None),
             has_merkzeichen_bl=values.get('person_a_has_merkzeichen_bl', False),
-            has_merkzeichen_tbl=values.get('person_a_has_merkzeichen_bl', False),
-            has_merkzeichen_h=values.get('person_a_has_merkzeichen_bl', False),
-            has_merkzeichen_ag=values.get('person_a_has_merkzeichen_tbl', False),
-            has_merkzeichen_g=values.get('person_a_has_merkzeichen_h', False)
+            has_merkzeichen_tbl=values.get('person_a_has_merkzeichen_tbl', False),
+            has_merkzeichen_h=values.get('person_a_has_merkzeichen_h', False),
+            has_merkzeichen_ag=values.get('person_a_has_merkzeichen_ag', False),
+            has_merkzeichen_g=values.get('person_a_has_merkzeichen_g', False)
         )
 
         if pauschbetrag_claim != 0 or fahrkostenpauschbetrag_claim != 0:
@@ -61,7 +60,7 @@ class HasNoPauschbetragOrFahrkostenpauschbetragClaimPersonBPrecondition(Disabili
             has_merkzeichen_bl=values.get('person_b_has_merkzeichen_bl', False),
             has_merkzeichen_tbl=values.get('person_b_has_merkzeichen_tbl', False),
             has_merkzeichen_h=values.get('person_b_has_merkzeichen_h', False),
-            has_merkzeichen_ag=values.get('person_b_has_merkzeichen_tbl', False),
+            has_merkzeichen_ag=values.get('person_b_has_merkzeichen_ag', False),
             has_merkzeichen_g=values.get('person_b_has_merkzeichen_g', False)
         )
 

--- a/webapp/tests/forms/steps/lotse/test_fahrkostenpauschale.py
+++ b/webapp/tests/forms/steps/lotse/test_fahrkostenpauschale.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 import pytest
 from pydantic import ValidationError
@@ -510,6 +510,7 @@ class TestFahrkostenpauschalePersonBGetOverviewValueRepresentation:
 
 
 class TestHasFahrkostenpauschaleClaimPersonAPrecondition:
+
     def test_if_calculate_fahrkostenpauschale_returns_zero_then_raise_validation_error(self):
         with patch('app.forms.steps.lotse.fahrkostenpauschale.calculate_fahrkostenpauschale', MagicMock(return_value=0)):
             with pytest.raises(ValidationError):
@@ -519,8 +520,33 @@ class TestHasFahrkostenpauschaleClaimPersonAPrecondition:
         with patch('app.forms.steps.lotse.fahrkostenpauschale.calculate_fahrkostenpauschale', MagicMock(return_value=1)):
             HasFahrkostenpauschaleClaimPersonAPrecondition.parse_obj({})
 
+    def test_if_values_given_then_call_get_fahrkostenpauschale_with_values(self):
+        input_data = {
+            'person_a_has_pflegegrad': 'yes',
+            'person_a_disability_degree': 20,
+            'person_a_has_merkzeichen_bl': True,
+            'person_a_has_merkzeichen_tbl': True,
+            'person_a_has_merkzeichen_h': True,
+            'person_a_has_merkzeichen_ag': True,
+            'person_a_has_merkzeichen_g': True,
+        }
+        with patch('app.forms.steps.lotse.fahrkostenpauschale.calculate_fahrkostenpauschale',
+                      MagicMock(return_value=1)) as calc_fahrkostenpauschale_mock:
+            HasFahrkostenpauschaleClaimPersonAPrecondition.parse_obj(input_data)
+
+            assert calc_fahrkostenpauschale_mock.call_args == call(
+                has_pflegegrad=input_data['person_a_has_pflegegrad'],
+                disability_degree=input_data['person_a_disability_degree'],
+                has_merkzeichen_bl=input_data['person_a_has_merkzeichen_bl'],
+                has_merkzeichen_tbl=input_data['person_a_has_merkzeichen_tbl'],
+                has_merkzeichen_h=input_data['person_a_has_merkzeichen_h'],
+                has_merkzeichen_g=input_data['person_a_has_merkzeichen_g'],
+                has_merkzeichen_ag=input_data['person_a_has_merkzeichen_ag']
+            )
+
 
 class TestHasFahrkostenpauschaleClaimPersonBPrecondition:
+
     def test_if_calculate_fahrkostenpauschale_returns_zero_then_raise_validation_error(self):
         with patch('app.forms.steps.lotse.fahrkostenpauschale.calculate_fahrkostenpauschale', MagicMock(return_value=0)):
             with pytest.raises(ValidationError):
@@ -529,3 +555,27 @@ class TestHasFahrkostenpauschaleClaimPersonBPrecondition:
     def test_if_calculate_fahrkostenpauschale_returns_number_other_than_zero_then_raise_no_error(self):
         with patch('app.forms.steps.lotse.fahrkostenpauschale.calculate_fahrkostenpauschale', MagicMock(return_value=1)):
             HasFahrkostenpauschaleClaimPersonBPrecondition.parse_obj({})
+
+    def test_if_values_given_then_call_get_fahrkostenpauschale_with_values(self):
+        input_data = {
+            'person_b_has_pflegegrad': 'yes',
+            'person_b_disability_degree': 20,
+            'person_b_has_merkzeichen_bl': True,
+            'person_b_has_merkzeichen_tbl': True,
+            'person_b_has_merkzeichen_h': True,
+            'person_b_has_merkzeichen_ag': True,
+            'person_b_has_merkzeichen_g': True,
+        }
+        with patch('app.forms.steps.lotse.fahrkostenpauschale.calculate_fahrkostenpauschale',
+                      MagicMock(return_value=1)) as calc_fahrkostenpauschale_mock:
+            HasFahrkostenpauschaleClaimPersonBPrecondition.parse_obj(input_data)
+
+            assert calc_fahrkostenpauschale_mock.call_args == call(
+                has_pflegegrad=input_data['person_b_has_pflegegrad'],
+                disability_degree=input_data['person_b_disability_degree'],
+                has_merkzeichen_bl=input_data['person_b_has_merkzeichen_bl'],
+                has_merkzeichen_tbl=input_data['person_b_has_merkzeichen_tbl'],
+                has_merkzeichen_h=input_data['person_b_has_merkzeichen_h'],
+                has_merkzeichen_g=input_data['person_b_has_merkzeichen_g'],
+                has_merkzeichen_ag=input_data['person_b_has_merkzeichen_ag']
+            )

--- a/webapp/tests/forms/steps/lotse/test_no_pauschbetrag.py
+++ b/webapp/tests/forms/steps/lotse/test_no_pauschbetrag.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 import pytest
 from pydantic import ValidationError
@@ -48,6 +48,54 @@ class TestHasNoPauschbetragOrFahrkostenpauschbetragClaimPersonAPrecondition:
             with pytest.raises(ValidationError):
                 HasNoPauschbetragOrFahrkostenpauschbetragClaimPersonAPrecondition.parse_obj({})
 
+    def test_if_values_given_then_call_get_pauschbetrag_with_values(self):
+        input_data = {
+            'person_a_has_pflegegrad': 'yes',
+            'person_a_disability_degree': 20,
+            'person_a_has_merkzeichen_bl': True,
+            'person_a_has_merkzeichen_tbl': True,
+            'person_a_has_merkzeichen_h': True,
+        }
+        with patch('app.forms.steps.lotse.no_pauschbetrag.calculate_pauschbetrag',
+                   MagicMock(return_value=0)) as calc_pauschbetrag_mock, \
+                patch('app.forms.steps.lotse.no_pauschbetrag.calculate_fahrkostenpauschale',
+                      MagicMock(return_value=0)):
+            HasNoPauschbetragOrFahrkostenpauschbetragClaimPersonAPrecondition.parse_obj(input_data)
+
+            assert calc_pauschbetrag_mock.call_args == call(
+                has_pflegegrad=input_data['person_a_has_pflegegrad'],
+                disability_degree=input_data['person_a_disability_degree'],
+                has_merkzeichen_bl=input_data['person_a_has_merkzeichen_bl'],
+                has_merkzeichen_tbl=input_data['person_a_has_merkzeichen_tbl'],
+                has_merkzeichen_h=input_data['person_a_has_merkzeichen_h']
+            )
+
+    def test_if_values_given_then_call_get_fahrkostenpauschale_with_values(self):
+        input_data = {
+            'person_a_has_pflegegrad': 'yes',
+            'person_a_disability_degree': 20,
+            'person_a_has_merkzeichen_bl': True,
+            'person_a_has_merkzeichen_tbl': True,
+            'person_a_has_merkzeichen_h': True,
+            'person_a_has_merkzeichen_ag': True,
+            'person_a_has_merkzeichen_g': True,
+        }
+        with patch('app.forms.steps.lotse.no_pauschbetrag.calculate_pauschbetrag',
+                   MagicMock(return_value=0)), \
+                patch('app.forms.steps.lotse.no_pauschbetrag.calculate_fahrkostenpauschale',
+                      MagicMock(return_value=0)) as calc_fahrkostenpauschale_mock:
+            HasNoPauschbetragOrFahrkostenpauschbetragClaimPersonAPrecondition.parse_obj(input_data)
+
+            assert calc_fahrkostenpauschale_mock.call_args == call(
+                has_pflegegrad=input_data['person_a_has_pflegegrad'],
+                disability_degree=input_data['person_a_disability_degree'],
+                has_merkzeichen_bl=input_data['person_a_has_merkzeichen_bl'],
+                has_merkzeichen_tbl=input_data['person_a_has_merkzeichen_tbl'],
+                has_merkzeichen_h=input_data['person_a_has_merkzeichen_h'],
+                has_merkzeichen_g=input_data['person_a_has_merkzeichen_g'],
+                has_merkzeichen_ag=input_data['person_a_has_merkzeichen_ag']
+            )
+
 
 class TestHasNoPauschbetragOrFahrkostenpauschbetragClaimPersonBPrecondition:
     def test_if_calculate_pauschbetrag_and_fahrkostenpauschbetrag_return_zero_then_raise_no_error(self):
@@ -87,3 +135,51 @@ class TestHasNoPauschbetragOrFahrkostenpauschbetragClaimPersonBPrecondition:
                    MagicMock(return_value=1)):
             with pytest.raises(ValidationError):
                 HasNoPauschbetragOrFahrkostenpauschbetragClaimPersonBPrecondition.parse_obj({})
+
+    def test_if_values_given_then_call_get_pauschbetrag_with_values(self):
+        input_data = {
+            'person_b_has_pflegegrad': 'yes',
+            'person_b_disability_degree': 20,
+            'person_b_has_merkzeichen_bl': True,
+            'person_b_has_merkzeichen_tbl': True,
+            'person_b_has_merkzeichen_h': True,
+        }
+        with patch('app.forms.steps.lotse.no_pauschbetrag.calculate_pauschbetrag',
+                   MagicMock(return_value=0)) as calc_pauschbetrag_mock, \
+                patch('app.forms.steps.lotse.no_pauschbetrag.calculate_fahrkostenpauschale',
+                      MagicMock(return_value=0)):
+            HasNoPauschbetragOrFahrkostenpauschbetragClaimPersonBPrecondition.parse_obj(input_data)
+
+            assert calc_pauschbetrag_mock.call_args == call(
+                has_pflegegrad=input_data['person_b_has_pflegegrad'],
+                disability_degree=input_data['person_b_disability_degree'],
+                has_merkzeichen_bl=input_data['person_b_has_merkzeichen_bl'],
+                has_merkzeichen_tbl=input_data['person_b_has_merkzeichen_tbl'],
+                has_merkzeichen_h=input_data['person_b_has_merkzeichen_h']
+            )
+
+    def test_if_values_given_then_call_get_fahrkostenpauschale_with_values(self):
+        input_data = {
+            'person_b_has_pflegegrad': 'yes',
+            'person_b_disability_degree': 20,
+            'person_b_has_merkzeichen_bl': True,
+            'person_b_has_merkzeichen_tbl': True,
+            'person_b_has_merkzeichen_h': True,
+            'person_b_has_merkzeichen_ag': True,
+            'person_b_has_merkzeichen_g': True,
+        }
+        with patch('app.forms.steps.lotse.no_pauschbetrag.calculate_pauschbetrag',
+                   MagicMock(return_value=0)), \
+                patch('app.forms.steps.lotse.no_pauschbetrag.calculate_fahrkostenpauschale',
+                      MagicMock(return_value=0)) as calc_fahrkostenpauschale_mock:
+            HasNoPauschbetragOrFahrkostenpauschbetragClaimPersonBPrecondition.parse_obj(input_data)
+
+            assert calc_fahrkostenpauschale_mock.call_args == call(
+                has_pflegegrad=input_data['person_b_has_pflegegrad'],
+                disability_degree=input_data['person_b_disability_degree'],
+                has_merkzeichen_bl=input_data['person_b_has_merkzeichen_bl'],
+                has_merkzeichen_tbl=input_data['person_b_has_merkzeichen_tbl'],
+                has_merkzeichen_h=input_data['person_b_has_merkzeichen_h'],
+                has_merkzeichen_g=input_data['person_b_has_merkzeichen_g'],
+                has_merkzeichen_ag=input_data['person_b_has_merkzeichen_ag']
+            )


### PR DESCRIPTION
# Short Description
the FahrkostenpauschaleStep was not displayed correctly. The reason for that was that we had some copy-pasta error with the values that we took from the session data. I changed those keys and added tests for that.


# Feedback
- Are you fine with the tests?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
