### PR TITLE
UX feedback: fix(css): add top space to backlink to match design

### DIFF
--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -374,11 +374,14 @@
 
 /* LINKS */
 .back-link{
-    font-weight: var(--font-bold);
-    font-size: var(--text-sm);
-    line-height: var(--lineheight-s);
-    text-transform: uppercase;
-    letter-spacing: var(--tracking-extra-wide);
+  display: inline-flex;
+  align-items: center;
+  font-weight: var(--font-bold);
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-extra-wide);
+  text-decoration: none;
+  padding-top: 0.3rem;
 }
 
 a.back-link{
@@ -401,18 +404,16 @@ a.back-link:focus a.back-link:active{
 .back-link-icon {
     --size: var(--back-link-size);
     content: url("/icons/arrow_back.svg");
-    margin: 3px 3px 3px 0px;
-
+    margin-right: 8px;
+    margin-top: -1px;
     width: var(--size);
     height: var(--size);
-
     color: var(--text-color);
-
-    border-radius: 50%;
 }
 
 .back-link-element{
     vertical-align: middle;
+    line-height: 1.6rem;
 }
 
 .edit-button {


### PR DESCRIPTION
# Short Description

- adapt styles from backlink in react pages to old css rules for non-refactored pages to have almost the same behaviour


# Changes
- add css to component.css for backlink to avoid jumping of backlink between pages

# Feedback
- Is it still jumping?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
