### PR TITLE
Add separate functions for setting cookie data

### DIFF
--- a/webapp/Pipfile.lock
+++ b/webapp/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0295318a85f37968e4e29274feca40a01c2bf0f579fc344ebc5d72c3b7256f47"
+            "sha256": "054bc655dd4f874cc65b73aadf1c87ceb7bd5dd553a58cf9f6a4bc22bbe6fdba"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "alembic": {
             "hashes": [
-                "sha256:7c328694a2e68f03ee971e63c3bd885846470373a5b532cf2c9f1601c413b153",
-                "sha256:a9dde941534e3d7573d9644e8ea62a2953541e27bc1793e166f60b777ae098b4"
+                "sha256:6c0c05e9768a896d804387e20b299880fe01bc56484246b0dffe8075d6d3d847",
+                "sha256:ad842f2c3ab5c5d4861232730779c05e33db4ba880a08b85eb505e87c01095bc"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.7.5"
+            "version": "==1.7.6"
         },
         "babel": {
             "hashes": [
@@ -240,11 +240,11 @@
         },
         "flask-wtf": {
             "hashes": [
-                "sha256:6ff7af73458f182180906a37a783e290bdc8a3817fe4ad17227563137ca285bf",
-                "sha256:ff177185f891302dc253437fe63081e7a46a4e99aca61dfe086fb23e54fff2dc"
+                "sha256:01feccfc395405cea48a3f36c23f0d766e2cc6fd2a5a065ad50ad3e5827ec797",
+                "sha256:872fbb17b5888bfc734edbdcf45bc08fb365ca39f69d25dc752465a455517b28"
             ],
             "index": "pypi",
-            "version": "==0.15.1"
+            "version": "==1.0.0"
         },
         "greenlet": {
             "hashes": [
@@ -304,7 +304,7 @@
                 "sha256:fa877ca7f6b48054f847b61d6fa7bed5cebb663ebc55e018fda12db09dcc664c",
                 "sha256:fdcec0b8399108577ec290f55551d926d9a1fa6cad45882093a7a07ac5ec147b"
             ],
-            "markers": "python_version >= '3' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.1.2"
         },
         "gunicorn": {
@@ -349,11 +349,11 @@
         },
         "limits": {
             "hashes": [
-                "sha256:6d6469c6014457b9c47e160f39f9aad333d3ca0a37e87263b5844268bdfe1b22",
-                "sha256:7f1311b9d48fcccf2b3120dad67126a329f44c5f9a3c33df97d6c19e20e66f82"
+                "sha256:9ead6236a71eb1d9a18d7e3b1faa58d588ea3510e55514fae58babc0a3223986",
+                "sha256:d4270d29591cc5eceab19be053455a4e619ba395062502bde2b5681af7dc1be8"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.3.2"
+            "version": "==2.3.3"
         },
         "mako": {
             "hashes": [
@@ -469,6 +469,44 @@
             ],
             "index": "pypi",
             "version": "==0.18.7"
+        },
+        "psutil": {
+            "hashes": [
+                "sha256:072664401ae6e7c1bfb878c65d7282d4b4391f1bc9a56d5e03b5a490403271b5",
+                "sha256:1070a9b287846a21a5d572d6dddd369517510b68710fca56b0e9e02fd24bed9a",
+                "sha256:1d7b433519b9a38192dfda962dd8f44446668c009833e1429a52424624f408b4",
+                "sha256:3151a58f0fbd8942ba94f7c31c7e6b310d2989f4da74fcbf28b934374e9bf841",
+                "sha256:32acf55cb9a8cbfb29167cd005951df81b567099295291bcfd1027365b36591d",
+                "sha256:3611e87eea393f779a35b192b46a164b1d01167c9d323dda9b1e527ea69d697d",
+                "sha256:3d00a664e31921009a84367266b35ba0aac04a2a6cad09c550a89041034d19a0",
+                "sha256:4e2fb92e3aeae3ec3b7b66c528981fd327fb93fd906a77215200404444ec1845",
+                "sha256:539e429da49c5d27d5a58e3563886057f8fc3868a5547b4f1876d9c0f007bccf",
+                "sha256:55ce319452e3d139e25d6c3f85a1acf12d1607ddedea5e35fb47a552c051161b",
+                "sha256:58c7d923dc209225600aec73aa2c4ae8ea33b1ab31bc11ef8a5933b027476f07",
+                "sha256:7336292a13a80eb93c21f36bde4328aa748a04b68c13d01dfddd67fc13fd0618",
+                "sha256:742c34fff804f34f62659279ed5c5b723bb0195e9d7bd9907591de9f8f6558e2",
+                "sha256:7641300de73e4909e5d148e90cc3142fb890079e1525a840cf0dfd39195239fd",
+                "sha256:76cebf84aac1d6da5b63df11fe0d377b46b7b500d892284068bacccf12f20666",
+                "sha256:7779be4025c540d1d65a2de3f30caeacc49ae7a2152108adeaf42c7534a115ce",
+                "sha256:7d190ee2eaef7831163f254dc58f6d2e2a22e27382b936aab51c835fc080c3d3",
+                "sha256:8293942e4ce0c5689821f65ce6522ce4786d02af57f13c0195b40e1edb1db61d",
+                "sha256:869842dbd66bb80c3217158e629d6fceaecc3a3166d3d1faee515b05dd26ca25",
+                "sha256:90a58b9fcae2dbfe4ba852b57bd4a1dded6b990a33d6428c7614b7d48eccb492",
+                "sha256:9b51917c1af3fa35a3f2dabd7ba96a2a4f19df3dec911da73875e1edaf22a40b",
+                "sha256:b2237f35c4bbae932ee98902a08050a27821f8f6dfa880a47195e5993af4702d",
+                "sha256:c3400cae15bdb449d518545cbd5b649117de54e3596ded84aacabfbb3297ead2",
+                "sha256:c51f1af02334e4b516ec221ee26b8fdf105032418ca5a5ab9737e8c87dafe203",
+                "sha256:cb8d10461c1ceee0c25a64f2dd54872b70b89c26419e147a05a10b753ad36ec2",
+                "sha256:d62a2796e08dd024b8179bd441cb714e0f81226c352c802fca0fd3f89eeacd94",
+                "sha256:df2c8bd48fb83a8408c8390b143c6a6fa10cb1a674ca664954de193fdcab36a9",
+                "sha256:e5c783d0b1ad6ca8a5d3e7b680468c9c926b804be83a3a8e95141b05c39c9f64",
+                "sha256:e9805fed4f2a81de98ae5fe38b75a74c6e6ad2df8a5c479594c7629a1fe35f56",
+                "sha256:ea42d747c5f71b5ccaa6897b216a7dadb9f52c72a0fe2b872ef7d3e1eacf3ba3",
+                "sha256:ef216cc9feb60634bda2f341a9559ac594e2eeaadd0ba187a4c2eb5b5d40b91c",
+                "sha256:ff0d41f8b3e9ebb6b6110057e40019a432e96aae2008951121ba4e56040b84f3"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==5.9.0"
         },
         "psycopg2-binary": {
             "hashes": [
@@ -673,11 +711,11 @@
         },
         "redis": {
             "hashes": [
-                "sha256:bf86397be532fc0a888d5976a5313a3a70d8f912d52bc0c09bffda4b8425a1d4",
-                "sha256:f13eea4254e302485add677cadedaf1305c1b3a4e07535e23b7b239798ce9301"
+                "sha256:c8481cf414474e3497ec7971a1ba9b998c8efad0f0d289a009a5bbef040894f9",
+                "sha256:ccf692811f2c1fc7a92b466aa2599e4a6d2d73d5f736a2c70be600657c0da34a"
             ],
             "index": "pypi",
-            "version": "==4.1.2"
+            "version": "==4.0.2"
         },
         "redislite": {
             "hashes": [
@@ -714,14 +752,6 @@
             "index": "pypi",
             "version": "==2021.10.2"
         },
-        "setuptools": {
-            "hashes": [
-                "sha256:c99207037c38984eae838c2fd986f39a9ddf4fabfe0fddd957e622d1d1dcdd05",
-                "sha256:eb83b1012ae6bf436901c2a2cee35d45b7260f31fd4b65fd1e50a9f99c11d7f8"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==60.6.0"
-        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -729,6 +759,13 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "sortedcontainers": {
+            "hashes": [
+                "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88",
+                "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"
+            ],
+            "version": "==2.4.0"
         },
         "sqlalchemy": {
             "hashes": [
@@ -961,7 +998,7 @@
                 "sha256:ef216cc9feb60634bda2f341a9559ac594e2eeaadd0ba187a4c2eb5b5d40b91c",
                 "sha256:ff0d41f8b3e9ebb6b6110057e40019a432e96aae2008951121ba4e56040b84f3"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==5.9.0"
         },
         "py": {

--- a/webapp/app/forms/cookie_data.py
+++ b/webapp/app/forms/cookie_data.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Optional
-from flask import session, json
+from flask import session
 
 from app.forms.session_data import deserialize_session_data, serialize_session_data
 
@@ -13,6 +13,7 @@ def get_data_from_cookie(cookie_data_identifier, ttl: Optional[int] = None, defa
 
     :param cookie_data_identifier: A string used to identify what data should be taken from the cookie
     :param ttl: The time to live for the cookie
+    :param default_data: Default data that will be used to replace missing data points
     """
     serialized_session = session.get(cookie_data_identifier, b"")
 
@@ -41,6 +42,3 @@ def _serialize_cookie_data(data):
 
 def _deserialize_cookie_data(serialized_session, ttl: Optional[int] = None):
     return deserialize_session_data(serialized_session, ttl)
-
-
-

--- a/webapp/app/forms/cookie_data.py
+++ b/webapp/app/forms/cookie_data.py
@@ -1,0 +1,46 @@
+import logging
+from typing import Optional
+from flask import session, json
+
+from app.forms.session_data import deserialize_session_data, serialize_session_data
+
+logger = logging.getLogger(__name__)
+
+
+def get_data_from_cookie(cookie_data_identifier, ttl: Optional[int] = None, default_data=None):
+    """
+    Gets data from the cookie that is associated with the currect session. The data is return deserialized.
+
+    :param cookie_data_identifier: A string used to identify what data should be taken from the cookie
+    :param ttl: The time to live for the cookie
+    """
+    serialized_session = session.get(cookie_data_identifier, b"")
+
+    if default_data:
+        # updates session_data only with non_existent values
+        stored_data = default_data | _deserialize_cookie_data(serialized_session, ttl)
+    else:
+        stored_data = _deserialize_cookie_data(serialized_session, ttl)
+
+    return stored_data
+
+
+def override_data_in_cookie(data_to_store, cookie_data_identifier='form_data'):
+    """
+    Stores data in the cookie that is associated with the currect session. The data is serialized before it is stored.
+
+    :param data_to_store: The data that is overriding the existing data in the cookie
+    :param cookie_data_identifier: A string used to identify what data should be taken from the cookie
+    """
+    session[cookie_data_identifier] = _serialize_cookie_data(data_to_store)
+
+
+def _serialize_cookie_data(data):
+    return serialize_session_data(data)
+
+
+def _deserialize_cookie_data(serialized_session, ttl: Optional[int] = None):
+    return deserialize_session_data(serialized_session, ttl)
+
+
+

--- a/webapp/app/forms/flows/eligibility_step_chooser.py
+++ b/webapp/app/forms/flows/eligibility_step_chooser.py
@@ -1,7 +1,6 @@
 from flask_babel import _
 
 from app.forms.cookie_data import get_data_from_cookie
-from app.forms.session_data import get_session_data
 from app.forms.steps.eligibility_steps import EligibilityStartDisplaySteuerlotseStep, \
     IncomeOtherDecisionEligibilityInputFormSteuerlotseStep, \
     IncomeOtherEligibilityFailureDisplaySteuerlotseStep, \

--- a/webapp/app/forms/flows/eligibility_step_chooser.py
+++ b/webapp/app/forms/flows/eligibility_step_chooser.py
@@ -1,5 +1,6 @@
 from flask_babel import _
 
+from app.forms.cookie_data import get_data_from_cookie
 from app.forms.session_data import get_session_data
 from app.forms.steps.eligibility_steps import EligibilityStartDisplaySteuerlotseStep, \
     IncomeOtherDecisionEligibilityInputFormSteuerlotseStep, \
@@ -96,3 +97,6 @@ class EligibilityStepChooser(StepChooser):
             if possible_previous_step.is_previous_step(current_step_name, stored_data):
                 return possible_previous_step
         return self.steps[self.step_order[0]]
+
+    def _get_session_data(self, session_data_identifier, default_data):
+        return get_data_from_cookie(cookie_data_identifier=session_data_identifier, default_data=default_data)

--- a/webapp/app/forms/flows/lotse_flow.py
+++ b/webapp/app/forms/flows/lotse_flow.py
@@ -6,7 +6,7 @@ from flask import request, flash, url_for
 from flask_babel import _, lazy_gettext as _l
 from flask_login import current_user
 from pydantic import ValidationError, MissingError
-from wtforms import SelectField, BooleanField, RadioField, IntegerField
+from wtforms import SelectField, BooleanField, RadioField
 from wtforms.fields.core import UnboundField
 
 from app.config import Config

--- a/webapp/app/forms/flows/multistep_flow.py
+++ b/webapp/app/forms/flows/multistep_flow.py
@@ -7,7 +7,7 @@ from wtforms import Form
 
 # The RenderInfo is provided to all templates
 from app.config import Config
-from app.forms.session_data import deserialize_session_data, override_session_data, get_session_data
+from app.forms.session_data import override_session_data, get_session_data
 from app.forms.steps.step import FormStep
 
 logger = logging.getLogger(__name__)

--- a/webapp/app/forms/flows/multistep_flow.py
+++ b/webapp/app/forms/flows/multistep_flow.py
@@ -96,7 +96,7 @@ class MultiStepFlow:
                 self.overview_step.name) if self.has_link_overview and self.overview_step else None)
 
         render_info, stored_data = self._handle_specifics_for_step(step, render_info, stored_data)
-        override_session_data(stored_data)
+        self._override_session_data(stored_data)
 
         if render_info.redirect_url:
             logger.info(f"Redirect to {render_info.redirect_url}")
@@ -135,6 +135,9 @@ class MultiStepFlow:
         if self.default_data():
             form_data = self.default_data()[1] | form_data  # updates form_data only with non_existent values
         return form_data
+
+    def _override_session_data(self, stored_data):
+        override_session_data(stored_data, session_data_identifier="form_data")
 
     def _load_step(self, step_name):
         step_names, step_types = list(self.steps.keys()), list(self.steps.values())

--- a/webapp/app/forms/flows/step_chooser.py
+++ b/webapp/app/forms/flows/step_chooser.py
@@ -1,11 +1,8 @@
-from typing import Dict
-
 from werkzeug.datastructures import ImmutableMultiDict
-from flask import flash
 from werkzeug.exceptions import abort
 
 from app.config import Config
-from app.forms.session_data import get_session_data, deserialize_session_data
+from app.forms.session_data import get_session_data
 from app.forms.steps.steuerlotse_step import SteuerlotseStep, RedirectSteuerlotseStep
 
 

--- a/webapp/app/forms/flows/step_chooser.py
+++ b/webapp/app/forms/flows/step_chooser.py
@@ -49,7 +49,7 @@ class StepChooser:
 
     def get_correct_step(self, step_name: str, should_update_data: bool, form_data: ImmutableMultiDict) -> SteuerlotseStep:
 
-        stored_data = get_session_data(self.session_data_identifier, default_data=self.default_data())
+        stored_data = self._get_session_data(self.session_data_identifier, default_data=self.default_data())
 
         if redirected_step_name := self._get_possible_redirect(step_name, stored_data):
             return RedirectSteuerlotseStep(redirected_step_name, endpoint=self.endpoint)
@@ -110,3 +110,6 @@ class StepChooser:
             return self._DEBUG_DATA
         else:
             return {}
+
+    def _get_session_data(self, session_data_identifier, default_data):
+        return get_session_data(session_data_identifier=session_data_identifier, default_data=default_data)

--- a/webapp/app/forms/flows/unlock_code_activation_flow.py
+++ b/webapp/app/forms/flows/unlock_code_activation_flow.py
@@ -1,10 +1,12 @@
 import logging
+from typing import Optional
 
 from app.data_access.user_controller import verify_and_login, activate_user, find_user
 from app.data_access.user_controller_errors import UserNotActivatedError, WrongUnlockCodeError, \
     UserNotExistingError
 from app.elster_client import elster_client
 from app.elster_client.elster_errors import ElsterProcessNotSuccessful
+from app.forms.cookie_data import get_data_from_cookie, override_data_in_cookie
 from app.forms.flows.multistep_flow import MultiStepFlow
 from flask_babel import _
 from flask import request, url_for
@@ -72,3 +74,9 @@ class UnlockCodeActivationMultiStepFlow(MultiStepFlow):
             elster_client.send_unlock_code_activation_with_elster(request_form, request_id, request.remote_addr)
             activate_user(idnr, unlock_code)    # If no error is thrown, this result in a problem
             verify_and_login(idnr, unlock_code)
+
+    def _get_session_data(self, ttl: Optional[int] = None):
+        return get_data_from_cookie('form_data', ttl)
+
+    def _override_session_data(self, stored_data):
+        override_data_in_cookie(data_to_store=stored_data, cookie_data_identifier="form_data")

--- a/webapp/app/forms/flows/unlock_code_request_flow.py
+++ b/webapp/app/forms/flows/unlock_code_request_flow.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from typing import Optional
 
 from flask import request
 from flask_babel import _
@@ -10,6 +11,7 @@ from app.data_access.user_controller import user_exists, create_user
 from app.data_access.user_controller_errors import UserAlreadyExistsError
 from app.elster_client import elster_client
 from app.elster_client.elster_errors import ElsterProcessNotSuccessful
+from app.forms.cookie_data import get_data_from_cookie, override_data_in_cookie
 from app.forms.flows.multistep_flow import MultiStepFlow
 from app.forms.steps.unlock_code_request_steps import UnlockCodeRequestInputStep, UnlockCodeRequestSuccessStep, \
     UnlockCodeRequestFailureStep
@@ -95,3 +97,9 @@ class UnlockCodeRequestMultiStepFlow(MultiStepFlow):
         request_id = escape(response['elster_request_id'])
 
         create_user(idnr, request_form['dob'].strftime("%d.%m.%Y"), request_id)
+
+    def _get_session_data(self, ttl: Optional[int] = None):
+        return get_data_from_cookie('form_data', ttl)
+
+    def _override_session_data(self, stored_data):
+        override_data_in_cookie(data_to_store=stored_data, cookie_data_identifier="form_data")

--- a/webapp/app/forms/flows/unlock_code_revocation_flow.py
+++ b/webapp/app/forms/flows/unlock_code_revocation_flow.py
@@ -11,7 +11,7 @@ from app.forms.cookie_data import get_data_from_cookie, override_data_in_cookie
 
 from app.forms.flows.multistep_flow import MultiStepFlow
 from flask_babel import _
-from flask import request, url_for
+from flask import request
 
 from app.elster_client.elster_errors import ElsterProcessNotSuccessful, ElsterRequestIdUnkownError, \
     ElsterRequestAlreadyRevoked

--- a/webapp/app/forms/flows/unlock_code_revocation_flow.py
+++ b/webapp/app/forms/flows/unlock_code_revocation_flow.py
@@ -1,11 +1,13 @@
 import datetime
 import logging
+from typing import Optional
 
 from app.data_access.db_model.user import User
 
 from app.data_access.user_controller import user_exists, check_dob, delete_user
 from app.data_access.user_controller_errors import UserNotExistingError, WrongDateOfBirthError
 from app.elster_client import elster_client
+from app.forms.cookie_data import get_data_from_cookie, override_data_in_cookie
 
 from app.forms.flows.multistep_flow import MultiStepFlow
 from flask_babel import _
@@ -88,3 +90,9 @@ class UnlockCodeRevocationMultiStepFlow(MultiStepFlow):
             logger.info("Could not revoke unlock code for user", exc_info=True)
             pass
         delete_user(idnr)
+
+    def _get_session_data(self, ttl: Optional[int] = None):
+        return get_data_from_cookie('form_data', ttl)
+
+    def _override_session_data(self, stored_data):
+        override_data_in_cookie(data_to_store=stored_data, cookie_data_identifier="form_data")

--- a/webapp/app/forms/steps/eligibility_steps.py
+++ b/webapp/app/forms/steps/eligibility_steps.py
@@ -6,7 +6,6 @@ from wtforms.validators import InputRequired
 
 from app.forms import SteuerlotseBaseForm
 from app.forms.cookie_data import override_data_in_cookie
-from app.forms.session_data import override_session_data
 from app.forms.steps.steuerlotse_step import FormSteuerlotseStep, DisplaySteuerlotseStep
 from app.model.eligibility_data import OtherIncomeEligibilityData, \
     ForeignCountrySuccessEligibility, MarginalEmploymentEligibilityData, NoEmploymentIncomeEligibilityData, \

--- a/webapp/app/forms/steps/eligibility_steps.py
+++ b/webapp/app/forms/steps/eligibility_steps.py
@@ -5,6 +5,7 @@ from wtforms import RadioField
 from wtforms.validators import InputRequired
 
 from app.forms import SteuerlotseBaseForm
+from app.forms.cookie_data import override_data_in_cookie
 from app.forms.session_data import override_session_data
 from app.forms.steps.steuerlotse_step import FormSteuerlotseStep, DisplaySteuerlotseStep
 from app.model.eligibility_data import OtherIncomeEligibilityData, \
@@ -133,6 +134,9 @@ class DecisionEligibilityInputFormSteuerlotseStep(EligibilityStepMixin, FormSteu
         else:
             return True
 
+    def _override_session_data(self, stored_data, session_data_identifier=None):
+        override_data_in_cookie(stored_data, session_data_identifier)
+
     def delete_not_dependent_data(self):
         """ Delete the data that is not (recursively) part of the first model in the list of next step data models. """
         self.stored_data = dict(
@@ -165,8 +169,11 @@ class EligibilityStartDisplaySteuerlotseStep(DisplaySteuerlotseStep):
         super()._main_handle()
         # Remove all eligibility data as the flow is restarting
         stored_data = {}
-        override_session_data(stored_data, session_data_identifier=self.session_data_identifier)
+        self._override_session_data(stored_data, session_data_identifier=self.session_data_identifier)
         self.render_info.additional_info['next_button_label'] = _('form.eligibility.check-now-button')
+
+    def _override_session_data(self, stored_data, session_data_identifier=None):
+        override_data_in_cookie(stored_data, session_data_identifier)
 
 
 class MaritalStatusInputFormSteuerlotseStep(DecisionEligibilityInputFormSteuerlotseStep):

--- a/webapp/app/forms/steps/steuerlotse_step.py
+++ b/webapp/app/forms/steps/steuerlotse_step.py
@@ -164,7 +164,7 @@ class FormSteuerlotseStep(SteuerlotseStep):
         return cls.InputForm(form_data, **prefilled_data)
 
     def _post_handle(self):
-        override_session_data(self.stored_data, self.session_data_identifier)
+        self._override_session_data(self.stored_data, self.session_data_identifier)
 
         redirection = self._handle_redirects()
         if redirection:
@@ -175,6 +175,9 @@ class FormSteuerlotseStep(SteuerlotseStep):
             logger.info(f"Redirect to next Step {self.render_info.next_url}")
             return redirect(self.render_info.next_url)
         return self.render()
+
+    def _override_session_data(self, stored_data, session_data_identifier=None):
+        override_session_data(stored_data, session_data_identifier)
 
     def render(self, **kwargs):
         """

--- a/webapp/tests/forms/flows/test_eligibility_step_chooser.py
+++ b/webapp/tests/forms/flows/test_eligibility_step_chooser.py
@@ -108,8 +108,7 @@ class TestEligibilityStepChooserDeterminePrevStep(unittest.TestCase):
             {'name': 'step-4', 'is_previous_step': False}
         ])
 
-        with patch('app.forms.flows.eligibility_step_chooser.get_session_data'):
-            self.step_chooser.determine_prev_step(given_step_name, {})
+        self.step_chooser.determine_prev_step(given_step_name, {})
 
         self.step_chooser.steps['step-0'].is_previous_step.assert_not_called()
         self.step_chooser.steps['step-1'].is_previous_step.assert_called()
@@ -126,8 +125,7 @@ class TestEligibilityStepChooserDeterminePrevStep(unittest.TestCase):
             {'name': 'step-3', 'is_previous_step': False}
         ])
 
-        with patch('app.forms.flows.eligibility_step_chooser.get_session_data'):
-            prev_step = self.step_chooser.determine_prev_step(given_step_name, {})
+        prev_step = self.step_chooser.determine_prev_step(given_step_name, {})
 
         self.assertEqual('step-2', prev_step.name)
 
@@ -139,8 +137,7 @@ class TestEligibilityStepChooserDeterminePrevStep(unittest.TestCase):
             {'name': 'step-2', 'is_previous_step': False}
         ])
 
-        with patch('app.forms.flows.eligibility_step_chooser.get_session_data'):
-            prev_step = self.step_chooser.determine_prev_step(given_step_name, {})
+        prev_step = self.step_chooser.determine_prev_step(given_step_name, {})
 
         self.assertIsNone(prev_step)
 
@@ -152,8 +149,7 @@ class TestEligibilityStepChooserDeterminePrevStep(unittest.TestCase):
             {'name': 'step-2', 'is_previous_step': False}
         ])
 
-        with patch('app.forms.flows.eligibility_step_chooser.get_session_data'):
-            prev_step = self.step_chooser.determine_prev_step(given_step_name, {})
+        prev_step = self.step_chooser.determine_prev_step(given_step_name, {})
 
         self.assertEqual('step-0', prev_step.name)
 

--- a/webapp/tests/forms/flows/test_eligibility_step_chooser.py
+++ b/webapp/tests/forms/flows/test_eligibility_step_chooser.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 import pytest
 
@@ -27,6 +27,11 @@ from app.forms.steps.eligibility_steps import EligibilityStartDisplaySteuerlotse
     IncomeOtherEligibilityFailureDisplaySteuerlotseStep, ForeignCountriesEligibilityFailureDisplaySteuerlotseStep, \
     SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep, SeparatedJointTaxesEligibilityInputFormSteuerlotseStep, \
     EligibilityMaybeDisplaySteuerlotseStep
+
+
+@pytest.fixture
+def test_eligibility_step_chooser():
+    return EligibilityStepChooser('eligibility')
 
 
 class TestEligibilityChooserInit(unittest.TestCase):
@@ -151,3 +156,13 @@ class TestEligibilityStepChooserDeterminePrevStep(unittest.TestCase):
             prev_step = self.step_chooser.determine_prev_step(given_step_name, {})
 
         self.assertEqual('step-0', prev_step.name)
+
+
+class TestEligibilityStepChooserGetSessionData:
+
+    @pytest.mark.usefixtures('test_request_context')
+    def test_if_get_session_data_called_then_get_cookie_data_function_called_with_correct_params(self, test_eligibility_step_chooser):
+        with patch('app.forms.flows.eligibility_step_chooser.get_data_from_cookie') as patched_get_cookie_data:
+            test_eligibility_step_chooser._get_session_data(session_data_identifier="catche_em_all", default_data={'name': 'Ash'})
+
+        assert patched_get_cookie_data.call_args == call(cookie_data_identifier="catche_em_all", default_data={'name': 'Ash'})

--- a/webapp/tests/forms/flows/test_multistep_flow.py
+++ b/webapp/tests/forms/flows/test_multistep_flow.py
@@ -126,8 +126,9 @@ class TestMultiStepFlowHandle(unittest.TestCase):
 
         session = self.run_handle(self.app, flow, MockFormWithInputStep.name, method='POST', form_data=original_data)
         session = self.run_handle(self.app, flow, MockRenderStep.name, method='GET', session=session)
-        self.run_handle(self.app, flow, MockFormStep.name, method='GET', session=session)
-        self.assertTrue(set(original_data).issubset(flow._get_session_data()))
+        session = self.run_handle(self.app, flow, MockFormStep.name, method='GET', session=session)
+        self.assertTrue(set(original_data).issubset(
+            set(deserialize_session_data(session['form_data'], self.app.config['PERMANENT_SESSION_LIFETIME']))))
 
     def test_update_session_data_is_called(self):
         expected_data = {'brother: Luigi'}
@@ -144,8 +145,9 @@ class TestMultiStepFlowHandle(unittest.TestCase):
         steps = [MockYesNoStep, MockFinalStep]
         flow_with_yes_no_field = MultiStepFlow('No_maybe', endpoint=self.endpoint_correct, steps=steps)
         resulting_session = self.run_handle(self.app, flow_with_yes_no_field, MockYesNoStep.name, 'POST', {'yes_no_field': 'yes'})
-        self.run_handle(self.app, flow_with_yes_no_field, MockYesNoStep.name, 'POST', {}, resulting_session)
-        self.assertEqual({'yes_no_field': None}, get_session_data('form_data'))
+        resulting_session = self.run_handle(self.app, flow_with_yes_no_field, MockYesNoStep.name, 'POST', {}, resulting_session)
+        self.assertEqual({'yes_no_field': None}, deserialize_session_data(resulting_session['form_data'],
+                                                                        self.app.config['PERMANENT_SESSION_LIFETIME']))
 
     @staticmethod
     def run_handle(app, flow, step_name, method='GET', form_data=None, session=None):

--- a/webapp/tests/forms/flows/test_multistep_flow.py
+++ b/webapp/tests/forms/flows/test_multistep_flow.py
@@ -1,7 +1,7 @@
 import datetime
 import unittest
 from decimal import Decimal
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 import pytest
 from flask import json
@@ -17,6 +17,12 @@ from app.forms.session_data import serialize_session_data, deserialize_session_d
 from tests.forms.mock_steps import MockStartStep, MockMiddleStep, MockFinalStep, MockFormStep, MockForm, \
     MockRenderStep, MockFormWithInputStep, MockYesNoStep
 from tests.utils import create_session_form_data
+
+
+@pytest.fixture
+def test_multistep_flow():
+    testing_steps = [MockStartStep, MockMiddleStep, MockFinalStep]
+    return MultiStepFlow(title="Testing MultiStepFlow", steps=testing_steps, endpoint="lotse")
 
 
 class TestMultiStepFlowInit(unittest.TestCase):
@@ -132,7 +138,7 @@ class TestMultiStepFlowHandle(unittest.TestCase):
                                         next_url="Next", submit_url="Submit", overview_url="Overview"), expected_data))):
             self.flow.handle(MockRenderStep.name)
 
-            update_fun.assert_called_once_with(expected_data)
+            update_fun.assert_called_once_with(expected_data, session_data_identifier='form_data')
 
     def test_yes_no_field_content_overriden_if_empty(self):
         steps = [MockYesNoStep, MockFinalStep]
@@ -484,3 +490,13 @@ class TestDeleteDependentData(unittest.TestCase):
     def test_non_matching_prefixes_not_deleted(self):
         returned_data = MultiStepFlow._delete_dependent_data(['plant'], self.example_data.copy())
         self.assertEqual(self.example_data, returned_data)
+
+
+class TestMultiStepFlowOverrideSessionData:
+
+    @pytest.mark.usefixtures('test_request_context')
+    def test_if_override_session_data_called_then_session_override_function_called_with_correct_params(self, test_multistep_flow):
+        with patch('app.forms.flows.multistep_flow.override_session_data') as patched_override:
+            test_multistep_flow._override_session_data(stored_data={'name': 'Ash'})
+
+        assert patched_override.call_args == call({'name': 'Ash'}, session_data_identifier='form_data')

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -302,8 +302,9 @@ class TestInteractionBetweenSteps(unittest.TestCase):
 
         session = self.run_handle(self.app, step_chooser, MockFormWithInputStep.name, method='POST', form_data=original_data)
         session = self.run_handle(self.app, step_chooser, MockRenderStep.name, method='GET', session=session)
-        self.run_handle(self.app, step_chooser, MockFormStep.name, method='GET', session=session)
-        self.assertTrue(set(original_data).issubset(get_session_data(session_data_identifier)))
+        session = self.run_handle(self.app, step_chooser, MockFormStep.name, method='GET', session=session)
+        self.assertTrue(set(original_data).issubset(
+            set(deserialize_session_data(session[session_data_identifier], self.app.config['PERMANENT_SESSION_LIFETIME']))))
 
     def test_if_form_step_after_form_step_then_keep_data_from_newer_form_step(self):
         testing_steps = [MockStartStep, MockFormWithInputStep, MockFormWithInputStep, MockRenderStep, MockFormStep, MockFinalStep]
@@ -319,7 +320,8 @@ class TestInteractionBetweenSteps(unittest.TestCase):
         session = self.run_handle(self.app, step_chooser, MockFormWithInputStep.name, method='POST', form_data=adapted_data, session=session)
         session = self.run_handle(self.app, step_chooser, MockRenderStep.name, method='GET', session=session)
         session = self.run_handle(self.app, step_chooser, MockFormStep.name, method='GET', session=session)
-        self.assertTrue(set(original_data).issubset(get_session_data(session_data_identifier)))
+        self.assertTrue(set(adapted_data).issubset(
+            set(deserialize_session_data(session[session_data_identifier], self.app.config['PERMANENT_SESSION_LIFETIME']))))
 
     @staticmethod
     def run_handle(app: Flask, step_chooser: StepChooser, step_name, method='GET', form_data=None, session=None):

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -1,12 +1,8 @@
-import datetime
 import unittest
-from copy import deepcopy
-from decimal import Decimal
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 import pytest
-from flask import Flask, get_flashed_messages, session
-from flask.sessions import SecureCookieSession
+from flask import Flask, session
 from werkzeug.datastructures import ImmutableMultiDict
 from werkzeug.exceptions import NotFound
 
@@ -17,6 +13,12 @@ from app.forms.steps.steuerlotse_step import RedirectSteuerlotseStep
 from tests.forms.mock_steuerlotse_steps import MockStartStep, MockMiddleStep, MockFinalStep, MockFormWithInputStep, \
     MockRenderStep, MockFormStep, MockYesNoStep, MockStepWithPrecondition, \
     MockStepWithPreconditionAndMessage, MockSecondPreconditionModelWithMessage
+
+
+@pytest.fixture
+def test_step_chooser():
+    testing_steps = [MockStartStep, MockFormWithInputStep, MockFormWithInputStep, MockRenderStep, MockFormStep, MockFinalStep]
+    return StepChooser(title="Testing StepChooser", steps=testing_steps, endpoint="lotse")
 
 
 class TestStepChooserInit(unittest.TestCase):
@@ -333,3 +335,13 @@ class TestInteractionBetweenSteps(unittest.TestCase):
             step_chooser.get_correct_step(step_name, method == 'POST', req.request.form).handle()
 
             return req.session
+
+
+class TestStepChooserGetSessionData:
+
+    @pytest.mark.usefixtures('test_request_context')
+    def test_if_get_session_data_called_then_get_session_data_function_called_with_correct_params(self, test_step_chooser):
+        with patch('app.forms.flows.step_chooser.get_session_data') as patched_get_session_data:
+            test_step_chooser._get_session_data(session_data_identifier="catche_em_all", default_data={'name': 'Ash'})
+
+        assert patched_get_session_data.call_args == call(session_data_identifier="catche_em_all", default_data={'name': 'Ash'})

--- a/webapp/tests/forms/flows/test_step_chooser.py
+++ b/webapp/tests/forms/flows/test_step_chooser.py
@@ -7,7 +7,7 @@ from werkzeug.datastructures import ImmutableMultiDict
 from werkzeug.exceptions import NotFound
 
 from app.forms.flows.multistep_flow import RenderInfo
-from app.forms.session_data import deserialize_session_data
+from app.forms.session_data import deserialize_session_data, get_session_data
 from app.forms.flows.step_chooser import StepChooser
 from app.forms.steps.steuerlotse_step import RedirectSteuerlotseStep
 from tests.forms.mock_steuerlotse_steps import MockStartStep, MockMiddleStep, MockFinalStep, MockFormWithInputStep, \
@@ -302,9 +302,8 @@ class TestInteractionBetweenSteps(unittest.TestCase):
 
         session = self.run_handle(self.app, step_chooser, MockFormWithInputStep.name, method='POST', form_data=original_data)
         session = self.run_handle(self.app, step_chooser, MockRenderStep.name, method='GET', session=session)
-        session = self.run_handle(self.app, step_chooser, MockFormStep.name, method='GET', session=session)
-        self.assertTrue(set(original_data).issubset(
-            set(deserialize_session_data(session[session_data_identifier], self.app.config['PERMANENT_SESSION_LIFETIME']))))
+        self.run_handle(self.app, step_chooser, MockFormStep.name, method='GET', session=session)
+        self.assertTrue(set(original_data).issubset(get_session_data(session_data_identifier)))
 
     def test_if_form_step_after_form_step_then_keep_data_from_newer_form_step(self):
         testing_steps = [MockStartStep, MockFormWithInputStep, MockFormWithInputStep, MockRenderStep, MockFormStep, MockFinalStep]
@@ -320,8 +319,7 @@ class TestInteractionBetweenSteps(unittest.TestCase):
         session = self.run_handle(self.app, step_chooser, MockFormWithInputStep.name, method='POST', form_data=adapted_data, session=session)
         session = self.run_handle(self.app, step_chooser, MockRenderStep.name, method='GET', session=session)
         session = self.run_handle(self.app, step_chooser, MockFormStep.name, method='GET', session=session)
-        self.assertTrue(set(adapted_data).issubset(
-            set(deserialize_session_data(session[session_data_identifier], self.app.config['PERMANENT_SESSION_LIFETIME']))))
+        self.assertTrue(set(original_data).issubset(get_session_data(session_data_identifier)))
 
     @staticmethod
     def run_handle(app: Flask, step_chooser: StepChooser, step_name, method='GET', form_data=None, session=None):

--- a/webapp/tests/forms/flows/test_unlock_code_activation_flow.py
+++ b/webapp/tests/forms/flows/test_unlock_code_activation_flow.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, call
 
 import pytest
 from flask import json
@@ -244,3 +244,27 @@ class TestUnlockCodeActivationHandleSpecificsForStep(unittest.TestCase):
                     self.input_step, self.render_info_input_step, self.session_data)
 
             self.assertEqual(self.failure_url, render_info.next_url)
+
+@pytest.fixture
+def unlock_code_activation_flow():
+    return UnlockCodeActivationMultiStepFlow(endpoint="unlock_code_activation")
+
+
+class TestUnlockCodeActivationGetSessionData:
+
+    @pytest.mark.usefixtures('test_request_context')
+    def test_if_get_session_data_called_then_get_cookie_data_function_called_with_correct_params(self, unlock_code_activation_flow):
+        with patch('app.forms.flows.unlock_code_activation_flow.get_data_from_cookie') as patched_get_cookie_data:
+            unlock_code_activation_flow._get_session_data(ttl=2)
+
+        assert patched_get_cookie_data.call_args == call('form_data', 2)
+
+
+class TestUnlockCodeActivationOverrideSessionData:
+
+    @pytest.mark.usefixtures('test_request_context')
+    def test_if_override_session_data_called_then_cookie_override_function_called_with_correct_params(self, unlock_code_activation_flow):
+        with patch('app.forms.flows.unlock_code_activation_flow.override_data_in_cookie') as patched_override:
+            unlock_code_activation_flow._override_session_data(stored_data={'name': 'Ash'})
+
+        assert patched_override.call_args == call(data_to_store={'name': 'Ash'}, cookie_data_identifier='form_data')

--- a/webapp/tests/forms/flows/test_unlock_code_request_flow.py
+++ b/webapp/tests/forms/flows/test_unlock_code_request_flow.py
@@ -292,3 +292,28 @@ class TestUnlockCodeRequestHandleSpecificsForStep(unittest.TestCase):
                         self.input_step, copy.deepcopy(self.render_info_input_step), {})
 
                     create_audit_log_fun.assert_not_called()
+
+
+@pytest.fixture
+def unlock_code_request_flow():
+    return UnlockCodeRequestMultiStepFlow(endpoint="unlock_code_request")
+
+
+class TestUnlockCodeActivationGetSessionData:
+
+    @pytest.mark.usefixtures('test_request_context')
+    def test_if_get_session_data_called_then_get_cookie_data_function_called_with_correct_params(self, unlock_code_request_flow):
+        with patch('app.forms.flows.unlock_code_request_flow.get_data_from_cookie') as patched_get_cookie_data:
+            unlock_code_request_flow._get_session_data(ttl=2)
+
+        assert patched_get_cookie_data.call_args == call('form_data', 2)
+
+
+class TestUnlockCodeActivationOverrideSessionData:
+
+    @pytest.mark.usefixtures('test_request_context')
+    def test_if_override_session_data_called_then_cookie_override_function_called_with_correct_params(self, unlock_code_request_flow):
+        with patch('app.forms.flows.unlock_code_request_flow.override_data_in_cookie') as patched_override:
+            unlock_code_request_flow._override_session_data(stored_data={'name': 'Ash'})
+
+        assert patched_override.call_args == call(data_to_store={'name': 'Ash'}, cookie_data_identifier='form_data')

--- a/webapp/tests/forms/flows/test_unlock_code_revocation_flow.py
+++ b/webapp/tests/forms/flows/test_unlock_code_revocation_flow.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, call
 
 import pytest
 from flask import json, make_response
@@ -311,3 +311,28 @@ class TestUnlockCodeRevocationHandleSpecificsForStep(unittest.TestCase):
                     self.input_step, self.render_info_input_step, self.session_data)
 
             self.assertEqual(self.failure_url, render_info.next_url)
+
+
+@pytest.fixture
+def unlock_code_revocation_flow():
+    return UnlockCodeRevocationMultiStepFlow(endpoint="unlock_code_revocation")
+
+
+class TestUnlockCodeActivationGetSessionData:
+
+    @pytest.mark.usefixtures('test_request_context')
+    def test_if_get_session_data_called_then_get_cookie_data_function_called_with_correct_params(self, unlock_code_revocation_flow):
+        with patch('app.forms.flows.unlock_code_revocation_flow.get_data_from_cookie') as patched_get_cookie_data:
+            unlock_code_revocation_flow._get_session_data(ttl=2)
+
+        assert patched_get_cookie_data.call_args == call('form_data', 2)
+
+
+class TestUnlockCodeActivationOverrideSessionData:
+
+    @pytest.mark.usefixtures('test_request_context')
+    def test_if_override_session_data_called_then_cookie_override_function_called_with_correct_params(self, unlock_code_revocation_flow):
+        with patch('app.forms.flows.unlock_code_revocation_flow.override_data_in_cookie') as patched_override:
+            unlock_code_revocation_flow._override_session_data(stored_data={'name': 'Ash'})
+
+        assert patched_override.call_args == call(data_to_store={'name': 'Ash'}, cookie_data_identifier='form_data')

--- a/webapp/tests/forms/steps/lotse/test_lotse_step.py
+++ b/webapp/tests/forms/steps/lotse/test_lotse_step.py
@@ -17,6 +17,7 @@ class TestLotseFormSteuerlotseStepPrepareRenderInfo:
 
 
 class TestLotseFormSteuerlotseStepMainHandle:
+
     def test_if_overview_button_set_in_request_set_next_url_to_summary_step(self, new_test_request_context):
         with new_test_request_context(form_data={'overview_button': ''}):
             render_info = LotseFormSteuerlotseStep.prepare_render_info({}, {})

--- a/webapp/tests/forms/steps/test_steuerlotse_step.py
+++ b/webapp/tests/forms/steps/test_steuerlotse_step.py
@@ -712,6 +712,16 @@ class TestFormSteuerlotseStepPrepareRenderInfo:
         assert render_info.stored_data == {'yes_no_field': None}
 
 
+class TestFormSteuerlotseStepOverrideSessionData:
+
+    @pytest.mark.usefixtures('test_request_context')
+    def test_if_override_session_data_called_then_session_override_function_called_with_same_params(self):
+        with patch('app.forms.steps.steuerlotse_step.override_session_data') as patched_override:
+            MockFormWithInputStep(endpoint='lotse')._override_session_data(stored_data={'name': 'Ash'}, session_data_identifier='catch_em_all')
+
+        assert patched_override.call_args == call({'name': 'Ash'}, 'catch_em_all')
+
+
 class TestFormSteuerlotseStepDeleteDependentData(unittest.TestCase):
 
     def setUp(self):

--- a/webapp/tests/forms/test_cookie_data.py
+++ b/webapp/tests/forms/test_cookie_data.py
@@ -1,0 +1,125 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+import pytest
+from flask.sessions import SecureCookieSession
+
+from app.forms.cookie_data import get_data_from_cookie, override_data_in_cookie
+from app.forms.session_data import serialize_session_data, deserialize_session_data
+from tests.utils import create_session_form_data
+
+
+@pytest.fixture
+def cookie_data_identifier():
+    return 'form_data'
+
+
+@pytest.fixture
+def prefilled_cookie_data():
+    return {"name": "Peach", "sister": "Daisy", "husband": "Mario"}
+
+
+class TestGetCookieData:
+
+    def test_if_cookie_data_then_return_cookie_data(self, cookie_data_identifier, prefilled_cookie_data, test_request_context):
+        test_request_context.session = SecureCookieSession({cookie_data_identifier: create_session_form_data(prefilled_cookie_data)})
+        cookie_data = get_data_from_cookie(cookie_data_identifier)
+
+        assert prefilled_cookie_data == cookie_data
+
+    def test_if_cookie_data_and_default_data_different_then_update_cookie_data(self, cookie_data_identifier, prefilled_cookie_data, test_request_context):
+        default_data = {"brother": "Luigi"}
+        expected_data = {**prefilled_cookie_data, **default_data}
+
+        test_request_context.session = SecureCookieSession({cookie_data_identifier: create_session_form_data(prefilled_cookie_data)})
+
+        cookie_data = get_data_from_cookie(cookie_data_identifier, default_data=default_data)
+
+        assert expected_data == cookie_data
+
+    def test_if_cookie_data_in_incorrect_identifier_then_return_only_data_from_correct_identifier(self, cookie_data_identifier, test_request_context):
+        form_data = {"brother": "Luigi"}
+        incorrect_identifier_data = {"enemy": "Bowser"}
+        expected_data = {**form_data}
+
+        test_request_context.session = SecureCookieSession(
+            {cookie_data_identifier: create_session_form_data(form_data),
+                "INCORRECT_IDENTIFIER": create_session_form_data(incorrect_identifier_data)})
+
+        cookie_data = get_data_from_cookie(cookie_data_identifier)
+
+        assert expected_data == cookie_data
+
+    def test_if_only_data_in_incorrect_identifier_then_return_empty_data(self, cookie_data_identifier, test_request_context):
+        incorrect_identifier = {"enemy": "Bowser"}
+
+        test_request_context.session = SecureCookieSession({"INCORRECT_IDENTIFIER": create_session_form_data(incorrect_identifier)})
+
+        cookie_data = get_data_from_cookie(cookie_data_identifier)
+
+        assert {} == cookie_data
+
+    def test_if_no_form_data_in_cookie_then_return_default_data(self, cookie_data_identifier, test_request_context):
+        default_data = {"brother": "Luigi"}
+        test_request_context.session = SecureCookieSession({})
+        cookie_data = get_data_from_cookie(cookie_data_identifier, default_data=default_data)
+
+        assert default_data == cookie_data
+
+    @pytest.mark.usefixtures("test_request_context")
+    def test_if_no_cookie_data_and_debug_data_provided_then_return_copy(self, cookie_data_identifier):
+        original_default_data = {}
+        cookie_data = get_data_from_cookie(cookie_data_identifier, default_data=original_default_data)
+
+        assert original_default_data is not cookie_data
+
+    @pytest.mark.usefixtures("test_request_context")
+    def test_if_no_cookie_data_and_no_debug_data_then_return_empty_dict(self, cookie_data_identifier):
+        cookie_data = get_data_from_cookie(cookie_data_identifier)
+
+        assert {} == cookie_data
+
+    def test_if_cookie_data_then_keep_data_in_cookie(self, cookie_data_identifier, prefilled_cookie_data, app, test_request_context):
+        test_request_context.session = SecureCookieSession({'form_data': create_session_form_data(prefilled_cookie_data)})
+
+        get_data_from_cookie(cookie_data_identifier)
+
+        assert 'form_data' in test_request_context.session
+        assert prefilled_cookie_data == deserialize_session_data(test_request_context.session['form_data'], app.config['PERMANENT_SESSION_LIFETIME'])
+
+
+class TestOverrideCookieData:
+
+    def test_data_is_saved_to_empty_cookie(self, test_request_context):
+        new_data = {'brother': 'Luigi'}
+        with patch('app.forms.cookie_data._serialize_cookie_data', MagicMock(side_effect=lambda _: _)):
+            assert 'form_data' not in test_request_context.session
+            override_data_in_cookie(new_data)
+            assert 'form_data' in test_request_context.session
+            assert new_data == test_request_context.session['form_data']
+
+    def test_data_is_saved_to_prefilled_cookie(self, test_request_context):
+        new_data = {'brother': 'Luigi'}
+        with patch('app.forms.cookie_data._serialize_cookie_data', MagicMock(side_effect=lambda _: _)):
+            test_request_context.session = {'form_data': {'brother': 'Mario', 'pet': 'Yoshi'}}
+            assert 'form_data' in test_request_context.session
+            override_data_in_cookie(new_data)
+            assert 'form_data' in test_request_context.session
+            assert new_data == test_request_context.session['form_data']
+
+    def test_if_data_stored_with_other_identifier_then_it_is_not_changed(self, test_request_context):
+        new_data = {'brother': 'Luigi'}
+        other_data = {'enemy': 'Bowser'}
+        with patch('app.forms.cookie_data._serialize_cookie_data', MagicMock(side_effect=lambda _: _)):
+            test_request_context.session = {'form_data': {'brother': 'Mario', 'pet': 'Yoshi'}, 'OTHER_IDENTIFIER': other_data}
+            override_data_in_cookie(new_data, 'form_data')
+            assert other_data == test_request_context.session['OTHER_IDENTIFIER']
+
+    def test_if_stored_data_identifier_is_set_then_override_data_in_cookie_with_that_new_identifier(self, test_request_context):
+        new_data = {'brother': 'Luigi'}
+        other_data = {'enemy': 'Bowser'}
+        new_identifier = "NEW_IDENTIFIER"
+        with patch('app.forms.cookie_data._serialize_cookie_data', MagicMock(side_effect=lambda _: _)):
+            test_request_context.session = {'form_data': {'brother': 'Mario', 'pet': 'Yoshi'}, 'OTHER_IDENTIFIER': other_data}
+            override_data_in_cookie(new_data, new_identifier)
+            assert new_data == test_request_context.session[new_identifier]


### PR DESCRIPTION
# Short Description
Because there are some flows in which we do want to keep the cookie (e.g. the eligibility flow because the max size of data is known and the FSC flows because of security concerns), this separates the cookie storage from the storage in the session.

@punknoir101 I think I see now the advantage of you solution in #642 and I agree with you. Sorry, that it took some time 🙈 

# Changes
- Use of scoped private functions to access data or override data
- Call the correct global functions to either read/set data to cookie or to session
- Change & add tests accordingly

# Feedback
- I think that using the scoped functions gives us a huge advantage or do you see any problems with that?
- Did I overlook any tests that we might need?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
