### PR TITLE
STL-1822 | Added dummy routes for post/get jobs in MockService

### DIFF
--- a/webapp/app/config.py
+++ b/webapp/app/config.py
@@ -95,6 +95,12 @@ class DevelopmentConfig(BaseConfig):
     SESSION_COOKIE_SECURE = False  # Because Safari can not send Secure Cookies via HTTP to localhost
 
     ERICA_BASE_URL = environ.get('ERICA_BASE_URL') or 'http://0.0.0.0:8000/01'
+    """ Use the following variables to make tests locally with the job queue dummy routes.
+    USE_MOCK_API = True
+    MOCK_MIN_REQUEST_COUNT = 5
+    MOCK_DELIVER_FAIL_ON_POST = False
+    MOCK_DELIVER_FAIL_ON_GET = False
+    """
     RATELIMIT_STORAGE_URL = environ.get('RATELIMIT_STORAGE_URL') or "memory://"
     SQLALCHEMY_DATABASE_URI = environ.get('SQLALCHEMY_DATABASE_URI') or "sqlite:///dev.db"
     SQLALCHEMY_ENGINE_OPTIONS = {}  # Some of our settings don't work with sqlite.

--- a/webapp/app/config.py
+++ b/webapp/app/config.py
@@ -95,12 +95,6 @@ class DevelopmentConfig(BaseConfig):
     SESSION_COOKIE_SECURE = False  # Because Safari can not send Secure Cookies via HTTP to localhost
 
     ERICA_BASE_URL = environ.get('ERICA_BASE_URL') or 'http://0.0.0.0:8000/01'
-    """ Use the following variables to make tests locally with the job queue dummy routes.
-    USE_MOCK_API = True
-    MOCK_MIN_REQUEST_COUNT = 5
-    MOCK_DELIVER_FAIL_ON_POST = False
-    MOCK_DELIVER_FAIL_ON_GET = False
-    """
     RATELIMIT_STORAGE_URL = environ.get('RATELIMIT_STORAGE_URL') or "memory://"
     SQLALCHEMY_DATABASE_URI = environ.get('SQLALCHEMY_DATABASE_URI') or "sqlite:///dev.db"
     SQLALCHEMY_ENGINE_OPTIONS = {}  # Some of our settings don't work with sqlite.
@@ -154,13 +148,19 @@ class TestingConfig(BaseConfig):
     USE_REDIS_LITE = True
     USE_COOKIE_STORAGE = False
 
+
+class MockedDevelopmentConfig(DevelopmentConfig):
+    USE_MOCK_API = True
+
+
 try:
     Config = {
         'development': DevelopmentConfig,
         'functional': FunctionalTestingConfig,
         'testing': TestingConfig,
         'staging': StagingConfig,
-        'production': ProductionConfig
+        'production': ProductionConfig,
+        'mocked_development': MockedDevelopmentConfig
     }[environ['FLASK_ENV']]
 except KeyError:
     raise RuntimeError(f'Unknown FLASK_ENV "{environ["FLASK_ENV"]}"')

--- a/webapp/tests/elster_client/mock_erica.py
+++ b/webapp/tests/elster_client/mock_erica.py
@@ -380,7 +380,7 @@ class MockErica:
             else:
                 response = {"processStatus": "success", "payload": get_json_response('est_without_responses')}
         elif count == 0:
-            response = {"errorCode": -1, "errorMessage": "Request ID not found"}, 500
+            response = {"errorCode": -1, "errorMessage": "Request ID not found"}, 404
         else:
             MockErica.request_id_count[request_id] = count
             response = {"processStatus": "processing"}

--- a/webapp/tests/elster_client/mock_erica.py
+++ b/webapp/tests/elster_client/mock_erica.py
@@ -51,6 +51,9 @@ class MockErica:
     tax_number_is_invalid = False
     invalid_request_timeout_occurred = False
     invalid_request_connection_error_occurred = False
+    min_request_count_get_job = 5
+    deliver_fail_on_post_job = False
+    deliver_fail_on_get_job = False
 
     INVALID_ID = 'C3PO'
 
@@ -361,7 +364,7 @@ class MockErica:
 
     @staticmethod
     def post_dummy_job(*args, **kwargs):
-        if Config.MOCK_DELIVER_FAIL_ON_POST:
+        if MockErica.deliver_fail_on_post_job:
             return {"errorCode": -1, "errorMessage": "Job could not be submitted."}, 422
         else:
             request_id = str(uuid.uuid4())
@@ -371,8 +374,8 @@ class MockErica:
     @staticmethod
     def get_dummy_job(request_id):
         count = MockErica.request_id_count.get(request_id, -1) + 1
-        if count >= Config.MOCK_MIN_REQUEST_COUNT:
-            if Config.MOCK_DELIVER_FAIL_ON_GET:
+        if count >= MockErica.min_request_count_get_job:
+            if MockErica.deliver_fail_on_get_job:
                 response = {"processStatus": "failure", "errorCode": -1, "errorMessage": "ELSTER Timeout error"}
             else:
                 response = {"processStatus": "success", "payload": get_json_response('est_without_responses')}

--- a/webapp/tests/elster_client/mock_erica.py
+++ b/webapp/tests/elster_client/mock_erica.py
@@ -1,8 +1,7 @@
+import uuid
 from typing import List, Tuple
 
-import requests
 from flask import json
-from requests import RequestException
 
 from app.config import Config
 from app.utils import VERANLAGUNGSJAHR
@@ -10,7 +9,10 @@ from tests.elster_client.json_responses.sample_responses import get_json_respons
 from tests.utils import gen_random_key
 
 _JSON_RESPONSES_PATH = "tests/app/elster_client/json_responses"
-_PYERIC_API_BASE_URL = Config.ERICA_BASE_URL
+_PYERIC_API_BASE_URL_01 = Config.ERICA_BASE_URL if Config.ERICA_BASE_URL == 'ERICA' else Config.ERICA_BASE_URL[
+                                                                                         :-2] + "01"
+_PYERIC_API_BASE_URL_02 = Config.ERICA_BASE_URL if Config.ERICA_BASE_URL == 'ERICA' else Config.ERICA_BASE_URL[
+                                                                                         :-2] + "02"
 _EST_KEYS = ['est_data', 'meta_data']
 _REQUIRED_FORM_KEYS_WITH_STEUERNUMMER = ["steuernummer", "bundesland", "familienstand", "person_a_idnr", "person_a_dob",
                                          "person_a_last_name", "person_a_first_name", "person_a_religion",
@@ -63,23 +65,28 @@ class MockErica:
                 sent_data = None
             include_elster_responses = kwargs['params']['include_elster_responses'] if 'params' in kwargs else False
 
-            if args[0] == _PYERIC_API_BASE_URL + '/est_validations':
+            if args[0] == _PYERIC_API_BASE_URL_01 + '/est_validations':
                 response = MockErica.validate_est(sent_data, include_elster_responses)
-            elif args[0] == _PYERIC_API_BASE_URL + '/ests':
+            elif args[0] == _PYERIC_API_BASE_URL_01 + '/ests':
                 response = MockErica.send_est(sent_data, include_elster_responses)
-            elif args[0] == _PYERIC_API_BASE_URL + '/unlock_code_requests':
+            elif args[0] == _PYERIC_API_BASE_URL_01 + '/unlock_code_requests':
                 response = MockErica.request_unlock_code(sent_data, include_elster_responses)
-            elif args[0] == _PYERIC_API_BASE_URL + '/unlock_code_activations':
+            elif args[0] == _PYERIC_API_BASE_URL_01 + '/unlock_code_activations':
                 response = MockErica.activate_unlock_code(sent_data, include_elster_responses)
-            elif args[0] == _PYERIC_API_BASE_URL + '/unlock_code_revocations':
+            elif args[0] == _PYERIC_API_BASE_URL_01 + '/unlock_code_revocations':
                 response = MockErica.revoke_unlock_code(sent_data, include_elster_responses)
-            elif args[0] == _PYERIC_API_BASE_URL + '/address':
+            elif args[0] == _PYERIC_API_BASE_URL_01 + '/address':
                 response = MockErica.get_address_data(sent_data, include_elster_responses)
-            elif args[0] == _PYERIC_API_BASE_URL + '/tax_offices':
+            elif args[0] == _PYERIC_API_BASE_URL_01 + '/tax_offices':
                 response = MockErica.get_tax_offices()
-            elif _PYERIC_API_BASE_URL + '/tax_number_validity' in args[0]:
+            elif _PYERIC_API_BASE_URL_01 + '/tax_number_validity' in args[0]:
                 sub_urls = args[0].split('/')
                 response = MockErica.is_valid_tax_number(state_abbreviation=sub_urls[2], tax_number=sub_urls[3])
+            elif args[0] == _PYERIC_API_BASE_URL_02 + '/post_job':
+                return MockErica.post_dummy_job()
+            elif args[0] == _PYERIC_API_BASE_URL_02 + '/get_job':
+                request_id = kwargs['request_id'] if 'request_id' in kwargs else None
+                return MockErica.get_dummy_job(request_id)
             else:
                 return MockResponse(None, 404)
         except UnexpectedInputDataError:
@@ -220,7 +227,9 @@ class MockErica:
             return err_response
 
         # Successful case
-        if (input_data['idnr'], input_data['elster_request_id'], input_data['unlock_code']) in MockErica.available_idnrs:
+        if (
+                input_data['idnr'], input_data['elster_request_id'],
+                input_data['unlock_code']) in MockErica.available_idnrs:
             elster_request_id_for_unlock = gen_random_key()
             if show_response:
                 return get_json_response('unlock_code_activation_with_resp', idnr=input_data['idnr'],
@@ -257,7 +266,8 @@ class MockErica:
         # Successful case
         if idnr_exists:
             elster_request_id_for_revocation = gen_random_key()
-            MockErica.available_idnrs = [idnr for idnr in MockErica.available_idnrs if idnr[0] != input_data.get('idnr')]
+            MockErica.available_idnrs = [idnr for idnr in MockErica.available_idnrs if
+                                         idnr[0] != input_data.get('idnr')]
             if show_response:
                 return get_json_response('unlock_code_revocation_with_resp',
                                          elster_request_id=elster_request_id_for_revocation)
@@ -303,7 +313,8 @@ class MockErica:
             return err_response
 
         _VALID_TAX_NUMBERS = ['19811310010']
-        _VALID_STATE_ABBREVIATIONS = ['BW', 'BY', 'BE', 'BB', 'HB', 'HH', 'HE', 'MV', 'ND', 'NW', 'RP', 'SL', 'SN', 'ST', 'SH', 'TH']
+        _VALID_STATE_ABBREVIATIONS = ['BW', 'BY', 'BE', 'BB', 'HB', 'HH', 'HE', 'MV', 'ND', 'NW', 'RP', 'SL', 'SN',
+                                      'ST', 'SH', 'TH']
 
         if MockErica.tax_number_is_invalid \
                 or tax_number not in _VALID_TAX_NUMBERS \
@@ -345,3 +356,29 @@ class MockErica:
         # InvalidTaxNumberError
         if MockErica.invalid_tax_number_error_occurred:
             return get_json_response('invalid_tax_number')
+
+    request_id_count = {}
+
+    @staticmethod
+    def post_dummy_job(*args, **kwargs):
+        if Config.MOCK_DELIVER_FAIL_ON_POST:
+            return {"errorCode": -1, "errorMessage": "Job could not be submitted."}, 422
+        else:
+            request_id = str(uuid.uuid4())
+            MockErica.request_id_count.setdefault(request_id, 0)
+            return "/02/get_job/" + request_id, 201
+
+    @staticmethod
+    def get_dummy_job(request_id):
+        count = MockErica.request_id_count.get(request_id, -1) + 1
+        if count >= Config.MOCK_MIN_REQUEST_COUNT:
+            if Config.MOCK_DELIVER_FAIL_ON_GET:
+                response = {"processStatus": "failure", "errorCode": -1, "errorMessage": "ELSTER Timeout error"}
+            else:
+                response = {"processStatus": "success", "payload": get_json_response('est_without_responses')}
+        elif count == 0:
+            response = {"errorCode": -1, "errorMessage": "Request ID not found"}, 500
+        else:
+            MockErica.request_id_count[request_id] = count
+            response = {"processStatus": "processing"}
+        return response


### PR DESCRIPTION
# Short Description
- Dummy routes created for posting and getting a job

# Changes
- Added dummy routes in mock erica
- Route for posting a job has optional parameters and successful return value is adapted for posting an est, in accordance with Julian
- Added commented values for the dev config profile, to be uncommented when testing the dummy routes locally (including flag for returning fail responses)

# Feedback
- No tests needed?
- Dummy routes do not return MockResponse, since they will be probable called from the client? MockResponse does not inherit from Response.


# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
