### PR TITLE
Delete fields if no claims exists

### DIFF
--- a/webapp/app/forms/steps/lotse/pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/pauschbetrag.py
@@ -121,8 +121,8 @@ class StepPauschbetragPersonA(LotseFormSteuerlotseStep):
             result = str(self.get_pauschbetrag(stored_data)) + ' ' + _('currency.euro')
         elif value == 'no':
             result = _('form.lotse.summary.not-requested')
-        elif not value and stored_data.get('person_a_has_disability') == 'yes':
-            result = _('form.lotse.no_answer')
+        elif self.get_pauschbetrag(stored_data) == 0:
+            result = _('form.lotse.summary.no-claim')
 
         return result
 
@@ -185,8 +185,8 @@ class StepPauschbetragPersonB(LotseFormSteuerlotseStep):
             result = str(self.get_pauschbetrag(stored_data)) + ' ' + _('currency.euro')
         elif value == 'no':
             result = _('form.lotse.summary.not-requested')
-        elif not value and stored_data.get('person_b_has_disability') == 'yes':
-            result = _('form.lotse.no_answer')
+        elif self.get_pauschbetrag(stored_data) == 0:
+            result = _('form.lotse.summary.no-claim')
 
         return result
 

--- a/webapp/app/model/form_data.py
+++ b/webapp/app/model/form_data.py
@@ -439,6 +439,42 @@ class FormDataDependencies(BaseModel):
             return None
         return v
 
+    @validator('person_a_requests_pauschbetrag')
+    def delete_person_a_pauschbetrags_request_data_if_no_claim(cls, v, values):
+        try:
+            from app.forms.steps.lotse.pauschbetrag import HasPauschbetragClaimPersonAPrecondition
+            HasPauschbetragClaimPersonAPrecondition.parse_obj(values)
+            return v
+        except ValidationError:
+            return None
+
+    @validator('person_b_requests_pauschbetrag')
+    def delete_person_b_pauschbetrags_request_data_if_no_claim(cls, v, values):
+        try:
+            from app.forms.steps.lotse.pauschbetrag import HasPauschbetragClaimPersonBPrecondition
+            HasPauschbetragClaimPersonBPrecondition.parse_obj(values)
+            return v
+        except ValidationError:
+            return None
+
+    @validator('person_a_requests_fahrkostenpauschale')
+    def delete_person_a_fahrkostenpauschale_request_data_if_no_claim(cls, v, values):
+        try:
+            from app.forms.steps.lotse.fahrkostenpauschale import HasFahrkostenpauschaleClaimPersonAPrecondition
+            HasFahrkostenpauschaleClaimPersonAPrecondition.parse_obj(values)
+            return v
+        except ValidationError:
+            return None
+
+    @validator('person_b_requests_fahrkostenpauschale')
+    def delete_person_b_fahrkostenpauschale_request_data_if_no_claim(cls, v, values):
+        try:
+            from app.forms.steps.lotse.fahrkostenpauschale import HasFahrkostenpauschaleClaimPersonBPrecondition
+            HasFahrkostenpauschaleClaimPersonBPrecondition.parse_obj(values)
+            return v
+        except ValidationError:
+            return None
+
 
 class InputDataInvalidError(ValueError):
     """Raised in case of invalid input data at the end of the lotse flow. This is an abstract class.

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-01-10 16:41+0100\n"
+"POT-Creation-Date: 2022-01-11 11:36+0100\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -205,8 +205,8 @@ msgstr "Ihre Steuererklärung"
 msgid "form.logout"
 msgstr "Abmelden"
 
-#: app/forms/flows/lotse_flow.py:323 app/forms/steps/lotse/pauschbetrag.py:123
-#: app/forms/steps/lotse/pauschbetrag.py:187
+#: app/forms/flows/lotse_flow.py:323 app/forms/steps/lotse/pauschbetrag.py:127
+#: app/forms/steps/lotse/pauschbetrag.py:193
 msgid "form.lotse.no_answer"
 msgstr "Keine Angabe"
 
@@ -291,8 +291,8 @@ msgstr "verwitwet"
 #: app/forms/steps/lotse/fahrkostenpauschale.py:165
 #: app/forms/steps/lotse/has_disability.py:29
 #: app/forms/steps/lotse/has_disability.py:63
-#: app/forms/steps/lotse/pauschbetrag.py:108
-#: app/forms/steps/lotse/pauschbetrag.py:173
+#: app/forms/steps/lotse/pauschbetrag.py:110
+#: app/forms/steps/lotse/pauschbetrag.py:177
 msgid "validate.input-required"
 msgstr "Diese Angabe wird benötigt, um fortfahren zu können."
 
@@ -1100,14 +1100,14 @@ msgstr ""
 "Fahrkostenpauschale."
 
 #: app/forms/steps/lotse/fahrkostenpauschale.py:86
-#: app/forms/steps/lotse/pauschbetrag.py:119
-#: app/forms/steps/lotse/pauschbetrag.py:183
+#: app/forms/steps/lotse/pauschbetrag.py:121
+#: app/forms/steps/lotse/pauschbetrag.py:187
 msgid "currency.euro"
 msgstr "Euro"
 
 #: app/forms/steps/lotse/fahrkostenpauschale.py:88
-#: app/forms/steps/lotse/pauschbetrag.py:121
-#: app/forms/steps/lotse/pauschbetrag.py:185
+#: app/forms/steps/lotse/pauschbetrag.py:123
+#: app/forms/steps/lotse/pauschbetrag.py:189
 msgid "form.lotse.summary.not-requested"
 msgstr "Keine Beantragung"
 
@@ -1117,8 +1117,8 @@ msgstr "Keine Beantragung"
 #: app/forms/steps/lotse/has_disability.py:58
 #: app/forms/steps/lotse/merkzeichen.py:31
 #: app/forms/steps/lotse/merkzeichen.py:120
-#: app/forms/steps/lotse/pauschbetrag.py:100
-#: app/forms/steps/lotse/pauschbetrag.py:162
+#: app/forms/steps/lotse/pauschbetrag.py:102
+#: app/forms/steps/lotse/pauschbetrag.py:166
 #: app/forms/steps/lotse/personal_data.py:37
 #: app/forms/steps/lotse/personal_data.py:183
 #: app/forms/steps/lotse/personal_data.py:274
@@ -1153,10 +1153,10 @@ msgstr[1] "Behinderungsbedingte Fahrtkostenpauschale für Person A"
 #: app/forms/steps/lotse/has_disability.py:90
 #: app/forms/steps/lotse/merkzeichen.py:109
 #: app/forms/steps/lotse/merkzeichen.py:182
-#: app/forms/steps/lotse/no_pauschbetrag.py:103
-#: app/forms/steps/lotse/no_pauschbetrag.py:125
-#: app/forms/steps/lotse/pauschbetrag.py:148
-#: app/forms/steps/lotse/pauschbetrag.py:210
+#: app/forms/steps/lotse/no_pauschbetrag.py:102
+#: app/forms/steps/lotse/no_pauschbetrag.py:124
+#: app/forms/steps/lotse/pauschbetrag.py:152
+#: app/forms/steps/lotse/pauschbetrag.py:216
 #: app/forms/steps/lotse/personal_data.py:395
 #: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:54
 #: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:74
@@ -1227,8 +1227,8 @@ msgstr ""
 
 #: app/forms/steps/lotse/merkzeichen.py:27
 #: app/forms/steps/lotse/merkzeichen.py:116
-#: app/forms/steps/lotse/no_pauschbetrag.py:76
-#: app/forms/steps/lotse/no_pauschbetrag.py:109
+#: app/forms/steps/lotse/no_pauschbetrag.py:75
+#: app/forms/steps/lotse/no_pauschbetrag.py:108
 #: app/forms/steps/lotse/personal_data.py:32
 #: app/forms/steps/lotse/personal_data.py:180
 #: app/forms/steps/lotse/personal_data.py:271
@@ -1357,13 +1357,13 @@ msgstr ""
 "ausstehend. Bitte machen Sie Angaben zu einer Behinderung oder "
 "Pflegebedürftigkeit."
 
-#: app/forms/steps/lotse/no_pauschbetrag.py:19
-#: app/forms/steps/lotse/no_pauschbetrag.py:47
+#: app/forms/steps/lotse/no_pauschbetrag.py:18
+#: app/forms/steps/lotse/no_pauschbetrag.py:46
 msgid "form.lotse.skip_reason.has_pauschbetrag_claim"
 msgstr "Ihre Angaben qualifizieren Sie für den behinderungsbedingten Pauschbetrag."
 
-#: app/forms/steps/lotse/no_pauschbetrag.py:75
-#: app/forms/steps/lotse/no_pauschbetrag.py:86
+#: app/forms/steps/lotse/no_pauschbetrag.py:74
+#: app/forms/steps/lotse/no_pauschbetrag.py:85
 msgid "form.lotse.no_pauschbetrag.person_a.title"
 msgid_plural "form.lotse.no_pauschbetrag.person_a.title"
 msgstr[0] "Leider haben Sie keinen Anspruch auf behinderungsbedingte Pauschbeträge."
@@ -1371,41 +1371,46 @@ msgstr[1] ""
 "Leider hat Person A keinen Anspruch auf behinderungsbedingte "
 "Pauschbeträge."
 
-#: app/forms/steps/lotse/no_pauschbetrag.py:108
+#: app/forms/steps/lotse/no_pauschbetrag.py:107
 msgid "form.lotse.no_pauschbetrag.person_b.title"
 msgstr ""
 "Leider hat Person B keinen Anspruch auf behinderungsbedingte "
 "Pauschbeträge."
 
-#: app/forms/steps/lotse/pauschbetrag.py:63
-#: app/forms/steps/lotse/pauschbetrag.py:82
+#: app/forms/steps/lotse/pauschbetrag.py:64
+#: app/forms/steps/lotse/pauschbetrag.py:83
 msgid "form.lotse.skip_reason.has_no_pauschbetrag_claim"
 msgstr ""
 "Ihre Angaben qualifizieren Sie leider nicht für den behinderungsbedingten"
 " Pauschbetrag."
 
-#: app/forms/steps/lotse/pauschbetrag.py:107
-#: app/forms/steps/lotse/pauschbetrag.py:172
+#: app/forms/steps/lotse/pauschbetrag.py:109
+#: app/forms/steps/lotse/pauschbetrag.py:176
 msgid "form.lotse.request_pauschbetrag.data_label"
 msgstr "Beantragung Pauschbetrag für Menschen mit Behinderung"
 
-#: app/forms/steps/lotse/pauschbetrag.py:113
+#: app/forms/steps/lotse/pauschbetrag.py:115
 msgid "form.lotse.person_a.request_pauschbetrag.label"
 msgid_plural "form.lotse.person_a.request_pauschbetrag.label"
 msgstr[0] "Pauschbetrag für Menschen mit Behinderung"
 msgstr[1] "Pauschbetrag für Menschen mit Behinderung für Person A"
 
-#: app/forms/steps/lotse/pauschbetrag.py:132
+#: app/forms/steps/lotse/pauschbetrag.py:125
+#: app/forms/steps/lotse/pauschbetrag.py:191
+msgid "form.lotse.summary.no-claim"
+msgstr "Kein Anspruch"
+
+#: app/forms/steps/lotse/pauschbetrag.py:136
 msgid "form.lotse.person_a.request_pauschbetrag.title"
 msgid_plural "form.lotse.person_a.request_pauschbetrag.title"
 msgstr[0] "Pauschbetrag für Menschen mit Behinderung"
 msgstr[1] "Pauschbetrag für Menschen mit Behinderung für Person A"
 
-#: app/forms/steps/lotse/pauschbetrag.py:164
+#: app/forms/steps/lotse/pauschbetrag.py:168
 msgid "form.lotse.person_b.request_pauschbetrag.label"
 msgstr "Pauschbetrag für Menschen mit Behinderung für Person B"
 
-#: app/forms/steps/lotse/pauschbetrag.py:194
+#: app/forms/steps/lotse/pauschbetrag.py:200
 msgid "form.lotse.person_b.request_pauschbetrag.title"
 msgstr "Pauschbetrag für Menschen mit Behinderung für Person B"
 
@@ -3025,7 +3030,7 @@ msgstr ""
 "Der Grad der Behinderung wird in 5er-Schritten bis 100 festgesetzt. "
 "Korrigieren Sie Ihre Angabe."
 
-#: app/model/form_data.py:459
+#: app/model/form_data.py:495
 msgid "form.lotse.input_invalid.mandatory_field_missing"
 msgid_plural "form.lotse.input_invalid.mandatory_field_missing"
 msgstr[0] ""
@@ -3035,11 +3040,11 @@ msgstr[1] ""
 "Bitte füllen Sie alle notwendigen Felder aus, um Ihre Angaben verschicken"
 " zu können. Es sind noch %(num)s notwendige Felder nicht ausgefüllt."
 
-#: app/model/form_data.py:464
+#: app/model/form_data.py:500
 msgid "form.lotse.input_invalid.confirmation_missing"
 msgstr "Bitte erteilen Sie alle notwendigen Einwilligungen um fortzufahren."
 
-#: app/model/form_data.py:470
+#: app/model/form_data.py:506
 msgid "form.lotse.input_invalid.idnr_mismatch"
 msgstr ""
 "Bitte prüfen Sie die Steuer-Identifikationsnummer. Die Angabe muss mit "

--- a/webapp/tests/model/test_form_data.py
+++ b/webapp/tests/model/test_form_data.py
@@ -8,6 +8,8 @@ from unittest.mock import patch, MagicMock
 import pytest
 from pydantic import ValidationError, MissingError
 
+from app.forms.steps.lotse.fahrkostenpauschale import HasFahrkostenpauschaleClaimPersonAPrecondition, \
+    HasFahrkostenpauschaleClaimPersonBPrecondition
 from app.forms.steps.lotse.pauschbetrag import HasPauschbetragClaimPersonAPrecondition, \
     HasPauschbetragClaimPersonBPrecondition
 from app.utils import VERANLAGUNGSJAHR
@@ -667,3 +669,55 @@ class TestFormDataDependencies:
             disability_data).dict(exclude_none=True)
 
         assert returned_data == disability_data
+
+    def test_if_person_a_has_no_pauschbetrags_claim_then_delete_answer_to_pauschbetrag_request(self):
+        with patch('app.forms.steps.lotse.pauschbetrag.HasPauschbetragClaimPersonAPrecondition.__init__',
+                   MagicMock(side_effect=ValidationError([], HasPauschbetragClaimPersonAPrecondition))):
+            disability_data = {
+                'person_a_has_disability': 'yes',
+                'person_a_requests_pauschbetrag': 'yes',
+            }
+
+            returned_data = FormDataDependencies.parse_obj(
+                disability_data).dict(exclude_none=True)
+
+            assert returned_data == {'person_a_has_disability': 'yes'}
+
+    def test_if_person_b_has_no_pauschbetrags_claim_then_delete_answer_to_pauschbetrag_request(self):
+        with patch('app.forms.steps.lotse.pauschbetrag.HasPauschbetragClaimPersonBPrecondition.__init__',
+                   MagicMock(side_effect=ValidationError([], HasPauschbetragClaimPersonBPrecondition))):
+            disability_data = {
+                'person_b_has_disability': 'yes',
+                'person_b_requests_pauschbetrag': 'yes',
+            }
+
+            returned_data = FormDataDependencies.parse_obj(
+                disability_data).dict(exclude_none=True)
+
+            assert returned_data == {'person_b_has_disability': 'yes'}
+
+    def test_if_person_a_has_no_fahrkostenpauschale_claim_then_delete_answer_to_pauschbetrag_request(self):
+        with patch('app.forms.steps.lotse.fahrkostenpauschale.HasFahrkostenpauschaleClaimPersonAPrecondition.__init__',
+                   MagicMock(side_effect=ValidationError([], HasFahrkostenpauschaleClaimPersonAPrecondition))):
+            disability_data = {
+                'person_a_has_disability': 'yes',
+                'person_a_requests_fahrkostenpauschale': 'yes',
+            }
+
+            returned_data = FormDataDependencies.parse_obj(
+                disability_data).dict(exclude_none=True)
+
+            assert returned_data == {'person_a_has_disability': 'yes'}
+
+    def test_if_person_b_has_no_fahrkostenpauschale_claim_then_delete_answer_to_pauschbetrag_request(self):
+        with patch('app.forms.steps.lotse.fahrkostenpauschale.HasFahrkostenpauschaleClaimPersonBPrecondition.__init__',
+                   MagicMock(side_effect=ValidationError([], HasFahrkostenpauschaleClaimPersonBPrecondition))):
+            disability_data = {
+                'person_b_has_disability': 'yes',
+                'person_b_requests_fahrkostenpauschale': 'yes',
+            }
+
+            returned_data = FormDataDependencies.parse_obj(
+                disability_data).dict(exclude_none=True)
+
+            assert returned_data == {'person_b_has_disability': 'yes'}


### PR DESCRIPTION
# Short Description
QA found the following problem: If a user changes their disability information and they no longer have a pauschbetrag or fahrkostenpauschale claim the answer whether they do request that is not deleted. Furthermore, if they have no Pauschbetrag's claim the summary page would just show `0 Euro`. 
This PR should delete the request information and show `Kein Anspruch`

# Changes
- Add validator functions to FormDataDependency to delete the fields
- Change the get_overview_value_function of the pauschbetrag to show `Kein Anspruch`

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
