### PR TITLE
refactor(pages): rebuild revocation failure as react page component

### DIFF
--- a/webapp/app/forms/steps/lotse/fahrtkostenpauschale.py
+++ b/webapp/app/forms/steps/lotse/fahrtkostenpauschale.py
@@ -1,4 +1,3 @@
-from flask import render_template
 from flask_babel import lazy_gettext as _l, ngettext, _
 from pydantic import root_validator
 from wtforms.validators import InputRequired, ValidationError
@@ -17,6 +16,7 @@ from app.forms import SteuerlotseBaseForm
 from app.forms.steps.step import SectionLink
 from app.forms.steps.lotse.lotse_step import LotseFormSteuerlotseStep
 from app.model.disability_data import DisabilityModel
+from app.templates.react_template import render_react_template
 
 
 def calculate_fahrtkostenpauschale(has_pflegegrad: str = None, disability_degree: int = None,
@@ -129,8 +129,7 @@ class StepFahrtkostenpauschalePersonA(StepFahrtkostenpauschale):
             prev_url=self.render_info.prev_url
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='FahrtkostenpauschalePersonAPage',
+        return render_react_template(component='FahrtkostenpauschalePersonAPage',
                                props=props_dict,
                                form=self.render_info.form,
                                header_title=_('form.lotse.header-title'))
@@ -181,8 +180,7 @@ class StepFahrtkostenpauschalePersonB(StepFahrtkostenpauschale):
             prev_url=self.render_info.prev_url
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='FahrtkostenpauschalePersonBPage',
+        return render_react_template(component='FahrtkostenpauschalePersonBPage',
                                props=props_dict,
                                form=self.render_info.form,
                                header_title=_('form.lotse.header-title'))

--- a/webapp/app/forms/steps/lotse/has_disability.py
+++ b/webapp/app/forms/steps/lotse/has_disability.py
@@ -1,4 +1,3 @@
-from flask import render_template
 from flask_babel import lazy_gettext as _l, _, ngettext
 from flask_wtf.csrf import generate_csrf
 from pydantic import validator
@@ -14,6 +13,7 @@ from app.forms.steps.lotse_multistep_flow_steps.personal_data_steps import StepF
 from app.forms.steps.step import SectionLink
 from app.model.components import HasDisabilityPersonBProps, HasDisabilityPersonAProps
 from app.model.components.helpers import form_fields_dict
+from app.templates.react_template import render_react_template
 
 
 class StepDisabilityPersonB(LotseFormSteuerlotseStep):
@@ -46,8 +46,7 @@ class StepDisabilityPersonB(LotseFormSteuerlotseStep):
             prev_url=self.render_info.prev_url
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='HasDisabilityPersonBPage',
+        return render_react_template(component='HasDisabilityPersonBPage',
                                props=props_dict,
                                form=self.render_info.form,
                                header_title=_('form.lotse.header-title'))
@@ -83,8 +82,7 @@ class StepDisabilityPersonA(LotseFormSteuerlotseStep):
             prev_url=self.render_info.prev_url
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='HasDisabilityPersonAPage',
+        return render_react_template(component='HasDisabilityPersonAPage',
                                props=props_dict,
                                form=self.render_info.form,
                                header_title=_('form.lotse.header-title'))

--- a/webapp/app/forms/steps/lotse/merkzeichen.py
+++ b/webapp/app/forms/steps/lotse/merkzeichen.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from flask import render_template
 from flask_wtf.csrf import generate_csrf
 from flask_babel import lazy_gettext as _l, _, ngettext
 from pydantic import BaseModel, validator
@@ -18,6 +17,7 @@ from app.forms.steps.step import SectionLink
 from app.forms.validations.validators import ValidDisabilityDegree
 from app.model.components import MerkzeichenProps
 from app.model.components.helpers import form_fields_dict
+from app.templates.react_template import render_react_template
 
 
 class StepMerkzeichenPersonA(LotseFormSteuerlotseStep):
@@ -102,8 +102,7 @@ class StepMerkzeichenPersonA(LotseFormSteuerlotseStep):
             prev_url=self.render_info.prev_url,
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='MerkzeichenPersonAPage',
+        return render_react_template(component='MerkzeichenPersonAPage',
                                props=props_dict,
                                form=self.render_info.form,
                                header_title=_('form.lotse.header-title'))
@@ -175,8 +174,7 @@ class StepMerkzeichenPersonB(LotseFormSteuerlotseStep):
             prev_url=self.render_info.prev_url,
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='MerkzeichenPersonBPage',
+        return render_react_template(component='MerkzeichenPersonBPage',
                                props=props_dict,
                                form=self.render_info.form,
                                header_title=_('form.lotse.header-title'))

--- a/webapp/app/forms/steps/lotse/no_pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/no_pauschbetrag.py
@@ -1,4 +1,3 @@
-from flask import render_template
 from flask_babel import lazy_gettext as _l, ngettext, _
 from pydantic import root_validator
 from wtforms.validators import ValidationError
@@ -11,6 +10,7 @@ from app.forms.steps.lotse.utils import get_number_of_users
 from app.forms.steps.lotse.has_disability import HasDisabilityPersonAPrecondition, HasDisabilityPersonBPrecondition
 from app.forms.steps.lotse.pauschbetrag import DisabilityModel, calculate_pauschbetrag
 from app.model.components import NoPauschbetragProps
+from app.templates.react_template import render_react_template
 
 
 class HasNoPauschbetragOrFahrtkostenpauschbetragClaimPersonAPrecondition(DisabilityModel):
@@ -96,8 +96,7 @@ class StepNoPauschbetragPersonA(LotseFormSteuerlotseStep):
             next_url=self.render_info.next_url,
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='NoPauschbetragPage',
+        return render_react_template(component='NoPauschbetragPage',
                                props=props_dict,
                                form=self.render_info.form,
                                header_title=_('form.lotse.header-title'))
@@ -120,8 +119,7 @@ class StepNoPauschbetragPersonB(LotseFormSteuerlotseStep):
             next_url=self.render_info.next_url,
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='NoPauschbetragPage',
+        return render_react_template(component='NoPauschbetragPage',
                                props=props_dict,
                                form=self.render_info.form,
                                header_title=_('form.lotse.header-title'))

--- a/webapp/app/forms/steps/lotse/pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/pauschbetrag.py
@@ -1,4 +1,3 @@
-from flask import render_template
 from flask_babel import lazy_gettext as _l, ngettext, _
 from pydantic import root_validator
 from wtforms.validators import InputRequired, ValidationError
@@ -16,6 +15,7 @@ from app.forms.steps.lotse.merkzeichen import StepMerkzeichenPersonA, StepMerkze
 from app.forms.steps.lotse.utils import get_number_of_users
 from app.forms.steps.lotse.has_disability import HasDisabilityPersonAPrecondition, HasDisabilityPersonBPrecondition
 from app.model.disability_data import DisabilityModel
+from app.templates.react_template import render_react_template
 
 
 def calculate_pauschbetrag(has_pflegegrad=None, disability_degree=None, has_merkzeichen_bl=False, has_merkzeichen_tbl=False, has_merkzeichen_h=False):
@@ -139,8 +139,7 @@ class StepPauschbetragPersonA(LotseFormSteuerlotseStep):
             prev_url=self.render_info.prev_url
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='PauschbetragPersonAPage',
+        return render_react_template(component='PauschbetragPersonAPage',
                                props=props_dict,
                                form=self.render_info.form,
                                header_title=_('form.lotse.header-title'))
@@ -201,8 +200,7 @@ class StepPauschbetragPersonB(LotseFormSteuerlotseStep):
             prev_url=self.render_info.prev_url
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='PauschbetragPersonBPage',
+        return render_react_template(component='PauschbetragPersonBPage',
                                props=props_dict,
                                form=self.render_info.form,
                                header_title=_('form.lotse.header-title'))

--- a/webapp/app/forms/steps/lotse/personal_data.py
+++ b/webapp/app/forms/steps/lotse/personal_data.py
@@ -1,4 +1,4 @@
-from flask import flash, Markup, render_template
+from flask import flash, Markup
 from flask_wtf.csrf import generate_csrf
 from pydantic import ValidationError, root_validator
 from wtforms import validators, SelectField, RadioField
@@ -22,7 +22,8 @@ from app.forms.validations.validators import ValidHessenTaxNumber, ValidTaxNumbe
 from app.forms.validations.validators import DecimalOnly, IntegerLength
 from app.model.components import TaxNumberStepFormProps, TelephoneNumberProps
 from app.model.components.helpers import form_fields_dict
-from app.model.form_data import show_person_b, FamilienstandModel, JointTaxesModel, BaseModel
+from app.model.form_data import show_person_b, FamilienstandModel, JointTaxesModel
+from app.templates.react_template import render_react_template
 
 
 class StepSteuernummer(LotseFormSteuerlotseStep):
@@ -165,8 +166,7 @@ class StepSteuernummer(LotseFormSteuerlotseStep):
             number_of_users=2 if show_person_b(self.stored_data) else 1
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='TaxNumberPage',
+        return render_react_template(component='TaxNumberPage',
                                props=props_dict,
                                # TODO: These are still required by base.html to set the page title.
                                form=self.render_info.form,
@@ -388,8 +388,7 @@ class StepTelephoneNumber(LotseFormSteuerlotseStep):
             prev_url=self.render_info.prev_url,
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='TelephoneNumberPage',
+        return render_react_template(component='TelephoneNumberPage',
                                props=props_dict,
                                form=self.render_info.form,
                                header_title=_('form.lotse.header-title'))

--- a/webapp/app/forms/steps/lotse/steuerminderungen.py
+++ b/webapp/app/forms/steps/lotse/steuerminderungen.py
@@ -26,7 +26,6 @@ class StepSelectStmind(LotseFormSteuerlotseStep):
     title = _l('form.lotse.select_stmind-title')
     intro = _l('form.lotse.select_stmind-intro')
     header_title = _l('form.lotse.steuerminderungen.header-title')
-    template = 'react_component.html'
     # TODO remove this once all steps are converted to steuerlotse steps
     prev_step = StepIban
     

--- a/webapp/app/forms/steps/lotse/steuerminderungen.py
+++ b/webapp/app/forms/steps/lotse/steuerminderungen.py
@@ -18,6 +18,7 @@ from app.forms.validations.validators import IntegerLength, EURO_FIELD_MAX_LENGT
 from app.model.components import SelectStMindProps
 from app.model.components.helpers import form_fields_dict
 from app.model.form_data import FamilienstandModel, JointTaxesModel
+from app.templates.react_template import render_react_template
 
 
 class StepSelectStmind(LotseFormSteuerlotseStep):
@@ -65,8 +66,7 @@ class StepSelectStmind(LotseFormSteuerlotseStep):
             prev_url=self.render_info.prev_url
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='StmindSelectionPage',
+        return render_react_template(component='StmindSelectionPage',
                                props=props_dict,
                                # TODO: These are still required by base.html to set the page title.
                                form=self.render_info.form,

--- a/webapp/app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py
+++ b/webapp/app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py
@@ -11,7 +11,7 @@ from flask_babel import lazy_gettext as _l
 
 from app.model.components import ConfirmationProps
 from app.model.components.helpers import form_fields_dict
-
+from app.templates.react_template import render_react_template
 
 class StepConfirmation(FormStep):
     name = 'confirmation'
@@ -45,8 +45,7 @@ class StepConfirmation(FormStep):
             prev_url=render_info.prev_url,
         ).camelized_dict()
 
-        return render_template('react_component.html',
-            component='ConfirmationPage',
+        return render_react_template(component='ConfirmationPage',
             props=props_dict,
             # TODO: These are still required by base.html to set the page title.
             form=render_info.form,

--- a/webapp/app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py
+++ b/webapp/app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py
@@ -11,6 +11,7 @@ from flask_babel import lazy_gettext as _l
 
 from app.model.components import DeclarationIncomesProps, DeclarationEDatenProps
 from app.model.components.helpers import form_fields_dict
+from app.templates.react_template import render_react_template
 
 
 class StepDeclarationIncomes(FormStep):
@@ -46,8 +47,7 @@ class StepDeclarationIncomes(FormStep):
             fields=form_fields_dict(render_info.form),
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='DeclarationIncomesPage',
+        return render_react_template(component='DeclarationIncomesPage',
                                props=props_dict,
                                # TODO: These are still required by base.html to set the page title.
                                form=render_info.form,
@@ -86,8 +86,7 @@ class StepDeclarationEdaten(FormStep):
             fields=form_fields_dict(render_info.form),
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='DeclarationEDatenPage',
+        return render_react_template(component='DeclarationEDatenPage',
                                props=props_dict,
                                # TODO: These are still required by base.html to set the page title.
                                form=render_info.form,

--- a/webapp/app/forms/steps/unlock_code_activation_steps.py
+++ b/webapp/app/forms/steps/unlock_code_activation_steps.py
@@ -1,5 +1,5 @@
 from app.model.components.helpers import form_fields_dict
-from flask import render_template, url_for
+from flask import url_for
 from flask_babel import _
 from flask_babel import lazy_gettext as _l
 from flask_wtf.csrf import generate_csrf
@@ -10,6 +10,7 @@ from app.forms.fields import UnlockCodeField, IdNrField
 from app.forms.steps.step import FormStep, DisplayStep
 from app.forms.validations.validators import ValidIdNr, ValidUnlockCode
 from app.model.components import LoginProps, LoginFailureProps
+from app.templates.react_template import render_react_template
 
 
 class UnlockCodeActivationInputStep(FormStep):
@@ -41,8 +42,7 @@ class UnlockCodeActivationInputStep(FormStep):
             fields=form_fields_dict(render_info.form)
         )
 
-        return render_template(
-            'react_component.html',
+        return render_react_template(
             component='LoginPage',
             props=props_model.camelized_dict(),
             # TODO: These are still required by base.html to set the page title.
@@ -68,8 +68,7 @@ class UnlockCodeActivationFailureStep(DisplayStep):
             revocation_link=url_for('unlock_code_revocation', step='start'),
         )
 
-        return render_template(
-            'react_component.html',
+        return render_react_template(
             component='LoginFailurePage',
             props=props_model.camelized_dict(),
             header_title=_('form.unlock-code-activation.header-title')

--- a/webapp/app/forms/steps/unlock_code_request_steps.py
+++ b/webapp/app/forms/steps/unlock_code_request_steps.py
@@ -1,4 +1,4 @@
-from flask import render_template, url_for
+from flask import url_for
 from flask_babel import _
 from flask_babel import lazy_gettext as _l
 from flask_wtf.csrf import generate_csrf
@@ -11,6 +11,7 @@ from app.forms.validations.validators import ValidIdNr
 from app.forms.validations.date_validations import ValidDateOfBirth
 from app.model.components import RegistrationProps, UnlockCodeSuccessProps, UnlockCodeFailureProps
 from app.model.components.helpers import form_fields_dict
+from app.templates.react_template import render_react_template
 
 
 class UnlockCodeRequestInputStep(FormStep):
@@ -53,8 +54,7 @@ class UnlockCodeRequestInputStep(FormStep):
             data_privacy_link=url_for('data_privacy'),
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='RegistrationPage',
+        return render_react_template(component='RegistrationPage',
                                props=props_dict,
                                # TODO: These are still required by base.html to set the page title.
                                form=render_info.form,
@@ -76,8 +76,7 @@ class UnlockCodeRequestSuccessStep(DisplayStep):
             vorbereitungs_hilfe_link=url_for('download_preparation'),
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='UnlockCodeSuccessPage',
+        return render_react_template(component='UnlockCodeSuccessPage',
                                props=props_dict,
                                header_title=_('form.unlock-code-request.header-title'))
 
@@ -95,7 +94,6 @@ class UnlockCodeRequestFailureStep(DisplayStep):
             prev_url=url_for('unlock_code_request', step='data_input'),
         ).camelized_dict()
 
-        return render_template('react_component.html',
-                               component='UnlockCodeFailurePage',
+        return render_react_template(component='UnlockCodeFailurePage',
                                props=props_dict,
                                header_title=_('form.unlock-code-request.header-title'))

--- a/webapp/app/forms/steps/unlock_code_revocation_steps.py
+++ b/webapp/app/forms/steps/unlock_code_revocation_steps.py
@@ -1,4 +1,4 @@
-from flask import render_template, url_for
+from flask import url_for
 from flask_babel import _
 from flask_babel import lazy_gettext as _l
 from flask_wtf.csrf import generate_csrf
@@ -11,9 +11,9 @@ from app.forms.validations.validators import ValidIdNr
 from app.forms.validations.date_validations import ValidDateOfBirth
 from app.model.components import RevocationProps, RevocationSuccessProps, RevocationFailureProps
 from app.model.components.helpers import form_fields_dict
+from app.templates.react_template import render_react_template
 
 HEADER_TITLE = 'form.unlock-code-revocation.header-title'
-REACT_COMPONENT = 'react_component.html'
 
 
 class UnlockCodeRevocationInputStep(FormStep):
@@ -48,8 +48,7 @@ class UnlockCodeRevocationInputStep(FormStep):
             fields=form_fields_dict(render_info.form),
         ).camelized_dict()
 
-        return render_template(REACT_COMPONENT,
-                               component='RevocationPage',
+        return render_react_template(component='RevocationPage',
                                props=props_dict,
                                form=render_info.form,
                                header_title=_(HEADER_TITLE))
@@ -73,8 +72,7 @@ class UnlockCodeRevocationSuccessStep(DisplayStep):
             next_url=url_for('unlock_code_request', step='data_input')
         ).camelized_dict()
 
-        return render_template(REACT_COMPONENT,
-                               component='RevocationSuccessPage',
+        return render_react_template(component='RevocationSuccessPage',
                                props=props_dict,
                                # TODO: These are still required by base.html to set the page title.
                                form=render_info.form,
@@ -94,7 +92,6 @@ class UnlockCodeRevocationFailureStep(DisplayStep):
             prev_url=url_for('unlock_code_revocation', step='data_input')
         ).camelized_dict()
 
-        return render_template(REACT_COMPONENT,
-                               component='RevocationFailurePage',
+        return render_react_template(component='RevocationFailurePage',
                                props=props_dict,
                                header_title=_(HEADER_TITLE))

--- a/webapp/app/forms/steps/unlock_code_revocation_steps.py
+++ b/webapp/app/forms/steps/unlock_code_revocation_steps.py
@@ -9,19 +9,23 @@ from app.forms.fields import LegacySteuerlotseDateField, LegacyIdNrField
 from app.forms.steps.step import FormStep, DisplayStep
 from app.forms.validations.validators import ValidIdNr
 from app.forms.validations.date_validations import ValidDateOfBirth
-from app.model.components import RevocationProps, RevocationSuccessProps
+from app.model.components import RevocationProps, RevocationSuccessProps, RevocationFailureProps
 from app.model.components.helpers import form_fields_dict
+
+HEADER_TITLE = 'form.unlock-code-revocation.header-title'
+REACT_COMPONENT = 'react_component.html'
 
 
 class UnlockCodeRevocationInputStep(FormStep):
     name = 'data_input'
 
     class Form(SteuerlotseBaseForm):
-        idnr = LegacyIdNrField(_l('unlock-code-revocation.idnr'), [InputRequired(message=_l('validate.missing-idnr')), ValidIdNr()])
-        dob = LegacySteuerlotseDateField(label=_l('unlock-code-revocation.dob'), 
+        idnr = LegacyIdNrField(_l('unlock-code-revocation.idnr'),
+                               [InputRequired(message=_l('validate.missing-idnr')), ValidIdNr()])
+        dob = LegacySteuerlotseDateField(label=_l('unlock-code-revocation.dob'),
                                          prevent_validation_error=True,
-                                         validators=[InputRequired(message=_l('validate.day-of-birth-missing')), 
-                                         ValidDateOfBirth()])
+                                         validators=[InputRequired(message=_l('validate.day-of-birth-missing')),
+                                                     ValidDateOfBirth()])
 
     def __init__(self, **kwargs):
         super(UnlockCodeRevocationInputStep, self).__init__(
@@ -44,11 +48,11 @@ class UnlockCodeRevocationInputStep(FormStep):
             fields=form_fields_dict(render_info.form),
         ).camelized_dict()
 
-        return render_template('react_component.html',
+        return render_template(REACT_COMPONENT,
                                component='RevocationPage',
                                props=props_dict,
                                form=render_info.form,
-                               header_title=_('form.unlock-code-revocation.header-title'))
+                               header_title=_(HEADER_TITLE))
 
 
 class UnlockCodeRevocationSuccessStep(DisplayStep):
@@ -69,12 +73,12 @@ class UnlockCodeRevocationSuccessStep(DisplayStep):
             next_url=url_for('unlock_code_request', step='data_input')
         ).camelized_dict()
 
-        return render_template('react_component.html',
+        return render_template(REACT_COMPONENT,
                                component='RevocationSuccessPage',
                                props=props_dict,
                                # TODO: These are still required by base.html to set the page title.
                                form=render_info.form,
-                               header_title=_('form.unlock-code-revocation.header-title'))
+                               header_title=_(HEADER_TITLE))
 
 
 class UnlockCodeRevocationFailureStep(DisplayStep):
@@ -86,5 +90,11 @@ class UnlockCodeRevocationFailureStep(DisplayStep):
             intro=_('form.unlock-code-revocation.failure-intro'), **kwargs)
 
     def render(self, data, render_info):
-        return render_template('basis/display_failure.html', render_info=render_info,
-                               header_title=_('form.unlock-code-revocation.header-title'))
+        props_dict = RevocationFailureProps(
+            prev_url=url_for('unlock_code_revocation', step='data_input')
+        ).camelized_dict()
+
+        return render_template(REACT_COMPONENT,
+                               component='RevocationFailurePage',
+                               props=props_dict,
+                               header_title=_(HEADER_TITLE))

--- a/webapp/app/model/components/__init__.py
+++ b/webapp/app/model/components/__init__.py
@@ -97,11 +97,17 @@ class RevocationSuccessProps(StepDisplayProps):
     pass
 
 
+class RevocationFailureProps(ComponentProps):
+    prev_url: Optional[str]
+
+
 class DeclarationIncomesProps(StepFormProps):
     pass
 
+
 class DeclarationEDatenProps(StepFormProps):
     pass
+
 
 class ConfirmationProps(StepFormProps):
     terms_of_service_link: str

--- a/webapp/app/templates/react_template.py
+++ b/webapp/app/templates/react_template.py
@@ -1,10 +1,9 @@
 from flask import render_template
 
-REACT_COMPONENT = 'react_component.html'
-
-def render_react_template(component, props=None, form=None, header_title=None):                          
-    return render_template(REACT_COMPONENT,
+def render_react_template(component, props=None, form=None, header_title=None, **kwargs):
+    return render_template('react_component.html',
             component=component,
             props=props,
             form=form,
-            header_title=header_title)
+            header_title=header_title,
+            **kwargs)

--- a/webapp/app/templates/react_template.py
+++ b/webapp/app/templates/react_template.py
@@ -1,0 +1,10 @@
+from flask import render_template
+
+REACT_COMPONENT = 'react_component.html'
+
+def render_react_template(component, props=None, form=None, header_title=None):                          
+    return render_template(REACT_COMPONENT,
+            component=component,
+            props=props,
+            form=form,
+            header_title=header_title)

--- a/webapp/client/cypress/integration/revocationFailure.spec.js
+++ b/webapp/client/cypress/integration/revocationFailure.spec.js
@@ -1,0 +1,15 @@
+describe("RevocationFailure", () => {
+  beforeEach(() => {
+    cy.visit("unlock_code_revocation/step/unlock_code_failure");
+  });
+
+  it("links back to revocation page", () => {
+    cy.get("a").contains("Zurück").click();
+
+    cy.url().should("include", "unlock_code_revocation/step/data_input");
+  });
+
+  it("has no forward link", () => {
+    cy.get("a").contains("Weiter").should("not.exist");
+  });
+});

--- a/webapp/client/src/index.js
+++ b/webapp/client/src/index.js
@@ -25,6 +25,7 @@ import NoPauschbetragPage from "./pages/NoPauschbetragPage";
 import DeclarationEDatenPage from "./pages/DeclarationEDatenPage";
 import UnlockCodeSuccessPage from "./pages/UnlockCodeSuccessPage";
 import UnlockCodeFailurePage from "./pages/UnlockCodeFailurePage";
+import RevocationFailurePage from "./pages/RevocationFailurePage";
 
 const allowedComponents = {
   RegistrationPage,
@@ -32,6 +33,7 @@ const allowedComponents = {
   LoginFailurePage,
   RevocationPage,
   RevocationSuccessPage,
+  RevocationFailurePage,
   UnlockCodeSuccessPage,
   UnlockCodeFailurePage,
   DeclarationIncomesPage,

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -299,6 +299,15 @@ const translations = {
       },
     },
   },
+  revocation: {
+    failure: {
+      header: {
+        title: "Stornierung fehlgeschlagen. Bitte prüfen Sie Ihre Angaben.",
+        intro:
+          "Sind Sie vielleicht noch nicht bei uns registriert? In diesem Fall können Sie Ihren Freischaltcode nicht stornieren. Haben Sie Ihre Steuererklärung bereits erfolgreich verschickt? Dann haben wir Ihren Freischaltcode automatisiert storniert und Sie müssen nichts weiter tun.",
+      },
+    },
+  },
   fields: {
     idnr: {
       labelText: "Steuer-Identifikationsnummer",

--- a/webapp/client/src/pages/DeclarationEDatenPage.test.js
+++ b/webapp/client/src/pages/DeclarationEDatenPage.test.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import { configure } from "@testing-library/dom";
 import DeclarationEDatenPage from "./DeclarationEDatenPage";
 import { Default as StepFormDefault } from "../stories/StepForm.stories";
-import { configure } from "@testing-library/dom";
 
 configure({ testIdAttribute: "id" });
 

--- a/webapp/client/src/pages/RevocationFailurePage.js
+++ b/webapp/client/src/pages/RevocationFailurePage.js
@@ -1,0 +1,24 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import StepHeaderButtons from "../components/StepHeaderButtons";
+import FormFailureHeader from "../components/FormFailureHeader";
+
+export default function RevocationFailurePage({ prevUrl }) {
+  const { t } = useTranslation();
+  const stepHeader = {
+    title: t("revocation.failure.header.title"),
+    intro: t("revocation.failure.header.intro"),
+  };
+
+  return (
+    <>
+      <StepHeaderButtons url={prevUrl} />
+      <FormFailureHeader {...stepHeader} />
+    </>
+  );
+}
+
+RevocationFailurePage.propTypes = {
+  prevUrl: PropTypes.string.isRequired,
+};

--- a/webapp/client/src/pages/RevocationFailurePage.test.js
+++ b/webapp/client/src/pages/RevocationFailurePage.test.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import RevocationFailureStepPage from "./RevocationFailurePage";
+
+const MOCK_PROPS = {
+  prevUrl: "/some/prev/path",
+};
+const EXPECTED_HEADER = {
+  title: "Stornierung fehlgeschlagen. Bitte prüfen Sie Ihre Angaben.",
+  intro:
+    "Sind Sie vielleicht noch nicht bei uns registriert? In diesem Fall können Sie Ihren Freischaltcode nicht stornieren. Haben Sie Ihre Steuererklärung bereits erfolgreich verschickt? Dann haben wir Ihren Freischaltcode automatisiert storniert und Sie müssen nichts weiter tun.",
+};
+
+describe("RevocationFailureStepPage", () => {
+  it("should render step header texts", () => {
+    render(<RevocationFailureStepPage {...MOCK_PROPS} />);
+    expect(screen.getByText(EXPECTED_HEADER.title)).toBeInTheDocument();
+    expect(screen.getByText(EXPECTED_HEADER.intro)).toBeInTheDocument();
+  });
+
+  it("should link to the previous page", () => {
+    render(<RevocationFailureStepPage {...MOCK_PROPS} />);
+    expect(screen.getByText("Zurück").closest("a")).toHaveAttribute(
+      "href",
+      expect.stringContaining(MOCK_PROPS.prevUrl)
+    );
+  });
+});

--- a/webapp/client/src/stories/RevocationFailurePage.stories.js
+++ b/webapp/client/src/stories/RevocationFailurePage.stories.js
@@ -1,0 +1,16 @@
+import React from "react";
+import RevocationFailurePage from "../pages/RevocationFailurePage";
+
+export default {
+  title: "Pages/RevocationFailure",
+  component: RevocationFailurePage,
+};
+
+function Template(args) {
+  return <RevocationFailurePage {...args} />;
+}
+
+export const Default = Template.bind({});
+Default.args = {
+  prevUrl: "/unlock_code_revocation/step/data_input",
+};


### PR DESCRIPTION
# Short Description
- rebuild revocation failure in react
- add unit and integration tests

# Changes
- adds new page for revocation failure in client
- adds story for revocation failure in client
- replace template part with react component template in unlock_code_revocation_steps
- fix some small code style issues
- add constants in unlock_code_revocation_steps to avoid string repetitions

# Feedback
- all 

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
