### PR TITLE
Send pausch requests to erica

### DIFF
--- a/erica_app/erica/elster_xml/elster_xml_tree.py
+++ b/erica_app/erica/elster_xml/elster_xml_tree.py
@@ -36,6 +36,8 @@ _BEH_GEH_STEH_BLIND_HILFL = ElsterXmlTreeNode(name='Geh_Steh_Blind_Hilfl', sub_e
 _BEH_AUSW_RENTB_BESCH = ElsterXmlTreeNode(name='Ausw_Rentb_Besch', sub_elements=['E0109708'])
 _AGB_BEH = ElsterXmlTreeNode(name="Beh", sub_elements=[_BEH_AUSW_RENTB_BESCH, _BEH_GEH_STEH_BLIND_HILFL],
                              is_person_specific=True, repetitions=2)
+_BEH_FK_PAUSCH = ElsterXmlTreeNode(name="Beh_Fk_Pausch", sub_elements=['E0161706', 'E0161806'], is_person_specific=True,
+                                   repetitions=2)
 
 # Besondere Belastungen
 _KRANKH_SUM = ElsterXmlTreeNode(name='Sum', sub_elements=['E0161304', 'E0161305'])
@@ -79,6 +81,6 @@ _VOR_KIST = ElsterXmlTreeNode(name='KiSt', sub_elements=[_KIST_GEZAHLT, _KIST_ER
 
 TOP_ELEMENT_ESTA1A = ElsterXmlTreeNode(name='ESt1A', sub_elements=[_EST1A_ART_ERKL, _EST1A_BELEGE, _EST1A_ALLG])
 TOP_ELEMENT_SA = ElsterXmlTreeNode(name='SA', sub_elements=[_VOR_KIST, _SA_ZUW])
-TOP_ELEMENT_AGB = ElsterXmlTreeNode(name='AgB', sub_elements=[_AGB_BEH, _AGB_AND_AUFW])
+TOP_ELEMENT_AGB = ElsterXmlTreeNode(name='AgB', sub_elements=[_AGB_BEH, _BEH_FK_PAUSCH, _AGB_AND_AUFW])
 TOP_ELEMENT_HA35A = ElsterXmlTreeNode(name='HA_35a', sub_elements=[_ST_ERM])
 TOP_ELEMENT_VOR = ElsterXmlTreeNode(name='VOR', sub_elements=[_VOR_WEIT])

--- a/webapp/app/elster_client/elster_client.py
+++ b/webapp/app/elster_client/elster_client.py
@@ -26,10 +26,10 @@ _BOOL_KEYS = ['familienstand_married_lived_separated', 'familienstand_widowed_li
               'person_b_same_address', 'request_new_tax_number',
               'person_a_has_pflegegrad', 'person_a_has_merkzeichen_bl',
               'person_a_has_merkzeichen_tbl', 'person_a_has_merkzeichen_h', 'person_a_has_merkzeichen_g',
-              'person_a_has_merkzeichen_ag',
+              'person_a_has_merkzeichen_ag', 'person_a_requests_pauschbetrag', 'person_a_requests_fahrkostenpauschale',
               'person_b_has_pflegegrad', 'person_b_has_merkzeichen_bl',
               'person_b_has_merkzeichen_tbl', 'person_b_has_merkzeichen_h', 'person_b_has_merkzeichen_g',
-              'person_b_has_merkzeichen_ag',]
+              'person_b_has_merkzeichen_ag', 'person_b_requests_pauschbetrag', 'person_b_requests_fahrkostenpauschale',]
 _DECIMAL_KEYS = ['stmind_haushaltsnahe_summe', 'stmind_handwerker_summe', 'stmind_handwerker_lohn_etc_summe',
                  'stmind_vorsorge_summe', 'stmind_religion_paid_summe', 'stmind_religion_reimbursed_summe',
                  'stmind_krankheitskosten_summe', 'stmind_krankheitskosten_anspruch', 'stmind_pflegekosten_summe',
@@ -203,8 +203,6 @@ def _generate_est_request_data(form_data, year=VERANLAGUNGSJAHR):
     if adapted_form_data.pop('is_user_account_holder', None):
         adapted_form_data['account_holder'] = 'person_a'
 
-    adapted_form_data = _set_names_for_merkzeichen(adapted_form_data)
-
     for key in list(set(_BOOL_KEYS) & set(adapted_form_data.keys())):
         if isinstance(adapted_form_data[key], str):
             adapted_form_data[key] = adapted_form_data[key] == 'yes'
@@ -242,35 +240,6 @@ def _generate_est_request_data(form_data, year=VERANLAGUNGSJAHR):
     }
 
     return {'est_data': adapted_form_data, 'meta_data': meta_data}
-
-
-def _set_names_for_merkzeichen(adapted_form_data):
-    # TODO Remove this once we have fully added the pauschbetrag step
-
-    merkzeichen_person_a = [
-        adapted_form_data.get('person_a_disability_degree'),
-        adapted_form_data.get('person_a_has_pflegegrad'),
-        adapted_form_data.get('person_a_has_merkzeichen_bl'),
-        adapted_form_data.get('person_a_has_merkzeichen_tbl'),
-        adapted_form_data.get('person_a_has_merkzeichen_h'),
-        adapted_form_data.get('person_a_has_merkzeichen_g'),
-        adapted_form_data.get('person_a_has_merkzeichen_ag'),
-    ]
-
-    merkzeichen_person_b = [
-        adapted_form_data.get('person_b_disability_degree'),
-        adapted_form_data.get('person_b_has_pflegegrad'),
-        adapted_form_data.get('person_b_has_merkzeichen_bl'),
-        adapted_form_data.get('person_b_has_merkzeichen_tbl'),
-        adapted_form_data.get('person_b_has_merkzeichen_h'),
-        adapted_form_data.get('person_b_has_merkzeichen_g'),
-        adapted_form_data.get('person_b_has_merkzeichen_ag'),
-    ]
-
-    adapted_form_data['person_a_requests_pauschbetrag'] = any(merkzeichen_person_a)
-    adapted_form_data['person_b_requests_pauschbetrag'] = any(merkzeichen_person_b)
-
-    return adapted_form_data
 
 
 def check_pyeric_response_for_errors(pyeric_response):

--- a/webapp/app/forms/steps/lotse/pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/pauschbetrag.py
@@ -121,7 +121,7 @@ class StepPauschbetragPersonA(LotseFormSteuerlotseStep):
             result = str(self.get_pauschbetrag(stored_data)) + ' ' + _('currency.euro')
         elif value == 'no':
             result = _('form.lotse.summary.not-requested')
-        elif self.get_pauschbetrag(stored_data) == 0:
+        elif self.get_pauschbetrag(stored_data) == 0 and stored_data.get('person_a_has_disability') == 'yes':
             result = _('form.lotse.summary.no-claim')
 
         return result
@@ -185,7 +185,7 @@ class StepPauschbetragPersonB(LotseFormSteuerlotseStep):
             result = str(self.get_pauschbetrag(stored_data)) + ' ' + _('currency.euro')
         elif value == 'no':
             result = _('form.lotse.summary.not-requested')
-        elif self.get_pauschbetrag(stored_data) == 0:
+        elif self.get_pauschbetrag(stored_data) == 0 and stored_data.get('person_b_has_disability') == 'yes':
             result = _('form.lotse.summary.no-claim')
 
         return result

--- a/webapp/client/src/pages/PauschbetragPage.test.js
+++ b/webapp/client/src/pages/PauschbetragPage.test.js
@@ -28,7 +28,7 @@ let props = {
       name: "requests_pauschbretrag",
     },
   },
-  pauschbetrag: 2400,
+  pauschbetrag: "2400",
   prevUrl: "/some/prev/path",
 };
 

--- a/webapp/client/src/stories/PauschbetragPagePersonA.stories.js
+++ b/webapp/client/src/stories/PauschbetragPagePersonA.stories.js
@@ -38,7 +38,7 @@ Default.args = {
       errors: [],
     },
   },
-  pauschbetrag: 2400,
+  pauschbetrag: "2400",
   prevUrl: "/previous/step",
 };
 

--- a/webapp/client/src/stories/PauschbetragPagePersonB.stories.js
+++ b/webapp/client/src/stories/PauschbetragPagePersonB.stories.js
@@ -38,7 +38,7 @@ Default.args = {
       errors: [],
     },
   },
-  pauschbetrag: 2400,
+  pauschbetrag: "2400",
   prevUrl: "/previous/step",
 };
 


### PR DESCRIPTION
# Short Description
I just realized that we do not send the correct values from the form to Erica. This changes that. Furthermore, this also fixes a bug that would show the Pauschbetrag for person b on the summary page for a single user.

# Changes
- Above changes
- Use a string for the PauschbetragsPage because we define a string in the PropTypes

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
