### PR TITLE
Use the status code if the response is not empty

### DIFF
--- a/webapp/app/elster_client/elster_client.py
+++ b/webapp/app/elster_client/elster_client.py
@@ -52,13 +52,22 @@ def send_to_erica(*args, **kwargs):
             logger.info(f'Completed Erica POST request with args {args!r}, got code {response.status_code}')
         return response
     except Timeout as error:
-        logger.info(f'Erica POST request raised a timeout exception, got code {error.response.status_code}')
+        # status code is 0 if response of the error is none
+        status_code = 0 if error.response is None else error.response.status_code
+        
+        logger.info(f'Erica POST request raised a timeout exception, got code {status_code}')
         raise EricaRequestTimeoutError(error)
     except requests.ConnectionError as error:
-        logger.info(f'Erica POST request raised a connection exception, got code {error.response.status_code}')
+        # status code is 0 if response of the error is none
+        status_code = 0 if error.response is None else error.response.status_code
+        
+        logger.info(f'Erica POST request raised a connection exception, got code {status_code}')
         raise EricaRequestConnectionError(error)
     except requests.RequestException as error:
-        logger.info(f'Erica POST request raised an exception, got code {error.response.status_code}')
+        # status code is 0 if response of the error is none
+        status_code = 0 if error.response is None else error.response.status_code
+        
+        logger.info(f'Erica POST request raised an exception, got code {status_code}')
         raise GeneralEricaError()
 
 

--- a/webapp/app/elster_client/elster_client.py
+++ b/webapp/app/elster_client/elster_client.py
@@ -52,22 +52,20 @@ def send_to_erica(*args, **kwargs):
             logger.info(f'Completed Erica POST request with args {args!r}, got code {response.status_code}')
         return response
     except Timeout as error:
-        # status code is 0 if response of the error is none
-        status_code = 0 if error.response is None else error.response.status_code
-        
-        logger.info(f'Erica POST request raised a timeout exception, got code {status_code}')
+        logger.info(f'Erica POST request raised a timeout exception')
         raise EricaRequestTimeoutError(error)
-    except requests.ConnectionError as error:
-        # status code is 0 if response of the error is none
-        status_code = 0 if error.response is None else error.response.status_code
-        
-        logger.info(f'Erica POST request raised a connection exception, got code {status_code}')
+    except requests.ConnectionError as error:        
+        logger.info(f'Erica POST request raised a connection exception')
         raise EricaRequestConnectionError(error)
     except requests.RequestException as error:
         # status code is 0 if response of the error is none
         status_code = 0 if error.response is None else error.response.status_code
         
-        logger.info(f'Erica POST request raised an exception, got code {status_code}')
+        info_log = 'Erica POST request raised an exception'
+        if error.response is not None:
+            info_log = info_log + F', got code {status_code}'   
+                             
+        logger.info(info_log)        
         raise GeneralEricaError()
 
 


### PR DESCRIPTION
# Short Description
- We got a exception during another exception (timeout) on the prod instance:
send_to_erica
    logger.info(f'Erica POST request raised a timeout exception, got code {error.response.status_code}')
AttributeError: 'NoneType' object has no attribute 'status_code'

# Changes
- Check the response before we use it in the logs
- Default is 0 -> If the response is none

# Feedback
- Any

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
