### PR TITLE
feat(storybook): replace s flag in scripts with main.js entry

### DIFF
--- a/webapp/client/.storybook/main.js
+++ b/webapp/client/.storybook/main.js
@@ -5,4 +5,5 @@ module.exports = {
     "@storybook/addon-essentials",
     "@storybook/preset-create-react-app",
   ],
+  staticDirs: ["../public"],
 };

--- a/webapp/client/package.json
+++ b/webapp/client/package.json
@@ -53,8 +53,8 @@
     "lint": "yarn run eslint src/",
     "format": "yarn prettier --write .",
     "prepare": "cd ../.. && husky install webapp/client/.husky",
-    "storybook": "start-storybook -p 6006 -s public",
-    "storybook:build": "build-storybook -s public",
+    "storybook": "start-storybook -p 6006",
+    "storybook:build": "build-storybook",
     "cypress": "cypress open",
     "cypress:run": "cypress run"
   },


### PR DESCRIPTION
# Short Description

[Deprecation Warning](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag) from storybook 

# Changes
- replace -s flag in package json scripts with entry in main.js as it is described in the migration path

# Feedback
- Is storybook working as expected locally?
- Is the storybook static folder build like before?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
