### PR TITLE
fix(components): improve style rules for backlink

### DIFF
--- a/webapp/client/public/css/variables.css
+++ b/webapp/client/public/css/variables.css
@@ -84,6 +84,6 @@
 
   --sidebar-width: 220px;
   --main-max-width: 1000px;
-  --back-link-size: 1.8em;
+  --back-link-size: 1.5rem;
   --header-navigation-height: var(--spacing-09);
 }

--- a/webapp/client/src/assets/icons/arrow_back.svg
+++ b/webapp/client/src/assets/icons/arrow_back.svg
@@ -1,4 +1,4 @@
-<svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="24" height="24" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
 <circle r="12.5" transform="matrix(-1 0 0 1 12.5 12.5)" fill="#E3D9CE"/>
 <path d="M11.7188 17.4479L6.77083 12.5L11.7188 7.8125" stroke="#0B0C0C" stroke-width="1.5"/>
 <path d="M6.77083 12.5H18.75" stroke="#0B0C0C" stroke-width="1.5"/>

--- a/webapp/client/src/components/BackLink.js
+++ b/webapp/client/src/components/BackLink.js
@@ -3,9 +3,10 @@ import styled from "styled-components";
 import backArrow from "../assets/icons/arrow_back.svg";
 
 const Anchor = styled.a`
+  display: inline-flex;
+  align-items: center;
   font-weight: var(--font-bold);
   font-size: var(--text-sm);
-  line-height: var(--lineheight-s);
   text-transform: uppercase;
   letter-spacing: var(--tracking-extra-wide);
   text-decoration: none !important;
@@ -20,23 +21,20 @@ const Anchor = styled.a`
 
   &:focus &:active {
     color: var(--text-color);
-    background-color: none;
   }
 `;
 
 const LinkElement = styled.span`
   color: var(--text-color);
-  vertical-align: middle;
+  line-height: var(--back-link-size);
 `;
 
 const Icon = styled(LinkElement)`
   --size: var(--back-link-size);
   content: url(${backArrow});
-  margin: 3px 3px 3px 0px;
-
+  margin-right: 8px;
   width: var(--size);
   height: var(--size);
-
   border-radius: 50%;
 `;
 

--- a/webapp/client/src/components/BackLink.js
+++ b/webapp/client/src/components/BackLink.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import backArrow from "../assets/icons/arrow_back.svg";
+import { ReactComponent as BackArrow } from "../assets/icons/arrow_back.svg";
 
 const Anchor = styled.a`
   display: inline-flex;
@@ -9,10 +9,33 @@ const Anchor = styled.a`
   font-size: var(--text-sm);
   text-transform: uppercase;
   letter-spacing: var(--tracking-extra-wide);
-  text-decoration: none !important;
+  text-decoration: none;
+
+  > svg {
+    margin-right: 5px;
+  }
 
   &:focus {
+    span:last-child {
+      background-color: var(--focus-color);
+      border-bottom: 1px solid var(--text-color);
+    }
+
+    > svg {
+      circle {
+        fill: var(--focus-color);
+      }
+    }
+  }
+
+  &:hover {
     text-decoration: none;
+
+    > svg {
+      circle {
+        fill: var(--icon-hover-color);
+      }
+    }
   }
 
   &:visited {
@@ -26,22 +49,14 @@ const Anchor = styled.a`
 
 const LinkElement = styled.span`
   color: var(--text-color);
-  line-height: var(--back-link-size);
-`;
-
-const Icon = styled(LinkElement)`
-  --size: var(--back-link-size);
-  content: url(${backArrow});
-  margin-right: 8px;
-  width: var(--size);
-  height: var(--size);
-  border-radius: 50%;
+  border-bottom: 1px solid transparent;
+  padding: 3px 3px 0;
 `;
 
 export default function BackLink({ text, url }) {
   return (
     <Anchor href={url}>
-      <Icon />
+      <BackArrow />
       <LinkElement>{text}</LinkElement>
     </Anchor>
   );


### PR DESCRIPTION
# Short Description

- Adjustments for backlink component

# Changes

- style rules for backlink component to match Figma Design (including hover and focus)
- provide icon as inline svg instead  via css content to have the possibility changing the svg state and to save requests

# Feedback
- Please check if other components are affected by the variable adjustment

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
