### PR TITLE
Fail Merkzeichen validation if disability degree 0

### DIFF
--- a/webapp/app/forms/steps/lotse/merkzeichen.py
+++ b/webapp/app/forms/steps/lotse/merkzeichen.py
@@ -54,17 +54,17 @@ class StepMerkzeichenPersonA(LotseFormSteuerlotseStep):
                 validators.InputRequired(_l('form.lotse.validation-disability_degree.merkzeichen_g_selected.required'))(
                     self, field)
 
-                if field.data and field.data < 20:
+                if field.data is not None and field.data < 20:
                     raise ValidationError(_l('form.lotse.merkzeichen_g_selected.validation-disability_degree.min20'))
             elif self.person_a_has_merkzeichen_ag.data:
                 validators.InputRequired(
                     _l('form.lotse.validation-disability_degree.merkzeichen_ag_selected.required'))(self, field)
 
-                if field.data and field.data < 20:
+                if field.data is not None and field.data < 20:
                     raise ValidationError(_l('form.lotse.merkzeichen_ag_selected.validation-disability_degree.min20'))
             else:
                 validators.Optional()(self, field)
-                if field.data and 0 < field.data < 20:
+                if field.data is not None and 0 < field.data < 20:
                     raise ValidationError(_l('form.lotse.validation-disability_degree.min20'))
 
 
@@ -143,17 +143,17 @@ class StepMerkzeichenPersonB(LotseFormSteuerlotseStep):
                 validators.InputRequired(_l('form.lotse.validation-disability_degree.merkzeichen_g_selected.required'))(
                     self, field)
 
-                if field.data and field.data < 20:
+                if field.data is not None and field.data < 20:
                     raise ValidationError(_l('form.lotse.merkzeichen_g_selected.validation-disability_degree.min20'))
             elif self.person_b_has_merkzeichen_ag.data:
                 validators.InputRequired(
                     _l('form.lotse.validation-disability_degree.merkzeichen_ag_selected.required'))(self, field)
 
-                if field.data and field.data < 20:
+                if field.data is not None and field.data < 20:
                     raise ValidationError(_l('form.lotse.merkzeichen_ag_selected.validation-disability_degree.min20'))
             else:
                 validators.Optional()(self, field)
-                if field.data and 0 < field.data < 20:
+                if field.data is not None and 0 < field.data < 20:
                     raise ValidationError(_l('form.lotse.validation-disability_degree.min20'))
 
     @classmethod

--- a/webapp/app/forms/steps/lotse/no_pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/no_pauschbetrag.py
@@ -13,7 +13,6 @@ from app.forms.steps.lotse.pauschbetrag import DisabilityModel, calculate_pausch
 from app.model.components import NoPauschbetragProps
 
 
-
 class HasNoPauschbetragOrFahrkostenpauschbetragClaimPersonAPrecondition(DisabilityModel):
     _step_to_redirect_to = StepMerkzeichenPersonA.name
     _message_to_flash = _l('form.lotse.skip_reason.has_pauschbetrag_claim')

--- a/webapp/app/forms/steps/lotse/pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/pauschbetrag.py
@@ -95,6 +95,7 @@ class HasPauschbetragClaimPersonBPrecondition(DisabilityModel):
             raise ValidationError
         return values
 
+
 class StepPauschbetragPersonA(LotseFormSteuerlotseStep):
     name = 'person_a_requests_pauschbetrag'
     section_link = SectionLink('mandatory_data', StepFamilienstand.name, _l('form.lotse.mandatory_data.label'))

--- a/webapp/tests/forms/steps/lotse/test_merkzeichen.py
+++ b/webapp/tests/forms/steps/lotse/test_merkzeichen.py
@@ -83,10 +83,20 @@ class TestStepMerkzeichenPersonAValidation:
             assert form.validate() is False
 
     def test_if_disability_degree_below_20_and_has_merkzeichen_g_then_fail_validation(self):
-        for not_allowed_value in [1, 19]:
+        for not_allowed_value in [0, 1, 19]:
             data = MultiDict({'person_a_has_pflegegrad': 'no',
                               'person_a_disability_degree': not_allowed_value,
                               'person_a_has_merkzeichen_g': True})
+
+            form = new_merkzeichen_person_a_step(form_data=data).render_info.form
+
+            assert form.validate() is False
+
+    def test_if_disability_degree_below_20_and_has_merkzeichen_ag_then_fail_validation(self):
+        for not_allowed_value in [0, 1, 19]:
+            data = MultiDict({'person_a_has_pflegegrad': 'no',
+                              'person_a_disability_degree': not_allowed_value,
+                              'person_a_has_merkzeichen_ag': True})
 
             form = new_merkzeichen_person_a_step(form_data=data).render_info.form
 
@@ -268,10 +278,20 @@ class TestStepMerkzeichenPersonBValidation:
             assert form.validate() is False
 
     def test_if_disability_degree_below_20_and_has_merkzeichen_g_then_fail_validation(self):
-        for not_allowed_value in [1, 19]:
+        for not_allowed_value in [0, 1, 19]:
             data = MultiDict({'person_b_has_pflegegrad': 'no',
                               'person_b_disability_degree': not_allowed_value,
                               'person_b_has_merkzeichen_g': True})
+
+            form = new_merkzeichen_person_b_step(form_data=data).render_info.form
+
+            assert form.validate() is False
+
+    def test_if_disability_degree_below_20_and_has_merkzeichen_ag_then_fail_validation(self):
+        for not_allowed_value in [0, 1, 19]:
+            data = MultiDict({'person_b_has_pflegegrad': 'no',
+                              'person_b_disability_degree': not_allowed_value,
+                              'person_b_has_merkzeichen_ag': True})
 
             form = new_merkzeichen_person_b_step(form_data=data).render_info.form
 


### PR DESCRIPTION
# Short Description
The validation did not show an error on the Merkzeichen page if Merkzeichen G or aG was selected and the disability degree was zero. The reason was that 0 is converted to False. However, we only want to check for None. This changes that.


# Feedback
- Does it work for you

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
