### PR TITLE
Set warning level for erica errors

### DIFF
--- a/webapp/app/routes.py
+++ b/webapp/app/routes.py
@@ -330,7 +330,7 @@ ERICA_ERROR_TEMPLATE = 'error/erica_error.html'
 def register_error_handlers(app):
     @app.errorhandler(GeneralEricaError)
     def error_erica(error):
-        current_app.logger.warning('A general erica error occurred', exc_info=error.original_exception)
+        current_app.logger.exception('A general erica error occurred')
         return render_template(ERICA_ERROR_TEMPLATE, header_title=_('erica-error.header-title'),
                                js_needed=False), 500
 

--- a/webapp/app/routes.py
+++ b/webapp/app/routes.py
@@ -330,7 +330,7 @@ ERICA_ERROR_TEMPLATE = 'error/erica_error.html'
 def register_error_handlers(app):
     @app.errorhandler(GeneralEricaError)
     def error_erica(error):
-        current_app.logger.exception('A general erica error occurred')
+        current_app.logger.warning('A general erica error occurred', exc_info=error.original_exception)
         return render_template(ERICA_ERROR_TEMPLATE, header_title=_('erica-error.header-title'),
                                js_needed=False), 500
 
@@ -353,20 +353,20 @@ def register_error_handlers(app):
 
     @app.errorhandler(InternalServerError)
     def error_500(error):
-        current_app.logger.error(
+        current_app.logger.warning(
             'An uncaught error occurred', exc_info=error.original_exception)
         return render_template('error/500.html', header_title=_('500.header-title'), js_needed=False), 500
 
     @app.errorhandler(EricaRequestTimeoutError)
     def timeout_error_erica(error):
-        current_app.logger.error(
+        current_app.logger.warning(
             'An Erica Request Timeout error occurred', exc_info=error.original_exception)
         return render_template(ERICA_ERROR_TEMPLATE, header_title=_('erica-error.header-title'),
                                js_needed=False), 504
 
     @app.errorhandler(EricaRequestConnectionError)
     def connection_error_erica(error):
-        current_app.logger.error(
+        current_app.logger.warning(
             'An Erica Request Connection error occurred', exc_info=error.original_exception)
         return render_template(ERICA_ERROR_TEMPLATE, header_title=_('erica-error.header-title'),
                                js_needed=False), 503


### PR DESCRIPTION
# Short Description
We logged expected errors with error level. We should only log them with warning level to not receive alerts if not necessary.

# Feedback
- Did I overlook sth?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
