### PR TITLE
refactor(pages): rebuild unlock code failure in react

### DIFF
--- a/webapp/app/forms/steps/unlock_code_request_steps.py
+++ b/webapp/app/forms/steps/unlock_code_request_steps.py
@@ -9,7 +9,7 @@ from app.forms.fields import ConfirmationField, SteuerlotseDateField, IdNrField
 from app.forms.steps.step import FormStep, DisplayStep
 from app.forms.validations.validators import ValidIdNr
 from app.forms.validations.date_validations import ValidDateOfBirth
-from app.model.components import RegistrationProps, UnlockCodeSuccessProps
+from app.model.components import RegistrationProps, UnlockCodeSuccessProps, UnlockCodeFailureProps
 from app.model.components.helpers import form_fields_dict
 
 
@@ -91,5 +91,11 @@ class UnlockCodeRequestFailureStep(DisplayStep):
             intro=_('form.unlock-code-request.failure-intro'), **kwargs)
 
     def render(self, data, render_info):
-        return render_template('basis/display_failure.html', render_info=render_info,
+        props_dict = UnlockCodeFailureProps(
+            prev_url=url_for('unlock_code_request', step='data_input'),
+        ).camelized_dict()
+
+        return render_template('react_component.html',
+                               component='UnlockCodeFailurePage',
+                               props=props_dict,
                                header_title=_('form.unlock-code-request.header-title'))

--- a/webapp/app/model/components/__init__.py
+++ b/webapp/app/model/components/__init__.py
@@ -85,6 +85,10 @@ class UnlockCodeSuccessProps(ComponentProps):
     vorbereitungs_hilfe_link: str
 
 
+class UnlockCodeFailureProps(ComponentProps):
+    prev_url: Optional[str]
+
+
 class RevocationProps(StepFormProps):
     pass
 

--- a/webapp/client/cypress/integration/unlockCodeFailure.spec.js
+++ b/webapp/client/cypress/integration/unlockCodeFailure.spec.js
@@ -1,0 +1,15 @@
+describe("Unlock Code Failure", () => {
+  beforeEach(() => {
+    cy.visit("unlock_code_request/step/unlock_code_failure");
+  });
+
+  it("links back to registration page", () => {
+    cy.get("a").contains("Zurück").click();
+
+    cy.url().should("include", "unlock_code_request/step/data_input");
+  });
+
+  it("has no forward link", () => {
+    cy.get("a").contains("Weiter").should("not.exist");
+  });
+});

--- a/webapp/client/src/index.js
+++ b/webapp/client/src/index.js
@@ -23,6 +23,7 @@ import FahrtkostenpauschalePersonAPage from "./pages/FahrtkostenpauschalePersonA
 import FahrtkostenpauschalePersonBPage from "./pages/FahrtkostenpauschalePersonBPage";
 import NoPauschbetragPage from "./pages/NoPauschbetragPage";
 import UnlockCodeSuccessPage from "./pages/UnlockCodeSuccessPage";
+import UnlockCodeFailurePage from "./pages/UnlockCodeFailurePage";
 
 const allowedComponents = {
   RegistrationPage,
@@ -31,6 +32,7 @@ const allowedComponents = {
   RevocationPage,
   RevocationSuccessPage,
   UnlockCodeSuccessPage,
+  UnlockCodeFailurePage,
   DeclarationIncomesPage,
   TaxNumberPage,
   HasDisabilityPersonAPage,

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -283,6 +283,13 @@ const translations = {
         anchor: "Vorbereitungshilfe herunterladen",
       },
     },
+    failure: {
+      header: {
+        title: "Registrierung fehlgeschlagen. Bitte prüfen Sie Ihre Angaben.",
+        intro:
+          "Haben Sie sich vielleicht bereits registriert? In diesem Fall können Sie sich nicht erneut registrieren und bekommen einen Brief mit Ihrem persönlichen Freischaltcode von Ihrer Finanzverwaltung zugeschickt.",
+      },
+    },
   },
   fields: {
     idnr: {

--- a/webapp/client/src/pages/UnlockCodeFailurePage.js
+++ b/webapp/client/src/pages/UnlockCodeFailurePage.js
@@ -1,0 +1,24 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import FormFailureHeader from "../components/FormFailureHeader";
+import StepHeaderButtons from "../components/StepHeaderButtons";
+
+export default function UnlockCodeFailurePage({ prevUrl }) {
+  const { t } = useTranslation();
+  const stepHeader = {
+    title: t("register.failure.header.title"),
+    intro: t("register.failure.header.intro"),
+  };
+
+  return (
+    <>
+      <StepHeaderButtons url={prevUrl} />
+      <FormFailureHeader {...stepHeader} />
+    </>
+  );
+}
+
+UnlockCodeFailurePage.propTypes = {
+  prevUrl: PropTypes.string.isRequired,
+};

--- a/webapp/client/src/pages/UnlockCodeFailurePage.test.js
+++ b/webapp/client/src/pages/UnlockCodeFailurePage.test.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import UnlockCodeFailurePage from "./UnlockCodeFailurePage";
+
+const MOCK_PROPS = {
+  prevUrl: "/some/prev/path",
+};
+const EXPECTED_HEADER = {
+  title: "Registrierung fehlgeschlagen. Bitte prüfen Sie Ihre Angaben.",
+  intro:
+    "Haben Sie sich vielleicht bereits registriert? In diesem Fall können Sie sich nicht erneut registrieren und bekommen einen Brief mit Ihrem persönlichen Freischaltcode von Ihrer Finanzverwaltung zugeschickt.",
+};
+
+describe("UnlockCodeFailurePage", () => {
+  it("should render step header texts", () => {
+    render(<UnlockCodeFailurePage {...MOCK_PROPS} />);
+    expect(screen.getByText(EXPECTED_HEADER.title)).toBeInTheDocument();
+    expect(screen.getByText(EXPECTED_HEADER.intro)).toBeInTheDocument();
+  });
+
+  it("should link to the previous page", () => {
+    render(<UnlockCodeFailurePage {...MOCK_PROPS} />);
+    expect(screen.getByText("Zurück").closest("a")).toHaveAttribute(
+      "href",
+      expect.stringContaining(MOCK_PROPS.prevUrl)
+    );
+  });
+});

--- a/webapp/client/src/stories/UnlockCodeFailurePage.stories.js
+++ b/webapp/client/src/stories/UnlockCodeFailurePage.stories.js
@@ -1,0 +1,16 @@
+import React from "react";
+import UnlockCodeFailurePage from "../pages/UnlockCodeFailurePage";
+
+export default {
+  title: "Pages/UnlockCodeFailurePage",
+  component: UnlockCodeFailurePage,
+};
+
+function Template(args) {
+  return <UnlockCodeFailurePage {...args} />;
+}
+
+export const Default = Template.bind({});
+Default.args = {
+  prevUrl: "/unlock_code_revocation/step/data_input",
+};


### PR DESCRIPTION
# Short Description
- rebuild unlock code failure in react
- add unit and integration tests

# Changes
- adds new page for unlock code failure in client
- adds story for unlock code failure in client
- replace template part with react component template in unlock_code_request_steps

# Feedback
- everything

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
