### PR TITLE
fix(components): add top space to backlink to match design

### DIFF
--- a/webapp/client/src/components/BackLink.js
+++ b/webapp/client/src/components/BackLink.js
@@ -10,6 +10,7 @@ const Anchor = styled.a`
   text-transform: uppercase;
   letter-spacing: var(--tracking-extra-wide);
   text-decoration: none;
+  padding-top: 0.3rem;
 
   > svg {
     margin-right: 5px;


### PR DESCRIPTION
# Short Description
- add css rule to match design for backling component
- [Ticket](https://steuerlotse.atlassian.net/browse/STL-1774?atlOrigin=eyJpIjoiNzRjNjE5MWMxOTk4NDZlYjhkNTExZmQyZDA1MjM5Y2YiLCJwIjoiaiJ9)    (internal)


# Changes
- add top space in backlink component

# Feedback
- Which parts of the code would you like feedback on?
- Questions that are open are also good (e. g. "Do you see any tests missing for class x?")

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
