### PR TITLE
STL-1913 | Added button and bold text

### DIFF
--- a/webapp/app/forms/flows/step_chooser.py
+++ b/webapp/app/forms/flows/step_chooser.py
@@ -24,7 +24,7 @@ class StepChooser:
         self.overview_step = overview_step
 
     def _is_step_name_valid(self, step_name):
-        return step_name == "start" or step_name == "start_next" or step_name in self.steps
+        return step_name == "start" or step_name == "first_input_step" or step_name in self.steps
 
     def _get_possible_redirect(self, step_name, stored_data):
         """
@@ -38,12 +38,6 @@ class StepChooser:
                 return dbg[0].name
             else:
                 return self.first_step.name
-        elif step_name == 'start_next':
-            dbg = self.default_data()
-            if dbg:
-                return dbg[0].name
-            else:
-                return self.determine_next_step(self.first_step.name, {}).name
         step_to_redirect_to = self.steps[step_name].get_redirection_step(stored_data)
         if step_to_redirect_to:
             return step_to_redirect_to

--- a/webapp/app/forms/flows/step_chooser.py
+++ b/webapp/app/forms/flows/step_chooser.py
@@ -24,7 +24,7 @@ class StepChooser:
         self.overview_step = overview_step
 
     def _is_step_name_valid(self, step_name):
-        return step_name == "start" or step_name in self.steps
+        return step_name == "start" or step_name == "start_next" or step_name in self.steps
 
     def _get_possible_redirect(self, step_name, stored_data):
         """
@@ -38,6 +38,12 @@ class StepChooser:
                 return dbg[0].name
             else:
                 return self.first_step.name
+        elif step_name == 'start_next':
+            dbg = self.default_data()
+            if dbg:
+                return dbg[0].name
+            else:
+                return self.determine_next_step(self.first_step.name, {}).name
         step_to_redirect_to = self.steps[step_name].get_redirection_step(stored_data)
         if step_to_redirect_to:
             return step_to_redirect_to

--- a/webapp/app/templates/content/landing_page.html
+++ b/webapp/app/templates/content/landing_page.html
@@ -67,6 +67,8 @@
                             <li class="mt-1">{{ _('landing.hero-list-item-2') }}</li>
                             <li class="mt-1">{{ _('landing.hero-list-item-3') }}</li>
                         </ul>
+                        <p class="mt-5 font-weight-bold">{{ _('landing.hero-check-use-desc') }}</p>
+                        {{ components.primaryButton( text=_('landing.hero-check-use-button'), url=url_for('eligibility', step='start_next')) }}
                     </div>
                         <div class="hero__inner_image">
                             <picture>

--- a/webapp/app/templates/content/landing_page.html
+++ b/webapp/app/templates/content/landing_page.html
@@ -68,7 +68,7 @@
                             <li class="mt-1">{{ _('landing.hero-list-item-3') }}</li>
                         </ul>
                         <p class="mt-5 font-weight-bold">{{ _('landing.hero-check-use-desc') }}</p>
-                        {{ components.primaryButton( text=_('landing.hero-check-use-button'), url=url_for('eligibility', step='start_next')) }}
+                        {{ components.primaryButton( text=_('landing.hero-check-use-button'), url=url_for('eligibility', step='first_input_step')) }}
                     </div>
                         <div class="hero__inner_image">
                             <picture>

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-02-18 07:54+0100\n"
+"POT-Creation-Date: 2022-02-23 11:55+0100\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -247,9 +247,9 @@ msgstr ""
 
 #: app/forms/steps/eligibility_steps.py:76
 #: app/forms/steps/eligibility_steps.py:99
-#: app/forms/steps/eligibility_steps.py:160
-#: app/forms/steps/eligibility_steps.py:739
-#: app/forms/steps/eligibility_steps.py:767
+#: app/forms/steps/eligibility_steps.py:161
+#: app/forms/steps/eligibility_steps.py:740
+#: app/forms/steps/eligibility_steps.py:768
 msgid "form.eligibility.header-title"
 msgstr "Nutzung Prüfen - Der Steuerlotse für Rente und Pension"
 
@@ -257,65 +257,65 @@ msgstr "Nutzung Prüfen - Der Steuerlotse für Rente und Pension"
 msgid "form.eligibility.back_link_text"
 msgstr "Zur vorherigen Frage"
 
-#: app/forms/steps/eligibility_steps.py:154
+#: app/forms/steps/eligibility_steps.py:155
 msgid "form.eligibility.start-title"
 msgstr "Sie möchten wissen, ob Sie den Steuerlotsen nutzen können?"
 
-#: app/forms/steps/eligibility_steps.py:155
+#: app/forms/steps/eligibility_steps.py:156
 msgid "form.eligibility.start-intro"
 msgstr ""
 "Der Steuerlotse ist auf Renten- oder Pensionsbeziehende ohne "
 "Zusatzeinkünfte zugeschnitten. Beantworten Sie paar einfache Fragen und "
 "wir sagen Ihnen, ob Sie den Steuerlotsen nutzen können."
 
-#: app/forms/steps/eligibility_steps.py:172
+#: app/forms/steps/eligibility_steps.py:173
 #: app/templates/eligibility/display_start.html:6
 msgid "form.eligibility.check-now-button"
 msgstr "Fragebogen starten"
 
-#: app/forms/steps/eligibility_steps.py:177
+#: app/forms/steps/eligibility_steps.py:178
 msgid "form.eligibility.marital_status-title"
 msgstr "Was war Ihr letzter Familienstand im Jahr 2021?"
 
-#: app/forms/steps/eligibility_steps.py:190
+#: app/forms/steps/eligibility_steps.py:191
 msgid "form.eligibility.marital_status.married"
 msgstr "verheiratet / in eingetragener Lebenspartnerschaft"
 
-#: app/forms/steps/eligibility_steps.py:191
+#: app/forms/steps/eligibility_steps.py:192
 msgid "form.eligibility.marital_status.single"
 msgstr "ledig"
 
-#: app/forms/steps/eligibility_steps.py:192
+#: app/forms/steps/eligibility_steps.py:193
 msgid "form.eligibility.marital_status.divorced"
 msgstr "geschieden / Lebenspartnerschaft aufgehoben"
 
-#: app/forms/steps/eligibility_steps.py:193
+#: app/forms/steps/eligibility_steps.py:194
 msgid "form.eligibility.marital_status.widowed"
 msgstr "verwitwet"
 
-#: app/forms/steps/eligibility_steps.py:195
+#: app/forms/steps/eligibility_steps.py:196
 #: app/forms/steps/lotse/fahrtkostenpauschale.py:109
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:162
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:166
 #: app/forms/steps/lotse/has_disability.py:29
-#: app/forms/steps/lotse/has_disability.py:62
-#: app/forms/steps/lotse/pauschbetrag.py:106
-#: app/forms/steps/lotse/pauschbetrag.py:170
+#: app/forms/steps/lotse/has_disability.py:63
+#: app/forms/steps/lotse/pauschbetrag.py:108
+#: app/forms/steps/lotse/pauschbetrag.py:174
 msgid "validate.input-required"
 msgstr "Diese Angabe wird benötigt, um fortfahren zu können."
 
-#: app/forms/steps/eligibility_steps.py:199
+#: app/forms/steps/eligibility_steps.py:200
 msgid "form.eligibility.marital_status.back_link_text"
 msgstr "Zurück zum Start"
 
-#: app/forms/steps/eligibility_steps.py:208
+#: app/forms/steps/eligibility_steps.py:209
 msgid "form.eligibility.separated_since_last_year-title"
 msgstr "Haben Sie im Jahr 2021 als Paar dauernd getrennt gelebt?"
 
-#: app/forms/steps/eligibility_steps.py:214
+#: app/forms/steps/eligibility_steps.py:215
 msgid "form.eligibility.separated_since_last_year.detail.title"
 msgstr "Ich weiß nicht, was dauernd getrennt lebend bedeutet."
 
-#: app/forms/steps/eligibility_steps.py:215
+#: app/forms/steps/eligibility_steps.py:216
 msgid "form.eligibility.separated_since_last_year.detail.text"
 msgstr ""
 "Wenn Sie Ihre Lebens- und Wirtschaftsgemeinschaft dauerhaft aufgelöst "
@@ -324,35 +324,35 @@ msgstr ""
 "Betten schlafen, eigene Konten besitzen und getrennt haushalten (ohne den"
 " anderen kochen oder Wäsche waschen)."
 
-#: app/forms/steps/eligibility_steps.py:216
+#: app/forms/steps/eligibility_steps.py:217
 msgid "form.eligibility.separated_since_last_year.yes"
 msgstr "Ja, wir haben dauernd getrennt gelebt."
 
-#: app/forms/steps/eligibility_steps.py:217
+#: app/forms/steps/eligibility_steps.py:218
 msgid "form.eligibility.separated_since_last_year.no"
 msgstr "Nein, wir haben nicht dauernd getrennt gelebt."
 
-#: app/forms/steps/eligibility_steps.py:228
+#: app/forms/steps/eligibility_steps.py:229
 msgid "form.eligibility.separated_lived_together-title"
 msgstr "Haben Sie an mindestens einem Tag im Jahr 2021 zusammengelebt?"
 
-#: app/forms/steps/eligibility_steps.py:234
+#: app/forms/steps/eligibility_steps.py:235
 msgid "form.eligibility.separated_lived_together.yes"
 msgstr "Ja, wir haben im Jahr 2021 auch zusammengelebt."
 
-#: app/forms/steps/eligibility_steps.py:235
+#: app/forms/steps/eligibility_steps.py:236
 msgid "form.eligibility.separated_lived_together.no"
 msgstr "Nein, wir haben das gesamte Jahr 2021 über getrennt gelebt."
 
-#: app/forms/steps/eligibility_steps.py:246
+#: app/forms/steps/eligibility_steps.py:247
 msgid "form.eligibility.separated_joint_taxes-title"
 msgstr "Möchten Sie die Steuererklärung 2021 gemeinsam als Paar machen?"
 
-#: app/forms/steps/eligibility_steps.py:252
+#: app/forms/steps/eligibility_steps.py:253
 msgid "form.eligibility.separated_joint_taxes.detail.title"
 msgstr "Was passiert bei der Zusammenveranlagung?"
 
-#: app/forms/steps/eligibility_steps.py:253
+#: app/forms/steps/eligibility_steps.py:254
 msgid "form.eligibility.separated_joint_taxes.detail.text"
 msgstr ""
 "Wenn Sie Ihre Steuererklärung gemeinsam machen, werden Sie zusammen "
@@ -360,32 +360,32 @@ msgstr ""
 "als gemeinsame Einkommensteuererklärung beim Finanzamt abgegeben werden. "
 "Das Finanzamt erlässt dann nur einen Steuerbescheid."
 
-#: app/forms/steps/eligibility_steps.py:254
+#: app/forms/steps/eligibility_steps.py:255
 msgid "form.eligibility.separated_joint_taxes.yes"
 msgstr "Ja, wir möchten die Zusammenveranlagung nutzen."
 
-#: app/forms/steps/eligibility_steps.py:255
+#: app/forms/steps/eligibility_steps.py:256
 msgid "form.eligibility.separated_joint_taxes.no"
 msgstr "Nein, wir möchten die Steuererklärung einzeln machen."
 
-#: app/forms/steps/eligibility_steps.py:262
+#: app/forms/steps/eligibility_steps.py:263
 msgid "form.eligibility.married_joint_taxes_failure-error"
 msgstr ""
 "Der Steuerlotse bildet die Einzelveranlagung für verheiratete Paare sowie"
 " für Paare in eingetragener Lebenspartnerschaft zurzeit nicht ab."
 
-#: app/forms/steps/eligibility_steps.py:272
-#: app/forms/steps/eligibility_steps.py:372
+#: app/forms/steps/eligibility_steps.py:273
+#: app/forms/steps/eligibility_steps.py:373
 msgid "form.eligibility.joint_taxes-title"
 msgstr "Möchten Sie die Steuererklärung 2021 gemeinsam als Paar machen?"
 
-#: app/forms/steps/eligibility_steps.py:278
-#: app/forms/steps/eligibility_steps.py:378
+#: app/forms/steps/eligibility_steps.py:279
+#: app/forms/steps/eligibility_steps.py:379
 msgid "form.eligibility.joint_taxes.detail.title"
 msgstr "Was passiert bei der Zusammenveranlagung?"
 
-#: app/forms/steps/eligibility_steps.py:279
-#: app/forms/steps/eligibility_steps.py:379
+#: app/forms/steps/eligibility_steps.py:280
+#: app/forms/steps/eligibility_steps.py:380
 msgid "form.eligibility.joint_taxes.detail.text"
 msgstr ""
 "Wenn Sie Ihre Steuererklärung gemeinsam machen, werden Sie zusammen "
@@ -393,67 +393,67 @@ msgstr ""
 "als gemeinsame Einkommensteuererklärung beim Finanzamt abgegeben werden. "
 "Das Finanzamt erlässt dann nur einen Steuerbescheid."
 
-#: app/forms/steps/eligibility_steps.py:280
-#: app/forms/steps/eligibility_steps.py:380
+#: app/forms/steps/eligibility_steps.py:281
+#: app/forms/steps/eligibility_steps.py:381
 msgid "form.eligibility.joint_taxes.yes"
 msgstr "Ja, wir möchten die Zusammenveranlagung nutzen."
 
-#: app/forms/steps/eligibility_steps.py:281
-#: app/forms/steps/eligibility_steps.py:381
+#: app/forms/steps/eligibility_steps.py:282
+#: app/forms/steps/eligibility_steps.py:382
 msgid "form.eligibility.joint_taxes.no"
 msgstr "Nein, wir möchten die Steuererklärung einzeln machen."
 
-#: app/forms/steps/eligibility_steps.py:288
-#: app/forms/steps/eligibility_steps.py:388
+#: app/forms/steps/eligibility_steps.py:289
+#: app/forms/steps/eligibility_steps.py:389
 msgid "form.eligibility.alimony_failure-error"
 msgstr ""
 "Wenn Sie Unterhalt zahlen oder beziehen, müssen Sie im Steuerformular "
 "Angaben machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:298
-#: app/forms/steps/eligibility_steps.py:398
+#: app/forms/steps/eligibility_steps.py:299
+#: app/forms/steps/eligibility_steps.py:399
 msgid "form.eligibility.alimony-title"
 msgstr "Zahlen oder beziehen Sie Unterhalt?"
 
-#: app/forms/steps/eligibility_steps.py:304
-#: app/forms/steps/eligibility_steps.py:404
+#: app/forms/steps/eligibility_steps.py:305
+#: app/forms/steps/eligibility_steps.py:405
 msgid "form.eligibility.alimony.detail.title"
 msgstr "Was bedeutet das?"
 
-#: app/forms/steps/eligibility_steps.py:305
-#: app/forms/steps/eligibility_steps.py:405
+#: app/forms/steps/eligibility_steps.py:306
+#: app/forms/steps/eligibility_steps.py:406
 msgid "form.eligibility.alimony.detail.text"
 msgstr ""
 "Beantworten Sie die Frage mit »Ja«, wenn Sie Unterhalt an einen "
 "geschiedenen bzw. dauernd getrennt lebenden Partner oder an bedürftige "
 "Personen leisten oder selbst Unterhalt erhalten."
 
-#: app/forms/steps/eligibility_steps.py:306
-#: app/forms/steps/eligibility_steps.py:315
+#: app/forms/steps/eligibility_steps.py:307
+#: app/forms/steps/eligibility_steps.py:316
 msgid "form.eligibility.alimony.yes"
 msgid_plural "form.eligibility.alimony.yes"
 msgstr[0] "Ja, ich zahle oder beziehe Unterhalt."
 msgstr[1] "Ja, eine Person von uns bzw. wir beide zahlen oder beziehen Unterhalt."
 
-#: app/forms/steps/eligibility_steps.py:307
-#: app/forms/steps/eligibility_steps.py:318
+#: app/forms/steps/eligibility_steps.py:308
+#: app/forms/steps/eligibility_steps.py:319
 msgid "form.eligibility.alimony.no"
 msgid_plural "form.eligibility.alimony.no"
 msgstr[0] "Nein, weder zahle, noch beziehe ich Unterhalt."
 msgstr[1] "Nein, niemand von uns zahlt oder bezieht Unterhalt."
 
-#: app/forms/steps/eligibility_steps.py:328
-#: app/forms/steps/eligibility_steps.py:418
+#: app/forms/steps/eligibility_steps.py:329
+#: app/forms/steps/eligibility_steps.py:419
 msgid "form.eligibility.user_a_has_elster_account-title"
 msgstr "Haben Sie ein Konto bei Mein ELSTER?"
 
-#: app/forms/steps/eligibility_steps.py:334
-#: app/forms/steps/eligibility_steps.py:424
+#: app/forms/steps/eligibility_steps.py:335
+#: app/forms/steps/eligibility_steps.py:425
 msgid "form.eligibility.user_a_has_elster_account.detail.title"
 msgstr "Was ist Mein ELSTER?"
 
-#: app/forms/steps/eligibility_steps.py:335
-#: app/forms/steps/eligibility_steps.py:425
+#: app/forms/steps/eligibility_steps.py:336
+#: app/forms/steps/eligibility_steps.py:426
 msgid "form.eligibility.user_a_has_elster_account.detail.text"
 msgstr ""
 "ELSTER steht für »Elektronische Steuererklärung« und ist die offizielle "
@@ -462,45 +462,45 @@ msgstr ""
 "ELSTER” können Privatpersonen die für die Einkommensteuererklärung "
 "notwendigen Formulare ausfüllen und abschicken."
 
-#: app/forms/steps/eligibility_steps.py:336
-#: app/forms/steps/eligibility_steps.py:426
+#: app/forms/steps/eligibility_steps.py:337
+#: app/forms/steps/eligibility_steps.py:427
 msgid "form.eligibility.user_a_has_elster_account.yes"
 msgstr "Ja"
 
-#: app/forms/steps/eligibility_steps.py:337
-#: app/forms/steps/eligibility_steps.py:427
+#: app/forms/steps/eligibility_steps.py:338
+#: app/forms/steps/eligibility_steps.py:428
 msgid "form.eligibility.user_a_has_elster_account.no"
 msgstr "Nein"
 
-#: app/forms/steps/eligibility_steps.py:348
+#: app/forms/steps/eligibility_steps.py:349
 msgid "form.eligibility.user_b_has_elster_account-title"
 msgstr ""
 "Hat die Person, mit der Sie zusammen veranlagen möchten, ein Konto bei "
 "Mein ELSTER?"
 
-#: app/forms/steps/eligibility_steps.py:354
+#: app/forms/steps/eligibility_steps.py:355
 msgid "form.eligibility.user_b_has_elster_account.yes"
 msgstr "Ja"
 
-#: app/forms/steps/eligibility_steps.py:355
+#: app/forms/steps/eligibility_steps.py:356
 msgid "form.eligibility.user_b_has_elster_account.no"
 msgstr "Nein"
 
-#: app/forms/steps/eligibility_steps.py:362
+#: app/forms/steps/eligibility_steps.py:363
 msgid "form.eligibility.divorced_joint_taxes_failure-error"
 msgstr ""
 "Der Steuerlotse bildet die Einzelveranlagung für geschiedene Paare "
 "zurzeit nicht ab."
 
-#: app/forms/steps/eligibility_steps.py:406
+#: app/forms/steps/eligibility_steps.py:407
 msgid "form.eligibility.alimony.single.yes"
 msgstr "Ja, ich zahle oder beziehe Unterhalt."
 
-#: app/forms/steps/eligibility_steps.py:407
+#: app/forms/steps/eligibility_steps.py:408
 msgid "form.eligibility.alimony.single.no"
 msgstr "Nein, weder zahle, noch beziehe ich Unterhalt."
 
-#: app/forms/steps/eligibility_steps.py:433
+#: app/forms/steps/eligibility_steps.py:434
 msgid "form.eligibility.pension_failure-error"
 msgstr ""
 "Sie können Ihre Steuererklärung nur mit dem Steuerlotsen machen, wenn die"
@@ -513,13 +513,13 @@ msgstr ""
 "nicht prüfen, arbeiten aber an einer Möglichkeit, Ihnen mehr "
 "Informationen zur Verfügung zu stellen."
 
-#: app/forms/steps/eligibility_steps.py:443
+#: app/forms/steps/eligibility_steps.py:444
 msgid "form.eligibility.pension-title"
 msgstr ""
 "Beziehen Sie eine inländische Rente bzw. eine Pension von einer oder "
 "mehrerer dieser Stellen:"
 
-#: app/forms/steps/eligibility_steps.py:444
+#: app/forms/steps/eligibility_steps.py:445
 msgid "form.eligibility.pension-intro"
 msgstr ""
 "<ul><li>Träger der gesetzlichen Rentenversicherung</li> <li>der "
@@ -528,8 +528,8 @@ msgstr ""
 " der sog. „Rürup- Rente\"</li><li>Anbieter der sog. „Riester-"
 "Rente\"</li><li>frühere Arbeitgeber</li></ul>"
 
-#: app/forms/steps/eligibility_steps.py:450
-#: app/forms/steps/eligibility_steps.py:459
+#: app/forms/steps/eligibility_steps.py:451
+#: app/forms/steps/eligibility_steps.py:460
 msgid "form.eligibility.pension.yes"
 msgid_plural "form.eligibility.pension.yes"
 msgstr[0] "Ja, ich beziehe meine Rente ausschließlich aus den genannten Stellen."
@@ -537,8 +537,8 @@ msgstr[1] ""
 "Ja, wir beziehen unsere Rente beziehungsweise Pensionen ausschließlich "
 "aus den genannten Stellen."
 
-#: app/forms/steps/eligibility_steps.py:451
-#: app/forms/steps/eligibility_steps.py:462
+#: app/forms/steps/eligibility_steps.py:452
+#: app/forms/steps/eligibility_steps.py:463
 msgid "form.eligibility.pension.no"
 msgid_plural "form.eligibility.pension.no"
 msgstr[0] "Nein, ich beziehe meine Rente aus weiteren Stellen."
@@ -546,15 +546,15 @@ msgstr[1] ""
 "Nein, wir beziehen unsere Rente beziehungsweise Pensionen aus weiteren "
 "Stellen."
 
-#: app/forms/steps/eligibility_steps.py:472
+#: app/forms/steps/eligibility_steps.py:473
 msgid "form.eligibility.investment_income-title"
 msgstr "Haben Sie Kapitalerträge?"
 
-#: app/forms/steps/eligibility_steps.py:478
+#: app/forms/steps/eligibility_steps.py:479
 msgid "form.eligibility.investment_income.detail.title"
 msgstr "Ich weiß nicht, ob ich Kapitalerträge habe."
 
-#: app/forms/steps/eligibility_steps.py:479
+#: app/forms/steps/eligibility_steps.py:480
 msgid "form.eligibility.investment_income.detail.text"
 msgstr ""
 "Kapitalerträge sind die Gewinne aus Geldanlagen. Hierzu gehören z.B. "
@@ -562,32 +562,32 @@ msgstr ""
 " aus Aktien oder GmbH-Anteilen. Unter Kapitalerträge fällt aber z.B. "
 "auch, wenn Sie privat Geld verliehen haben und dafür Zinsen erhalten."
 
-#: app/forms/steps/eligibility_steps.py:480
-#: app/forms/steps/eligibility_steps.py:489
+#: app/forms/steps/eligibility_steps.py:481
+#: app/forms/steps/eligibility_steps.py:490
 msgid "form.eligibility.investment_income.yes"
 msgid_plural "form.eligibility.investment_income.yes"
 msgstr[0] "Ja, ich habe Kapitalerträge."
 msgstr[1] "Ja, wir haben Kapitalerträge."
 
-#: app/forms/steps/eligibility_steps.py:481
-#: app/forms/steps/eligibility_steps.py:493
+#: app/forms/steps/eligibility_steps.py:482
+#: app/forms/steps/eligibility_steps.py:494
 msgid "form.eligibility.investment_income.no"
 msgid_plural "form.eligibility.investment_income.no"
 msgstr[0] "Nein, ich habe keine Kapitalerträge."
 msgstr[1] "Nein, wir haben keine Kapitalerträge."
 
-#: app/forms/steps/eligibility_steps.py:504
+#: app/forms/steps/eligibility_steps.py:505
 msgid "form.eligibility.minimal_investment_income-title"
 msgstr ""
 "Haben Sie ausschließlich Kapitalerträge, die nicht versteuert werden "
 "müssen, weil diese den in Anspruch genommenen Sparer-Pauschbetrag nicht "
 "überschreiten?"
 
-#: app/forms/steps/eligibility_steps.py:510
+#: app/forms/steps/eligibility_steps.py:511
 msgid "form.eligibility.minimal_investment_income.detail.title"
 msgstr "Was ist der Sparer-Pauschbetrag?"
 
-#: app/forms/steps/eligibility_steps.py:511
+#: app/forms/steps/eligibility_steps.py:512
 msgid "form.eligibility.minimal_investment_income.detail.text"
 msgstr ""
 "Wenn Sie für Ihre Kapitalerträge bei Ihrer Bank einen "
@@ -596,8 +596,8 @@ msgstr ""
 "Rahmen des Sparer-Pauschbetrags sind 801€ für Alleinstehende und 1.602€ "
 "für gemeinsam Veranlagte steuerfrei."
 
-#: app/forms/steps/eligibility_steps.py:512
-#: app/forms/steps/eligibility_steps.py:522
+#: app/forms/steps/eligibility_steps.py:513
+#: app/forms/steps/eligibility_steps.py:523
 msgid "form.eligibility.minimal_investment_income.yes"
 msgid_plural "form.eligibility.minimal_investment_income.yes"
 msgstr[0] ""
@@ -607,30 +607,30 @@ msgstr[1] ""
 "Ja, alle unsere Kapitalerträge liegen unter dem Sparerpauschbetrag, den "
 "wir in Anspruch genommen haben."
 
-#: app/forms/steps/eligibility_steps.py:513
-#: app/forms/steps/eligibility_steps.py:527
+#: app/forms/steps/eligibility_steps.py:514
+#: app/forms/steps/eligibility_steps.py:528
 msgid "form.eligibility.minimal_investment_income.no"
 msgid_plural "form.eligibility.minimal_investment_income.no"
 msgstr[0] "Nein, das trifft auf die Kapitalerträge nicht zu."
 msgstr[1] "Nein, das trifft auf die Kapitalerträge nicht zu.\""
 
-#: app/forms/steps/eligibility_steps.py:533
+#: app/forms/steps/eligibility_steps.py:534
 msgid "form.eligibility.taxed_investment_failure-error"
 msgstr ""
 "Wenn Sie unversteuerte Kapitalerträge haben, müssen Sie Angaben im "
 "Steuerformular machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:543
+#: app/forms/steps/eligibility_steps.py:544
 msgid "form.eligibility.taxed_investment-title"
 msgstr ""
 "Sind die Kapitalerträge besteuert, weil die Abgeltungsteuer bereits "
 "abgeführt wurde?"
 
-#: app/forms/steps/eligibility_steps.py:549
+#: app/forms/steps/eligibility_steps.py:550
 msgid "form.eligibility.taxed_investment.detail.title"
 msgstr "Ich weiß nicht, wann die Abgeltungsteuer abgeführt wird."
 
-#: app/forms/steps/eligibility_steps.py:550
+#: app/forms/steps/eligibility_steps.py:551
 msgid "form.eligibility.taxed_investment.detail.text"
 msgstr ""
 "Die Abgeltungsteuer hat den Effekt, dass die Steuerschuld auf "
@@ -652,31 +652,31 @@ msgstr ""
 "Versicherung und Auszahlung noch versteuert werden. Wenn dies auf Sie "
 "zutrifft, wählen Sie bitte »Nein« aus.</p>"
 
-#: app/forms/steps/eligibility_steps.py:551
+#: app/forms/steps/eligibility_steps.py:552
 msgid "form.eligibility.taxed_investment.yes"
 msgstr "Ja, die Abgeltungsteuer wurde bereits abgeführt."
 
-#: app/forms/steps/eligibility_steps.py:552
+#: app/forms/steps/eligibility_steps.py:553
 msgid "form.eligibility.taxed_investment.no"
 msgstr "Nein, die Abgeltungsteuer wurde noch nicht abgeführt."
 
-#: app/forms/steps/eligibility_steps.py:559
+#: app/forms/steps/eligibility_steps.py:560
 msgid "form.eligibility.cheaper_check_failure-error"
 msgstr ""
 "Wenn Sie die Günstigerprüfung beantragen möchten, müssen Sie Angaben im "
 "Steuerformular machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:569
+#: app/forms/steps/eligibility_steps.py:570
 msgid "form.eligibility.cheaper_check-title"
 msgstr ""
 "Haben Sie ein geringes Einkommen und möchten daher eine Günstigerprüfung "
 "beantragen?"
 
-#: app/forms/steps/eligibility_steps.py:575
+#: app/forms/steps/eligibility_steps.py:576
 msgid "form.eligibility.cheaper_check.detail.title"
 msgstr "Was ist die Günstigerprüfung?"
 
-#: app/forms/steps/eligibility_steps.py:576
+#: app/forms/steps/eligibility_steps.py:577
 msgid "form.eligibility.cheaper_check.detail.text"
 msgstr ""
 "Die Günstigerprüfung ist ein Verfahren, bei dem das Finanzamt den "
@@ -687,66 +687,66 @@ msgstr ""
 "persönlichen Steuersatz besteuert werden anstatt der Besteuerung Ihrer "
 "Kapitalerträge mit der Abgeltungsteuer."
 
-#: app/forms/steps/eligibility_steps.py:577
-#: app/forms/steps/eligibility_steps.py:587
+#: app/forms/steps/eligibility_steps.py:578
+#: app/forms/steps/eligibility_steps.py:588
 msgid "form.eligibility.cheaper_check_eligibility.yes"
 msgid_plural "form.eligibility.cheaper_check_eligibility.yes"
 msgstr[0] "Ja, ich möchte die Günstigerprüfung beantragen."
 msgstr[1] "Ja, wir möchten die Günstigerprüfung beantragen."
 
-#: app/forms/steps/eligibility_steps.py:578
-#: app/forms/steps/eligibility_steps.py:591
+#: app/forms/steps/eligibility_steps.py:579
+#: app/forms/steps/eligibility_steps.py:592
 msgid "form.eligibility.cheaper_check_eligibility.no"
 msgid_plural "form.eligibility.cheaper_check_eligibility.no"
 msgstr[0] "Nein, ich möchte die Günstigerprüfung nicht beantragen."
 msgstr[1] "Nein, wir möchten die Günstigerprüfung nicht beantragen."
 
-#: app/forms/steps/eligibility_steps.py:601
+#: app/forms/steps/eligibility_steps.py:602
 msgid "form.eligibility.employment_income-title"
 msgstr "Haben Sie Einkünfte aus einer Erwerbstätigkeit?"
 
-#: app/forms/steps/eligibility_steps.py:607
+#: app/forms/steps/eligibility_steps.py:608
 msgid "form.eligibility.employment_income.detail.title"
 msgstr "Ich weiß nicht, ob ich erwerbstätig bin."
 
-#: app/forms/steps/eligibility_steps.py:608
+#: app/forms/steps/eligibility_steps.py:609
 msgid "form.eligibility.employment_income.detail.text"
 msgstr ""
 "Sie sind zum Beispiel erwerbstätig, wenn Sie mindestens eine Stunde in "
 "der Woche gegen Entgelt einer beruflichen Tätigkeit nachgehen, "
 "selbstständig sind, einem Gewerbe, Handwerk oder freien Beruf nachgehen."
 
-#: app/forms/steps/eligibility_steps.py:609
-#: app/forms/steps/eligibility_steps.py:619
+#: app/forms/steps/eligibility_steps.py:610
+#: app/forms/steps/eligibility_steps.py:620
 msgid "form.eligibility.employment_income.yes"
 msgid_plural "form.eligibility.employment_income.yes"
 msgstr[0] "Ja, ich habe Einkünfte aus einer Erwerbstätigkeit."
 msgstr[1] "Ja, wir haben Einkünfte aus einer Erwerbstätigkeit."
 
-#: app/forms/steps/eligibility_steps.py:610
-#: app/forms/steps/eligibility_steps.py:623
+#: app/forms/steps/eligibility_steps.py:611
+#: app/forms/steps/eligibility_steps.py:624
 msgid "form.eligibility.employment_income.no"
 msgid_plural "form.eligibility.employment_income.no"
 msgstr[0] "Nein, ich habe keine Einkünfte aus einer Erwerbstätigkeit."
 msgstr[1] "Nein, wir haben keine Einkünfte aus einer Erwerbstätigkeit."
 
-#: app/forms/steps/eligibility_steps.py:629
+#: app/forms/steps/eligibility_steps.py:630
 msgid "form.eligibility.marginal_employment_failure-error"
 msgstr ""
 "Wenn Sie Einkünfte haben, die noch zu versteuern sind, müssen Sie Angaben"
 " im Steuerformular machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:639
+#: app/forms/steps/eligibility_steps.py:640
 msgid "form.eligibility.marginal_employment-title"
 msgstr ""
 "Handelt es sich bei der Erwerbstätigkeit um eine geringfügige "
 "Beschäftigung bis zu 450€, die bereits pauschal besteuert wurde?"
 
-#: app/forms/steps/eligibility_steps.py:645
+#: app/forms/steps/eligibility_steps.py:646
 msgid "form.eligibility.marginal_employment.detail.title"
 msgstr "Was bedeutet das?"
 
-#: app/forms/steps/eligibility_steps.py:646
+#: app/forms/steps/eligibility_steps.py:647
 msgid "form.eligibility.marginal_employment.detail.text"
 msgstr ""
 "Wer nicht mehr als 450 Euro im Monat verdient, gilt als geringfügig "
@@ -754,99 +754,99 @@ msgstr ""
 "Minijob vom Arbeitgeber mit einem Satz von zwei Prozent pauschal "
 "versteuert."
 
-#: app/forms/steps/eligibility_steps.py:647
+#: app/forms/steps/eligibility_steps.py:648
 msgid "form.eligibility.marginal_employment.yes"
 msgstr ""
 "Ja, es handelt sich um eine geringfügige Beschäftigung. Die Einkünfte "
 "wurden bereits pauschal versteuert."
 
-#: app/forms/steps/eligibility_steps.py:648
+#: app/forms/steps/eligibility_steps.py:649
 msgid "form.eligibility.marginal_employment.no"
 msgstr ""
 "Nein, es handelt sich nicht um eine geringfügige Beschäftigung. Die "
 "Einkünfte wurden noch nicht pauschal besteuert."
 
-#: app/forms/steps/eligibility_steps.py:655
+#: app/forms/steps/eligibility_steps.py:656
 msgid "form.eligibility.income_other_failure-error"
 msgstr ""
 "Wenn Sie Einkünfte haben, die noch zu versteuern sind, müssen Sie Angaben"
 " im Steuerformular machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:665
+#: app/forms/steps/eligibility_steps.py:666
 msgid "form.eligibility.income-other-title"
 msgstr ""
 "Haben Sie noch weitere Einkünfte als die bisher genannten Einkünfte? Zum "
 "Beispiel aus einer Vermietung?"
 
-#: app/forms/steps/eligibility_steps.py:671
+#: app/forms/steps/eligibility_steps.py:672
 msgid "form.eligibility.income-other.detail.title"
 msgstr "Ich bin mir nicht sicher."
 
-#: app/forms/steps/eligibility_steps.py:672
+#: app/forms/steps/eligibility_steps.py:673
 msgid "form.eligibility.income-other.detail.text"
 msgstr ""
 "Wenn Sie außer Ihren Renteneinkünften bzw. Pensionen, Kapitalerträgen "
 "oder Einkünften aus einer Erwerbstätigkeit weitere Einkünfte wie zum "
 "Beispiel aus einer Vermietung haben, wählen Sie bitte »Ja«."
 
-#: app/forms/steps/eligibility_steps.py:673
-#: app/forms/steps/eligibility_steps.py:683
+#: app/forms/steps/eligibility_steps.py:674
+#: app/forms/steps/eligibility_steps.py:684
 msgid "form.eligibility.income_other.yes"
 msgid_plural "form.eligibility.income_other.yes"
 msgstr[0] "Ja, ich habe noch weitere Einkünfte."
 msgstr[1] "Ja, wir haben noch weitere Einkünfte."
 
-#: app/forms/steps/eligibility_steps.py:674
-#: app/forms/steps/eligibility_steps.py:687
+#: app/forms/steps/eligibility_steps.py:675
+#: app/forms/steps/eligibility_steps.py:688
 msgid "form.eligibility.income_other.no"
 msgid_plural "form.eligibility.income_other.no"
 msgstr[0] "Nein, ich habe keine weiteren Einkünfte."
 msgstr[1] "Nein, wir haben keine weiteren Einkünfte."
 
-#: app/forms/steps/eligibility_steps.py:693
+#: app/forms/steps/eligibility_steps.py:694
 msgid "form.eligibility.foreign_country_failure-error"
 msgstr ""
 "Wenn Sie letztes Jahr im Ausland gelebt haben, müssen Sie Angaben im "
 "Steuerformular machen, die der Steuerlotse zurzeit nicht abbildet."
 
-#: app/forms/steps/eligibility_steps.py:704
+#: app/forms/steps/eligibility_steps.py:705
 msgid "form.eligibility.foreign-country-title"
 msgstr ""
 "Leben Sie dauerhaft im Ausland und kommen nur gelegentlich, zum Beispiel "
 "zu Besuchszwecken, nach Deutschland?"
 
-#: app/forms/steps/eligibility_steps.py:710
+#: app/forms/steps/eligibility_steps.py:711
 msgid "form.eligibility.foreign-country.detail.title"
 msgstr "Ab welcher Dauer lebt man dauerhaft im Ausland?"
 
-#: app/forms/steps/eligibility_steps.py:711
+#: app/forms/steps/eligibility_steps.py:712
 msgid "form.eligibility.foreign-country.detail.text"
 msgstr ""
 "Sie leben dauerhaft im Ausland, wenn Sie länger als 183 Tage im Jahr in "
 "einem anderen Land gelebt haben. Sollte dies der Fall sein, wählen Sie "
 "»Ja« aus. "
 
-#: app/forms/steps/eligibility_steps.py:712
-#: app/forms/steps/eligibility_steps.py:722
+#: app/forms/steps/eligibility_steps.py:713
+#: app/forms/steps/eligibility_steps.py:723
 msgid "form.eligibility.foreign_country.yes"
 msgid_plural "form.eligibility.foreign_country.yes"
 msgstr[0] "Ja, ich lebe dauerhaft im Ausland."
 msgstr[1] "Ja, wir leben dauerhaft im Ausland."
 
-#: app/forms/steps/eligibility_steps.py:713
-#: app/forms/steps/eligibility_steps.py:726
+#: app/forms/steps/eligibility_steps.py:714
+#: app/forms/steps/eligibility_steps.py:727
 msgid "form.eligibility.foreign_country.no"
 msgid_plural "form.eligibility.foreign_country.no"
 msgstr[0] "Nein, ich lebe dauerhaft in Deutschland."
 msgstr[1] "Nein, wir leben dauerhaft in Deutschland."
 
-#: app/forms/steps/eligibility_steps.py:732
+#: app/forms/steps/eligibility_steps.py:733
 msgid "form.eligibility.result-title"
 msgstr ""
 "Sie können Ihre Steuererklärung für das Jahr 2021 mit dem Steuerlotsen "
 "machen."
 
-#: app/forms/steps/eligibility_steps.py:733
+#: app/forms/steps/eligibility_steps.py:734
 msgid "form.eligibility.result-intro"
 msgstr ""
 "Wenn Sie alle Fragen korrekt beantwortet haben, können Sie den "
@@ -855,7 +855,7 @@ msgstr ""
 "die Finanzverwaltung übermitteln. Außerdem haben Sie keine weiteren "
 "Einkünfte, die Sie in Ihrer Steuererklärung geltend machen müssen."
 
-#: app/forms/steps/eligibility_steps.py:749
+#: app/forms/steps/eligibility_steps.py:750
 msgid "form.eligibility.result-note.user_b_elster_account-registration-success"
 msgstr ""
 "Um den Freischaltcode per Post zu erhalten, muss sich die Person "
@@ -864,8 +864,8 @@ msgstr ""
 " Person von Ihnen registriert. Wer sich von Ihnen registriert, können Sie"
 " entscheiden."
 
-#: app/forms/steps/eligibility_steps.py:752
-#: app/forms/steps/eligibility_steps.py:780
+#: app/forms/steps/eligibility_steps.py:753
+#: app/forms/steps/eligibility_steps.py:781
 msgid "form.eligibility.result-note.capital_investment"
 msgstr ""
 "Die Besteuerung von Kapitalerträgen erledigen Banken und Versicherungen "
@@ -876,13 +876,13 @@ msgstr ""
 "Änderung der Steuerbelastung beantragen. Der Steuerlotse bietet Ihnen "
 "dafür allerdings derzeit keine Möglichkeiten."
 
-#: app/forms/steps/eligibility_steps.py:760
+#: app/forms/steps/eligibility_steps.py:761
 msgid "form.eligibility.success.maybe.title"
 msgstr ""
 "Sie können Ihre Steuererklärung für das Jahr 2021 vielleicht mit dem "
 "Steuerlotsen machen."
 
-#: app/forms/steps/eligibility_steps.py:761
+#: app/forms/steps/eligibility_steps.py:762
 msgid "form.eligibility.success.maybe.intro"
 msgstr ""
 "Sie können Ihre Steuererklärung mit dem Steuerlotsen machen, wenn Ihnen "
@@ -899,7 +899,7 @@ msgstr ""
 "Finanzverwaltung übermitteln. Außerdem haben Sie keine weiteren "
 "Einkünfte, die Sie in Ihrer Steuererklärung geltend machen müssen."
 
-#: app/forms/steps/eligibility_steps.py:777
+#: app/forms/steps/eligibility_steps.py:778
 msgid "form.eligibility.result-note.both_elster_account-registration-maybe"
 msgstr ""
 "Um die Chancen auf den Erhalt eines Freischaltcodes zu erhöhen, empfehlen"
@@ -907,11 +907,11 @@ msgstr ""
 "Steuererklärung gemeinsam als Paar zu machen, reicht allerdings ein "
 "Freischaltcode aus."
 
-#: app/forms/steps/eligibility_steps.py:784
+#: app/forms/steps/eligibility_steps.py:785
 msgid "form.eligibility.result-note.when_unlock_code.title"
 msgstr "Wann bekomme ich einen Freischaltcode?"
 
-#: app/forms/steps/eligibility_steps.py:785
+#: app/forms/steps/eligibility_steps.py:786
 msgid "form.eligibility.result-note.when_unlock_code.description"
 msgstr ""
 "Sie bekommen einen Freischaltcode, wenn Sie sich bei Mein Elster mit "
@@ -941,8 +941,8 @@ msgstr ""
 msgid "form.logout.header-title"
 msgstr "Infos zur Abmeldung - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse/personal_data.py:190
-#: app/forms/steps/lotse/personal_data.py:288
+#: app/forms/steps/lotse/personal_data.py:191
+#: app/forms/steps/lotse/personal_data.py:290
 #: app/forms/steps/unlock_code_activation_steps.py:20
 #: app/forms/steps/unlock_code_request_steps.py:21
 #: app/forms/steps/unlock_code_revocation_steps.py:22
@@ -1099,83 +1099,83 @@ msgstr ""
 msgid "form.lotse.confirm_complete_correct.required"
 msgstr "Bestätigen Sie, dass Ihre Angaben korrekt sind, um fortfahren zu können."
 
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:38
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:59
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:37
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:58
 msgid "form.lotse.skip_reason.has_fahrtkostenpauschale_claim"
 msgstr ""
 "Ihre Angaben qualifizieren Sie leider nicht für die behinderungsbedingte "
 "Fahrtkostenpauschale."
 
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:84
-#: app/forms/steps/lotse/pauschbetrag.py:117
-#: app/forms/steps/lotse/pauschbetrag.py:180
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:83
+#: app/forms/steps/lotse/pauschbetrag.py:120
+#: app/forms/steps/lotse/pauschbetrag.py:184
 msgid "currency.euro"
 msgstr "Euro"
 
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:86
-#: app/forms/steps/lotse/pauschbetrag.py:119
-#: app/forms/steps/lotse/pauschbetrag.py:182
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:85
+#: app/forms/steps/lotse/pauschbetrag.py:122
+#: app/forms/steps/lotse/pauschbetrag.py:186
 msgid "form.lotse.summary.not-requested"
 msgstr "Keine Beantragung"
 
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:99
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:151
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:98
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:154
 #: app/forms/steps/lotse/has_disability.py:22
-#: app/forms/steps/lotse/has_disability.py:57
+#: app/forms/steps/lotse/has_disability.py:58
 #: app/forms/steps/lotse/merkzeichen.py:31
 #: app/forms/steps/lotse/merkzeichen.py:119
-#: app/forms/steps/lotse/pauschbetrag.py:98
-#: app/forms/steps/lotse/pauschbetrag.py:159
+#: app/forms/steps/lotse/pauschbetrag.py:99
+#: app/forms/steps/lotse/pauschbetrag.py:163
 #: app/forms/steps/lotse/personal_data.py:38
-#: app/forms/steps/lotse/personal_data.py:183
-#: app/forms/steps/lotse/personal_data.py:274
-#: app/forms/steps/lotse/personal_data.py:365
+#: app/forms/steps/lotse/personal_data.py:184
+#: app/forms/steps/lotse/personal_data.py:275
+#: app/forms/steps/lotse/personal_data.py:367
 #: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:20
-#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:60
+#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:61
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:21
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:189
 msgid "form.lotse.mandatory_data.label"
 msgstr "Pflichtangaben"
 
 #: app/forms/steps/lotse/fahrtkostenpauschale.py:107
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:160
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:164
 msgid "form.lotse.request_fahrtkostenpauschale.data_label"
 msgstr "Beantragung behinderungsbedingte Fahrtkostenpauschale"
 
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:114
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:115
 msgid "form.lotse.person_a.request_fahrtkostenpauschale.label"
 msgid_plural "form.lotse.person_a.request_fahrtkostenpauschale.label"
 msgstr[0] "Behinderungsbedingte Fahrtkostenpauschale"
 msgstr[1] "Behinderungsbedingte Fahrtkostenpauschale für Person A"
 
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:120
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:122
 msgid "form.lotse.person_a.request_fahrtkostenpauschale.title"
 msgid_plural "form.lotse.person_a.request_fahrtkostenpauschale.title"
 msgstr[0] "Behinderungsbedingte Fahrtkostenpauschale"
 msgstr[1] "Behinderungsbedingte Fahrtkostenpauschale für Person A"
 
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:135
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:186
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:137
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:190
 #: app/forms/steps/lotse/has_disability.py:52
-#: app/forms/steps/lotse/has_disability.py:88
-#: app/forms/steps/lotse/merkzeichen.py:108
+#: app/forms/steps/lotse/has_disability.py:89
+#: app/forms/steps/lotse/merkzeichen.py:107
 #: app/forms/steps/lotse/merkzeichen.py:180
-#: app/forms/steps/lotse/no_pauschbetrag.py:102
-#: app/forms/steps/lotse/no_pauschbetrag.py:125
-#: app/forms/steps/lotse/pauschbetrag.py:145
-#: app/forms/steps/lotse/pauschbetrag.py:206
-#: app/forms/steps/lotse/personal_data.py:394
+#: app/forms/steps/lotse/no_pauschbetrag.py:103
+#: app/forms/steps/lotse/no_pauschbetrag.py:128
+#: app/forms/steps/lotse/pauschbetrag.py:148
+#: app/forms/steps/lotse/pauschbetrag.py:210
+#: app/forms/steps/lotse/personal_data.py:396
 #: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:53
-#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:93
-#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:120
+#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:94
+#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:122
 msgid "form.lotse.header-title"
 msgstr "Steuerformular - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:154
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:157
 msgid "form.lotse.person_b.request_fahrtkostenpauschale.label"
 msgstr "Behinderungsbedingte Fahrtkostenpauschale für Person B"
 
-#: app/forms/steps/lotse/fahrtkostenpauschale.py:171
+#: app/forms/steps/lotse/fahrtkostenpauschale.py:175
 msgid "form.lotse.person_b.request_fahrtkostenpauschale.title"
 msgstr "Behinderungsbedingte Fahrtkostenpauschale für Person B"
 
@@ -1184,7 +1184,7 @@ msgid "form.lotse.has_disability.label_person_b"
 msgstr "Behinderung oder Pflegebedürftigkeit für Person B"
 
 #: app/forms/steps/lotse/has_disability.py:28
-#: app/forms/steps/lotse/has_disability.py:61
+#: app/forms/steps/lotse/has_disability.py:62
 msgid "form.lotse.has_disability.data_label"
 msgstr "Liegt eine Behinderung oder Pflegebedürftigkeit vor?"
 
@@ -1194,13 +1194,13 @@ msgstr ""
 "Möchten Sie Angaben zu einer Behinderung oder Pflegebedürftigkeit für "
 "Person B machen?"
 
-#: app/forms/steps/lotse/has_disability.py:67
+#: app/forms/steps/lotse/has_disability.py:68
 msgid "form.lotse.has_disability.label_person_a"
 msgid_plural "form.lotse.has_disability.label_person_a"
 msgstr[0] "Behinderung oder Pflegebedürftigkeit"
 msgstr[1] "Behinderung oder Pflegebedürftigkeit für Person A"
 
-#: app/forms/steps/lotse/has_disability.py:73
+#: app/forms/steps/lotse/has_disability.py:74
 msgid "form.lotse.has_disability.title"
 msgid_plural "form.lotse.has_disability.title"
 msgstr[0] "Möchten Sie Angaben zu einer Behinderung oder Pflegebedürftigkeit machen?"
@@ -1208,8 +1208,8 @@ msgstr[1] ""
 "Möchten Sie Angaben zu einer Behinderung oder Pflegebedürftigkeit für "
 "Person A machen?"
 
-#: app/forms/steps/lotse/has_disability.py:93
-#: app/forms/steps/lotse/has_disability.py:106
+#: app/forms/steps/lotse/has_disability.py:95
+#: app/forms/steps/lotse/has_disability.py:108
 msgid "form.lotse.skip_reason.has_no_disability"
 msgstr ""
 "Sie haben angegeben, dass Sie keine Angaben zu einer Behinderung oder "
@@ -1218,7 +1218,7 @@ msgstr ""
 "machen möchten."
 
 #: app/forms/steps/lotse/merkzeichen.py:25
-#: app/forms/steps/lotse/merkzeichen.py:83
+#: app/forms/steps/lotse/merkzeichen.py:82
 msgid "form.lotse.merkzeichen_person_a.title"
 msgid_plural "form.lotse.merkzeichen_person_a.title"
 msgstr[0] "Angaben zu Ihrer Behinderung oder Pflegebedürftigkeit"
@@ -1235,11 +1235,11 @@ msgstr ""
 #: app/forms/steps/lotse/merkzeichen.py:27
 #: app/forms/steps/lotse/merkzeichen.py:115
 #: app/forms/steps/lotse/no_pauschbetrag.py:75
-#: app/forms/steps/lotse/no_pauschbetrag.py:108
+#: app/forms/steps/lotse/no_pauschbetrag.py:110
 #: app/forms/steps/lotse/personal_data.py:33
-#: app/forms/steps/lotse/personal_data.py:180
-#: app/forms/steps/lotse/personal_data.py:271
-#: app/forms/steps/lotse/personal_data.py:360
+#: app/forms/steps/lotse/personal_data.py:181
+#: app/forms/steps/lotse/personal_data.py:272
+#: app/forms/steps/lotse/personal_data.py:362
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:148
 #: app/forms/steps/lotse_multistep_flow_steps/personal_data_steps.py:224
 msgid "form.lotse.mandatory_data.header-title"
@@ -1340,8 +1340,8 @@ msgstr ""
 "Behinderung von 20. Lassen Sie das Feld leer, falls der Wert unter 20 "
 "liegt."
 
-#: app/forms/steps/lotse/merkzeichen.py:75
-#: app/forms/steps/lotse/merkzeichen.py:86
+#: app/forms/steps/lotse/merkzeichen.py:74
+#: app/forms/steps/lotse/merkzeichen.py:85
 msgid "form.lotse.merkzeichen_person_a.label"
 msgid_plural "form.lotse.merkzeichen_person_a.label"
 msgstr[0] "Angaben zur festgestellten Behinderung oder Pflegebedürftigkeit"
@@ -1355,8 +1355,8 @@ msgstr "Angaben zu Behinderung oder Pflegebedürftigkeit von Person B"
 msgid "form.lotse.merkzeichen_person_b.label"
 msgstr "Angaben zur festgestellten Behinderung oder Pflegebedürftigkeit Person B"
 
-#: app/forms/steps/lotse/merkzeichen.py:185
-#: app/forms/steps/lotse/merkzeichen.py:211
+#: app/forms/steps/lotse/merkzeichen.py:186
+#: app/forms/steps/lotse/merkzeichen.py:212
 msgid "form.lotse.skip_reason.has_no_merkzeichen"
 msgstr ""
 "Sie haben ausgewählt, dass Sie Angaben zu einer Behinderung oder "
@@ -1370,7 +1370,7 @@ msgid "form.lotse.skip_reason.has_pauschbetrag_claim"
 msgstr "Ihre Angaben qualifizieren Sie für den behinderungsbedingten Pauschbetrag."
 
 #: app/forms/steps/lotse/no_pauschbetrag.py:74
-#: app/forms/steps/lotse/no_pauschbetrag.py:84
+#: app/forms/steps/lotse/no_pauschbetrag.py:85
 msgid "form.lotse.no_pauschbetrag.person_a.title"
 msgid_plural "form.lotse.no_pauschbetrag.person_a.title"
 msgstr[0] "Leider haben Sie keinen Anspruch auf behinderungsbedingte Pauschbeträge."
@@ -1378,46 +1378,46 @@ msgstr[1] ""
 "Leider hat Person A keinen Anspruch auf behinderungsbedingte "
 "Pauschbeträge."
 
-#: app/forms/steps/lotse/no_pauschbetrag.py:107
+#: app/forms/steps/lotse/no_pauschbetrag.py:109
 msgid "form.lotse.no_pauschbetrag.person_b.title"
 msgstr ""
 "Leider hat Person B keinen Anspruch auf behinderungsbedingte "
 "Pauschbeträge."
 
-#: app/forms/steps/lotse/pauschbetrag.py:60
-#: app/forms/steps/lotse/pauschbetrag.py:79
+#: app/forms/steps/lotse/pauschbetrag.py:61
+#: app/forms/steps/lotse/pauschbetrag.py:80
 msgid "form.lotse.skip_reason.has_no_pauschbetrag_claim"
 msgstr ""
 "Ihre Angaben qualifizieren Sie leider nicht für den behinderungsbedingten"
 " Pauschbetrag."
 
-#: app/forms/steps/lotse/pauschbetrag.py:105
-#: app/forms/steps/lotse/pauschbetrag.py:169
+#: app/forms/steps/lotse/pauschbetrag.py:107
+#: app/forms/steps/lotse/pauschbetrag.py:173
 msgid "form.lotse.request_pauschbetrag.data_label"
 msgstr "Beantragung Pauschbetrag für Menschen mit Behinderung"
 
-#: app/forms/steps/lotse/pauschbetrag.py:111
+#: app/forms/steps/lotse/pauschbetrag.py:114
 msgid "form.lotse.person_a.request_pauschbetrag.label"
 msgid_plural "form.lotse.person_a.request_pauschbetrag.label"
 msgstr[0] "Pauschbetrag für Menschen mit Behinderung"
 msgstr[1] "Pauschbetrag für Menschen mit Behinderung für Person A"
 
-#: app/forms/steps/lotse/pauschbetrag.py:121
-#: app/forms/steps/lotse/pauschbetrag.py:184
+#: app/forms/steps/lotse/pauschbetrag.py:124
+#: app/forms/steps/lotse/pauschbetrag.py:188
 msgid "form.lotse.summary.no-claim"
 msgstr "Kein Anspruch"
 
-#: app/forms/steps/lotse/pauschbetrag.py:130
+#: app/forms/steps/lotse/pauschbetrag.py:133
 msgid "form.lotse.person_a.request_pauschbetrag.title"
 msgid_plural "form.lotse.person_a.request_pauschbetrag.title"
 msgstr[0] "Pauschbetrag für Menschen mit Behinderung"
 msgstr[1] "Pauschbetrag für Menschen mit Behinderung für Person A"
 
-#: app/forms/steps/lotse/pauschbetrag.py:161
+#: app/forms/steps/lotse/pauschbetrag.py:165
 msgid "form.lotse.person_b.request_pauschbetrag.label"
 msgstr "Pauschbetrag für Menschen mit Behinderung für Person B"
 
-#: app/forms/steps/lotse/pauschbetrag.py:191
+#: app/forms/steps/lotse/pauschbetrag.py:195
 msgid "form.lotse.person_b.request_pauschbetrag.title"
 msgstr "Pauschbetrag für Menschen mit Behinderung für Person B"
 
@@ -1585,185 +1585,185 @@ msgstr ""
 "korrekt ist</li></ul>Bitte wenden Sie sich andernfalls mit einer E-Mail "
 "an uns und schildern Sie uns das Problem. "
 
-#: app/forms/steps/lotse/personal_data.py:189
-#: app/forms/steps/lotse/personal_data.py:288
+#: app/forms/steps/lotse/personal_data.py:190
+#: app/forms/steps/lotse/personal_data.py:289
 msgid "form.lotse.field_person_idnr"
 msgstr "Steuer-Identifikationsnummer"
 
-#: app/forms/steps/lotse/personal_data.py:191
-#: app/forms/steps/lotse/personal_data.py:289
+#: app/forms/steps/lotse/personal_data.py:192
+#: app/forms/steps/lotse/personal_data.py:291
 msgid "form.lotse.field_person_idnr.data_label"
 msgstr "Steuer-Identifikationsnummer"
 
-#: app/forms/steps/lotse/personal_data.py:193
-#: app/forms/steps/lotse/personal_data.py:291
+#: app/forms/steps/lotse/personal_data.py:194
+#: app/forms/steps/lotse/personal_data.py:293
 msgid "form.lotse.field_person_dob"
 msgstr "Geburtsdatum"
 
-#: app/forms/steps/lotse/personal_data.py:194
-#: app/forms/steps/lotse/personal_data.py:292
+#: app/forms/steps/lotse/personal_data.py:195
+#: app/forms/steps/lotse/personal_data.py:294
 msgid "form.lotse.field_person_dob.data_label"
 msgstr "Geburtsdatum"
 
-#: app/forms/steps/lotse/personal_data.py:195
-#: app/forms/steps/lotse/personal_data.py:293
+#: app/forms/steps/lotse/personal_data.py:196
+#: app/forms/steps/lotse/personal_data.py:295
 msgid "form.lotse.validation-dob-missing"
 msgstr ""
 "Geben Sie Ihr vollständiges Geburtsdatum ein. Ihre Angabe muss folgendem "
 "Muster entsprechen: 29 2 1951 "
 
-#: app/forms/steps/lotse/personal_data.py:198
-#: app/forms/steps/lotse/personal_data.py:296
+#: app/forms/steps/lotse/personal_data.py:199
+#: app/forms/steps/lotse/personal_data.py:298
 msgid "form.lotse.field_person_first_name"
 msgstr "Vorname"
 
-#: app/forms/steps/lotse/personal_data.py:199
-#: app/forms/steps/lotse/personal_data.py:297
+#: app/forms/steps/lotse/personal_data.py:200
+#: app/forms/steps/lotse/personal_data.py:299
 msgid "form.lotse.field_person_first_name.data_label"
 msgstr "Vorname"
 
-#: app/forms/steps/lotse/personal_data.py:203
-#: app/forms/steps/lotse/personal_data.py:301
+#: app/forms/steps/lotse/personal_data.py:204
+#: app/forms/steps/lotse/personal_data.py:303
 msgid "form.lotse.field_person_last_name"
 msgstr "Nachname"
 
-#: app/forms/steps/lotse/personal_data.py:204
-#: app/forms/steps/lotse/personal_data.py:302
+#: app/forms/steps/lotse/personal_data.py:205
+#: app/forms/steps/lotse/personal_data.py:304
 msgid "form.lotse.field_person_last_name.data_label"
 msgstr "Nachname"
 
-#: app/forms/steps/lotse/personal_data.py:208
-#: app/forms/steps/lotse/personal_data.py:314
+#: app/forms/steps/lotse/personal_data.py:209
+#: app/forms/steps/lotse/personal_data.py:316
 msgid "form.lotse.field_person_street"
 msgstr "Straße"
 
-#: app/forms/steps/lotse/personal_data.py:209
-#: app/forms/steps/lotse/personal_data.py:315
+#: app/forms/steps/lotse/personal_data.py:210
+#: app/forms/steps/lotse/personal_data.py:317
 msgid "form.lotse.field_person_street.data_label"
 msgstr "Straße"
 
-#: app/forms/steps/lotse/personal_data.py:213
-#: app/forms/steps/lotse/personal_data.py:320
+#: app/forms/steps/lotse/personal_data.py:214
+#: app/forms/steps/lotse/personal_data.py:322
 msgid "form.lotse.field_person_street_number"
 msgstr "Hausnummer"
 
-#: app/forms/steps/lotse/personal_data.py:214
-#: app/forms/steps/lotse/personal_data.py:321
+#: app/forms/steps/lotse/personal_data.py:215
+#: app/forms/steps/lotse/personal_data.py:323
 msgid "form.lotse.field_person_street_number.data_label"
 msgstr "Hausnummer"
 
-#: app/forms/steps/lotse/personal_data.py:218
-#: app/forms/steps/lotse/personal_data.py:327
+#: app/forms/steps/lotse/personal_data.py:219
+#: app/forms/steps/lotse/personal_data.py:329
 msgid "form.lotse.field_person_street_number_ext"
 msgstr "Hausnummerzusatz"
 
-#: app/forms/steps/lotse/personal_data.py:219
-#: app/forms/steps/lotse/personal_data.py:328
+#: app/forms/steps/lotse/personal_data.py:220
+#: app/forms/steps/lotse/personal_data.py:330
 msgid "form.lotse.field_person_street_number_ext.data_label"
 msgstr "Hausnummerzusatz"
 
-#: app/forms/steps/lotse/personal_data.py:223
-#: app/forms/steps/lotse/personal_data.py:332
+#: app/forms/steps/lotse/personal_data.py:224
+#: app/forms/steps/lotse/personal_data.py:334
 msgid "form.lotse.field_person_address_ext"
 msgstr "Adressergänzung"
 
-#: app/forms/steps/lotse/personal_data.py:224
-#: app/forms/steps/lotse/personal_data.py:333
+#: app/forms/steps/lotse/personal_data.py:225
+#: app/forms/steps/lotse/personal_data.py:335
 msgid "form.lotse.field_person_address_ext.data_label"
 msgstr "Adressergänzung"
 
-#: app/forms/steps/lotse/personal_data.py:228
-#: app/forms/steps/lotse/personal_data.py:337
+#: app/forms/steps/lotse/personal_data.py:229
+#: app/forms/steps/lotse/personal_data.py:339
 msgid "form.lotse.field_person_plz"
 msgstr "Postleitzahl"
 
-#: app/forms/steps/lotse/personal_data.py:229
-#: app/forms/steps/lotse/personal_data.py:338
+#: app/forms/steps/lotse/personal_data.py:230
+#: app/forms/steps/lotse/personal_data.py:340
 msgid "form.lotse.field_person_plz.data_label"
 msgstr "Postleitzahl"
 
-#: app/forms/steps/lotse/personal_data.py:232
-#: app/forms/steps/lotse/personal_data.py:342
+#: app/forms/steps/lotse/personal_data.py:233
+#: app/forms/steps/lotse/personal_data.py:344
 msgid "validator-length-exactly"
 msgstr "Das Feld darf muss genau %(minmax)s Ziffern lang sein."
 
-#: app/forms/steps/lotse/personal_data.py:234
-#: app/forms/steps/lotse/personal_data.py:344
+#: app/forms/steps/lotse/personal_data.py:235
+#: app/forms/steps/lotse/personal_data.py:346
 msgid "form.lotse.field_person_town"
 msgstr "Wohnort"
 
-#: app/forms/steps/lotse/personal_data.py:235
-#: app/forms/steps/lotse/personal_data.py:345
+#: app/forms/steps/lotse/personal_data.py:236
+#: app/forms/steps/lotse/personal_data.py:347
 msgid "form.lotse.field_person_town.data_label"
 msgstr "Wohnort"
 
-#: app/forms/steps/lotse/personal_data.py:243
+#: app/forms/steps/lotse/personal_data.py:244
 msgid "form.lotse.step_person_a.label"
 msgid_plural "form.lotse.step_person_a.label"
 msgstr[0] "Ihre Angaben"
 msgstr[1] "Person A"
 
-#: app/forms/steps/lotse/personal_data.py:251
+#: app/forms/steps/lotse/personal_data.py:252
 msgid "form.lotse.person-a-title"
 msgid_plural "form.lotse.person-a-title"
 msgstr[0] "Ihre Angaben"
 msgstr[1] "Angaben für Person A"
 
-#: app/forms/steps/lotse/personal_data.py:253
+#: app/forms/steps/lotse/personal_data.py:254
 msgid "form.lotse.person-a-intro"
 msgstr ""
 "Geben Sie bitte zunächst die Informationen des Ehemannes an. Wenn Sie in "
 "einer gleichgeschlechtlichen Partnerschaft leben, geben Sie bitte "
 "zunächst die Person an, deren Name im Alphabet zuerst kommt."
 
-#: app/forms/steps/lotse/personal_data.py:258
+#: app/forms/steps/lotse/personal_data.py:259
 msgid "form.lotse.skip_reason.familienstand_single"
 msgstr "Sie haben als Familienstand ledig angegeben."
 
-#: app/forms/steps/lotse/personal_data.py:269
+#: app/forms/steps/lotse/personal_data.py:270
 msgid "form.lotse.person-b-title"
 msgstr "Angaben für Person B"
 
-#: app/forms/steps/lotse/personal_data.py:270
+#: app/forms/steps/lotse/personal_data.py:271
 msgid "form.lotse.person-b-intro"
 msgstr ""
 "Geben Sie hier bitte die Daten der Ehefrau an. Wenn Sie in einer "
 "gleichgeschlechtlichen Partnerschaft leben, geben Sie bitte die Person "
 "an, deren Name im Alphabet zuletzt kommt."
 
-#: app/forms/steps/lotse/personal_data.py:273
+#: app/forms/steps/lotse/personal_data.py:274
 msgid "form.lotse.step_person_b.label"
 msgstr "Person B"
 
-#: app/forms/steps/lotse/personal_data.py:308
+#: app/forms/steps/lotse/personal_data.py:310
 msgid "form.lotse.field_person_b_same_address.data_label"
 msgstr "Mein Partner / Meine Partnerin und ich wohnen zusammen."
 
-#: app/forms/steps/lotse/personal_data.py:310
+#: app/forms/steps/lotse/personal_data.py:312
 msgid "form.lotse.field_person_b_same_address-yes"
 msgstr "Mein Partner / Meine Partnerin und ich wohnen zusammen."
 
-#: app/forms/steps/lotse/personal_data.py:311
+#: app/forms/steps/lotse/personal_data.py:313
 msgid "form.lotse.field_person_b_same_address-no"
 msgstr ""
 "Mein Partner / Meine Partnerin und ich wohnen nicht zusammen. Er / Sie "
 "ist wohnhaft in:"
 
-#: app/forms/steps/lotse/personal_data.py:358
+#: app/forms/steps/lotse/personal_data.py:360
 msgid "form.lotse.telephone-number.title"
 msgstr "Telefonnummer für Rückfragen"
 
-#: app/forms/steps/lotse/personal_data.py:359
+#: app/forms/steps/lotse/personal_data.py:361
 msgid "form.lotse.telephone-number.intro"
 msgstr ""
 "Geben Sie eine Telefonnummer an, wenn Sie wünschen, dass Ihr Finanzamt "
 "Sie bei eventuellen Rückfragen kontaktieren kann."
 
-#: app/forms/steps/lotse/personal_data.py:364
+#: app/forms/steps/lotse/personal_data.py:366
 msgid "form.lotse.step_telephone_number.label"
 msgstr "Telefonnummer für Rückfragen"
 
-#: app/forms/steps/lotse/personal_data.py:370
+#: app/forms/steps/lotse/personal_data.py:372
 msgid "form.lotse.field_telephone_number.data_label"
 msgstr "Angabe Telefonnummer"
 
@@ -1779,16 +1779,16 @@ msgstr ""
 " Sie Angaben machen möchten."
 
 #: app/forms/steps/lotse/steuerminderungen.py:28
-#: app/forms/steps/lotse/steuerminderungen.py:155
-#: app/forms/steps/lotse/steuerminderungen.py:178
-#: app/forms/steps/lotse/steuerminderungen.py:185
-#: app/forms/steps/lotse/steuerminderungen.py:262
-#: app/forms/steps/lotse/steuerminderungen.py:337
-#: app/forms/steps/lotse/steuerminderungen.py:364
-#: app/forms/steps/lotse/steuerminderungen.py:404
-#: app/forms/steps/lotse/steuerminderungen.py:411
-#: app/forms/steps/lotse/steuerminderungen.py:438
-#: app/forms/steps/lotse/steuerminderungen.py:445
+#: app/forms/steps/lotse/steuerminderungen.py:156
+#: app/forms/steps/lotse/steuerminderungen.py:179
+#: app/forms/steps/lotse/steuerminderungen.py:186
+#: app/forms/steps/lotse/steuerminderungen.py:263
+#: app/forms/steps/lotse/steuerminderungen.py:340
+#: app/forms/steps/lotse/steuerminderungen.py:367
+#: app/forms/steps/lotse/steuerminderungen.py:408
+#: app/forms/steps/lotse/steuerminderungen.py:415
+#: app/forms/steps/lotse/steuerminderungen.py:442
+#: app/forms/steps/lotse/steuerminderungen.py:449
 msgid "form.lotse.steuerminderungen.header-title"
 msgstr ""
 "Steuerformular - Steuermindernde Aufwendungen - Der Steuerlotse für Rente"
@@ -1799,12 +1799,12 @@ msgid "form.lotse.step_select_stmind.label"
 msgstr "Ihre Ausgaben"
 
 #: app/forms/steps/lotse/steuerminderungen.py:35
-#: app/forms/steps/lotse/steuerminderungen.py:162
-#: app/forms/steps/lotse/steuerminderungen.py:191
-#: app/forms/steps/lotse/steuerminderungen.py:268
-#: app/forms/steps/lotse/steuerminderungen.py:370
-#: app/forms/steps/lotse/steuerminderungen.py:417
-#: app/forms/steps/lotse/steuerminderungen.py:450
+#: app/forms/steps/lotse/steuerminderungen.py:163
+#: app/forms/steps/lotse/steuerminderungen.py:192
+#: app/forms/steps/lotse/steuerminderungen.py:269
+#: app/forms/steps/lotse/steuerminderungen.py:373
+#: app/forms/steps/lotse/steuerminderungen.py:421
+#: app/forms/steps/lotse/steuerminderungen.py:455
 msgid "form.lotse.section_steuerminderung.label"
 msgstr "Steuermindernde Aufwendungen"
 
@@ -1828,27 +1828,27 @@ msgstr "Spenden und Mitgliedsbeiträge ausgewählt"
 msgid "form.lotse.stmind_select_religion.data_label"
 msgstr "Steuern für Ihre Religionsgemeinschaft ausgwählt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:77
-#: app/forms/steps/lotse/steuerminderungen.py:90
-#: app/forms/steps/lotse/steuerminderungen.py:103
-#: app/forms/steps/lotse/steuerminderungen.py:116
-#: app/forms/steps/lotse/steuerminderungen.py:129
+#: app/forms/steps/lotse/steuerminderungen.py:78
+#: app/forms/steps/lotse/steuerminderungen.py:91
+#: app/forms/steps/lotse/steuerminderungen.py:104
+#: app/forms/steps/lotse/steuerminderungen.py:117
+#: app/forms/steps/lotse/steuerminderungen.py:130
 msgid "form.lotse.skip_reason.steuerminderung_is_no"
 msgstr ""
 "Bitte wählen Sie zuerst aus, dass Sie steuermindernde Aufwendungen "
 "geltend machen möchten."
 
-#: app/forms/steps/lotse/steuerminderungen.py:142
+#: app/forms/steps/lotse/steuerminderungen.py:143
 msgid "form.lotse.skip_reason.stmind_gem_haushalt.not-alleinstehend"
 msgstr ""
 "Wenn Sie zusammenveranlagen, müssen Sie keine Angaben zu einem "
 "gemeinsamen Haushalt mit anderen alleinstehenden Personen machen."
 
-#: app/forms/steps/lotse/steuerminderungen.py:153
+#: app/forms/steps/lotse/steuerminderungen.py:154
 msgid "form.lotse.vorsorge-title"
 msgstr "Vorsorgeaufwendungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:154
+#: app/forms/steps/lotse/steuerminderungen.py:155
 msgid "form.lotse.vorsorge-intro"
 msgstr ""
 "Zu den Vorsorgeaufwendungen zählen Versicherungen wie z.B. "
@@ -1856,15 +1856,15 @@ msgstr ""
 "Risikolebensversicherungen</b>.</p><p>Beiträge zu Kasko-, Hausrat-, "
 "Gebäude- und Rechtsschutzversicherungen können Sie nicht absetzen."
 
-#: app/forms/steps/lotse/steuerminderungen.py:159
+#: app/forms/steps/lotse/steuerminderungen.py:160
 msgid "form.lotse.step_vorsorge.label"
 msgstr "Vorsorgeaufwendungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:166
+#: app/forms/steps/lotse/steuerminderungen.py:167
 msgid "form.lotse.field_vorsorge_summe"
 msgstr "Summe der Rechnungsbeträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:168
+#: app/forms/steps/lotse/steuerminderungen.py:169
 msgid "form.lotse.field_vorsorge_summe-help"
 msgstr ""
 "<p>Die Summe Ihrer Beiträge <b>wirkt sich steuerlich nur aus,</b> wenn "
@@ -1876,30 +1876,30 @@ msgstr ""
 "Rentenanpassungsmitteilung. Ihre Jahresbeiträge können Sie auch Ihrer "
 "Jahreslohnsteuerbescheinigung entnehmen.</p>"
 
-#: app/forms/steps/lotse/steuerminderungen.py:169
+#: app/forms/steps/lotse/steuerminderungen.py:170
 msgid "form.lotse.field_vorsorge_summe.data_label"
 msgstr "Summe der Rechnungsbeträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:183
+#: app/forms/steps/lotse/steuerminderungen.py:184
 msgid "form.lotse.ausserg_bela-title"
 msgstr "Krankheitskosten und weitere außergewöhnliche Belastungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:184
+#: app/forms/steps/lotse/steuerminderungen.py:185
 msgid "form.lotse.ausserg_bela-intro"
 msgstr ""
 "Hatten Sie höhere Ausgaben als die Mehrzahl der Steuerzahler, die "
 "aufgrund besonderer Umstände zwangsläufig angefallen sind? Dann können "
 "Sie diese hier angeben."
 
-#: app/forms/steps/lotse/steuerminderungen.py:189
+#: app/forms/steps/lotse/steuerminderungen.py:190
 msgid "form.lotse.step_ausserg_bela.label"
 msgstr "Krankheitskosten und weitere außergewöhnliche Belastungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:195
+#: app/forms/steps/lotse/steuerminderungen.py:196
 msgid "form.lotse.field_krankheitskosten_summe"
 msgstr "Krankheitskosten Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:196
+#: app/forms/steps/lotse/steuerminderungen.py:197
 msgid "form.lotse.field_krankheitskosten-help"
 msgstr ""
 "Hier können Kosten eingetragen werden, die im Zusammenhang mit "
@@ -1920,15 +1920,15 @@ msgstr ""
 "einer andauernden Erkrankung mit anhaltendem Verbrauch bestimmter "
 "Medikamente, reicht die einmalige Vorlage einer solchen Verordnung aus."
 
-#: app/forms/steps/lotse/steuerminderungen.py:197
+#: app/forms/steps/lotse/steuerminderungen.py:198
 msgid "form.lotse.field_krankheitskosten_summe.data_label"
 msgstr "Krankheitskosten Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:200
+#: app/forms/steps/lotse/steuerminderungen.py:201
 msgid "form.lotse.field_krankheitskosten_anspruch"
 msgstr "Krankheitskosten Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:201
+#: app/forms/steps/lotse/steuerminderungen.py:202
 msgid "form.lotse.field_krankheitskosten-anspruch-help"
 msgstr ""
 "<b>Minderung der Kosten um Erstattungen</b><br>Wurden Ihre angegebenen "
@@ -1937,15 +1937,15 @@ msgstr ""
 "Versicherungsleistungen von Ihrer Krankenkasse bzw. Krankenversicherung, "
 "Beihilfen oder andere Unterstützungen sein. "
 
-#: app/forms/steps/lotse/steuerminderungen.py:202
+#: app/forms/steps/lotse/steuerminderungen.py:203
 msgid "form.lotse.field_krankheitskosten_anspruch.data_label"
 msgstr "Krankheitskosten Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:205
+#: app/forms/steps/lotse/steuerminderungen.py:206
 msgid "form.lotse.field_pflegekosten_summe"
 msgstr "Pflegekosten Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:206
+#: app/forms/steps/lotse/steuerminderungen.py:207
 msgid "form.lotse.field_pflegekosten-help"
 msgstr ""
 "Zu den Pflegekosten zählen Kosten, die durch die Pflegebedürftigkeit "
@@ -1962,23 +1962,23 @@ msgstr ""
 "gemacht werden. Auch der Schwerbehindertenausweis dient als Nachweis, "
 "wenn das Merkzeichen H vorliegt."
 
-#: app/forms/steps/lotse/steuerminderungen.py:207
+#: app/forms/steps/lotse/steuerminderungen.py:208
 msgid "form.lotse.field_pflegekosten_summe.data_label"
 msgstr "Pflegekosten Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:210
+#: app/forms/steps/lotse/steuerminderungen.py:211
 msgid "form.lotse.field_pflegekosten_anspruch"
 msgstr "Pflegekosten Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:211
+#: app/forms/steps/lotse/steuerminderungen.py:212
 msgid "form.lotse.field_pflegekosten_anspruch.data_label"
 msgstr "Pflegekosten Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:214
+#: app/forms/steps/lotse/steuerminderungen.py:215
 msgid "form.lotse.field_beh_aufw_summe"
 msgstr "Behinderungsbedingte Aufwendungen Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:215
+#: app/forms/steps/lotse/steuerminderungen.py:216
 msgid "form.lotse.field_beh_aufw-help"
 msgstr ""
 "Hier können alle Aufwendungen eingetragen werden, die Menschen mit "
@@ -2001,23 +2001,23 @@ msgstr ""
 "Schwerbehindertenausweis oder eines Bescheides über die Behinderung "
 "nachweisen."
 
-#: app/forms/steps/lotse/steuerminderungen.py:216
+#: app/forms/steps/lotse/steuerminderungen.py:217
 msgid "form.lotse.field_beh_aufw_summe.data_label"
 msgstr "Behinderungsbedingte Aufwendungen Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:219
+#: app/forms/steps/lotse/steuerminderungen.py:220
 msgid "form.lotse.field_beh_aufw_anspruch"
 msgstr "Behinderungsbedingte Aufwendungen Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:220
+#: app/forms/steps/lotse/steuerminderungen.py:221
 msgid "form.lotse.field_beh_aufw_anspruch.data_label"
 msgstr "Behinderungsbedingte Aufwendungen Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:223
+#: app/forms/steps/lotse/steuerminderungen.py:224
 msgid "form.lotse.bestattung_summe"
 msgstr "Bestattungskosten Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:224
+#: app/forms/steps/lotse/steuerminderungen.py:225
 msgid "form.lotse.bestattung-help"
 msgstr ""
 "Hier können alle Kosten eingetragen werden, die unmittelbar mit der "
@@ -2032,23 +2032,23 @@ msgstr ""
 "Grabpflege.</p><p><b>Nachweise</b><br>Die entstehenden Kosten weisen Sie "
 "mithilfe der entsprechenden Rechnungen nach."
 
-#: app/forms/steps/lotse/steuerminderungen.py:225
+#: app/forms/steps/lotse/steuerminderungen.py:226
 msgid "form.lotse.bestattung_summe.data_label"
 msgstr "Bestattungskosten Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:228
+#: app/forms/steps/lotse/steuerminderungen.py:229
 msgid "form.lotse.bestattung_anspruch"
 msgstr "Bestattungskosten Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:229
+#: app/forms/steps/lotse/steuerminderungen.py:230
 msgid "form.lotse.bestattung_anspruch.data_label"
 msgstr "Bestattungskosten Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:232
+#: app/forms/steps/lotse/steuerminderungen.py:233
 msgid "form.lotse.aussergbela_sonst_summe"
 msgstr "Sonstige Außergewöhnliche Belastungen Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:233
+#: app/forms/steps/lotse/steuerminderungen.py:234
 msgid "form.lotse.aussergbela_sonst-help"
 msgstr ""
 "Zu den sonstigen außergewöhnlichen Belastungen zählen zum Beispiel Kosten"
@@ -2058,23 +2058,23 @@ msgstr ""
 "war. In den außergewöhnlichen Belastungen sind auch die notwendigen und "
 "angemessenen Kosten der Schadensbeseitigung enthalten."
 
-#: app/forms/steps/lotse/steuerminderungen.py:234
+#: app/forms/steps/lotse/steuerminderungen.py:235
 msgid "form.lotse.aussergbela_sonst_summe.data_label"
 msgstr "Sonstige Außergewöhnliche Belastungen Summe"
 
-#: app/forms/steps/lotse/steuerminderungen.py:237
+#: app/forms/steps/lotse/steuerminderungen.py:238
 msgid "form.lotse.aussergbela_sonst_anspruch"
 msgstr "Sonstige Außergewöhnliche Belastungen Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:238
+#: app/forms/steps/lotse/steuerminderungen.py:239
 msgid "form.lotse.aussergbela_sonst_anspruch.data_label"
 msgstr "Sonstige Außergewöhnliche Belastungen Anspruch auf Erstattung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:251
+#: app/forms/steps/lotse/steuerminderungen.py:252
 msgid "form.lotse.ausserg_bela.details-title"
 msgstr "Hinweis zur zumutbaren Belastung"
 
-#: app/forms/steps/lotse/steuerminderungen.py:252
+#: app/forms/steps/lotse/steuerminderungen.py:253
 msgid "form.lotse.ausserg_bela.details-text"
 msgstr ""
 "Nur der Betrag, der höher ist als Ihre zumutbare Belastung, wirkt sich "
@@ -2082,11 +2082,11 @@ msgstr ""
 "Höhe Ihres Einkommens ab und wird von Ihrem Finanzamt automatisch "
 "berechnet."
 
-#: app/forms/steps/lotse/steuerminderungen.py:260
+#: app/forms/steps/lotse/steuerminderungen.py:261
 msgid "form.lotse.haushaltsnahe-handwerker-title"
 msgstr "Haushaltsnahe Dienstleistungen und Handwerkerleistungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:261
+#: app/forms/steps/lotse/steuerminderungen.py:262
 msgid "form.lotse.handwerker-haushaltsnahe-intro"
 msgstr ""
 "Auch Kosten für Dienstleistungen im eigenen Haushalt oder "
@@ -2096,15 +2096,15 @@ msgstr ""
 "Nebenkostenabrechnung haben oder Leistungen selbstständig in Auftrag "
 "gegeben haben, können diese ebenfalls geltend gemacht werden. "
 
-#: app/forms/steps/lotse/steuerminderungen.py:266
+#: app/forms/steps/lotse/steuerminderungen.py:267
 msgid "form.lotse.step_haushaltsnahe_handwerker.label"
 msgstr "Haushaltsnahe Dienstleistungen und Handwerkerleistungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:272
+#: app/forms/steps/lotse/steuerminderungen.py:273
 msgid "form.lotse.field_haushaltsnahe_entries"
 msgstr "Aufwendungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:274
+#: app/forms/steps/lotse/steuerminderungen.py:275
 msgid "form.lotse.field_haushaltsnahe_entries-help"
 msgstr ""
 "<p class='mt-2'>Hier können Arbeiten eingetragen werden, die Sie "
@@ -2127,27 +2127,27 @@ msgstr ""
 "kann zum Beispiel eine Hilfe bei den gewöhnlichen und regelmäßig "
 "wiederkehrenden Verrichtungen des täglichen Lebens sein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:275
+#: app/forms/steps/lotse/steuerminderungen.py:276
 msgid "form.lotse.field_haushaltsnahe_entries.data_label"
 msgstr "Haushaltsnahe Aufwendungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:277
+#: app/forms/steps/lotse/steuerminderungen.py:278
 msgid "form.lotse.field_haushaltsnahe_summe"
 msgstr "Summe der Rechnungsbeträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:278
+#: app/forms/steps/lotse/steuerminderungen.py:279
 msgid "form.lotse.field_haushaltsnahe_summe-help"
 msgstr "Tragen Sie hier die Summe Ihrer angegebenen Aufwendungen ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:279
+#: app/forms/steps/lotse/steuerminderungen.py:280
 msgid "form.lotse.field_haushaltsnahe_summe.data_label"
 msgstr "Summe der Rechnungsbeträge (Haushalt)"
 
-#: app/forms/steps/lotse/steuerminderungen.py:282
+#: app/forms/steps/lotse/steuerminderungen.py:283
 msgid "form.lotse.field_handwerker_entries"
 msgstr "Aufwendungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:284
+#: app/forms/steps/lotse/steuerminderungen.py:285
 msgid "form.lotse.field_handwerker_entries-help"
 msgstr ""
 "Hier können Arbeiten eingetragen werden, die Sie beauftragt haben, aber "
@@ -2168,27 +2168,27 @@ msgstr ""
 " Jahr bezahlt haben</b>. Relevant ist der Zeitpunkt der Bezahlung, nicht "
 "der Rechnungsstellung."
 
-#: app/forms/steps/lotse/steuerminderungen.py:285
+#: app/forms/steps/lotse/steuerminderungen.py:286
 msgid "form.lotse.field_handwerker_entries.data_label"
 msgstr "Handwerker Aufwendungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:287
+#: app/forms/steps/lotse/steuerminderungen.py:288
 msgid "form.lotse.field_handwerker_summe"
 msgstr "Summe der Rechnungsbeträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:288
+#: app/forms/steps/lotse/steuerminderungen.py:289
 msgid "form.lotse.field_handwerker_summe-help"
 msgstr "Tragen Sie hier die Summe Ihrer angegebenen Aufwendungen ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:289
+#: app/forms/steps/lotse/steuerminderungen.py:290
 msgid "form.lotse.field_handwerker_summe.data_label"
 msgstr "Summe der Rechnungsbeträge (Handwerker)"
 
-#: app/forms/steps/lotse/steuerminderungen.py:292
+#: app/forms/steps/lotse/steuerminderungen.py:293
 msgid "form.lotse.field_handwerker_lohn_etc_summe"
 msgstr "Betrag der Lohn-, Maschinen- und Fahrtkosten, inkl. USt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:293
+#: app/forms/steps/lotse/steuerminderungen.py:294
 msgid "form.lotse.field_handwerker_lohn_etc_summe-help"
 msgstr ""
 "Bei haushaltsnahen Dienstleistungen und Handwerkerleistungen im eigenen "
@@ -2199,46 +2199,46 @@ msgstr ""
 "extra ausgewiesen sind, können Sie den Dienstleister bitten, eine neue, "
 "detailliertere Rechnung auszustellen."
 
-#: app/forms/steps/lotse/steuerminderungen.py:294
+#: app/forms/steps/lotse/steuerminderungen.py:295
 msgid "form.lotse.field_handwerker_lohn_etc_summe.data_label"
 msgstr "Betrag der Lohn-, Maschinen- und Fahrtkosten, inkl. USt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:299
+#: app/forms/steps/lotse/steuerminderungen.py:300
 msgid "form.lotse.validation-haushaltsnahe-summe"
 msgstr ""
 "Sie haben angegeben, dass es haushaltsnahe Dienstleistungen gab. Bitte "
 "geben Sie hier deren Summe ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:306
+#: app/forms/steps/lotse/steuerminderungen.py:307
 msgid "form.lotse.validation-haushaltsnahe-entries"
 msgstr ""
 "Sie haben angegeben, dass es haushaltsnahe Dienstleistungen gab. Bitte "
 "geben Sie hier deren Art ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:312
+#: app/forms/steps/lotse/steuerminderungen.py:314
 msgid "form.lotse.validation-handwerker-summe"
 msgstr ""
 "Sie haben angegeben, dass es Handwerkerleistungen gab. Bitte geben Sie "
 "hier deren Summe ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:319
+#: app/forms/steps/lotse/steuerminderungen.py:321
 msgid "form.lotse.validation-handwerker-entries"
 msgstr ""
 "Sie haben angegeben, dass es Handwerkerleistungen gab. Bitte geben Sie "
 "hier deren Art ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:325
+#: app/forms/steps/lotse/steuerminderungen.py:328
 msgid "form.lotse.validation-handwerker-lohn-etc-summe"
 msgstr ""
 "Sie haben angegeben, dass es Handwerkerleistungen gab. Bitte geben Sie "
 "hier die Summe der Lohnanteile, Maschinen- und Fahrtkosten inklusive "
 "Umsatzsteuer ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:338
+#: app/forms/steps/lotse/steuerminderungen.py:341
 msgid "form.lotse.steuerminderungen.details-title"
 msgstr "Was muss ich beachten?"
 
-#: app/forms/steps/lotse/steuerminderungen.py:340
+#: app/forms/steps/lotse/steuerminderungen.py:343
 msgid "form.lotse.steuerminderungen.details-list-item-1"
 msgstr ""
 "Es muss eine <b>Rechnung vorliegen</b>, die zum Beispiel per "
@@ -2247,32 +2247,32 @@ msgstr ""
 "der Nebenkostenabrechnung Ihres Vermieters genügt es, wenn Sie diese "
 "beilegen."
 
-#: app/forms/steps/lotse/steuerminderungen.py:341
+#: app/forms/steps/lotse/steuerminderungen.py:344
 msgid "form.lotse.steuerminderungen.details-list-item-2"
 msgstr ""
 "Abgesetzt werden können Kosten, die Sie im <b>letzten Jahr</b> selbst "
 "bezahlt haben. Relevant ist der Zeitpunkt der Bezahlung, nicht der "
 "Rechnungsstellung."
 
-#: app/forms/steps/lotse/steuerminderungen.py:342
+#: app/forms/steps/lotse/steuerminderungen.py:345
 msgid "form.lotse.steuerminderungen.details-list-item-3"
 msgstr ""
 "Wenn Sie sich als Arbeitgeber betätigen und Haushaltshilfen als "
 "Arbeitnehmer einstellen, können Sie dies im Steuerlotsen nicht steuerlich"
 " absetzen."
 
-#: app/forms/steps/lotse/steuerminderungen.py:348
+#: app/forms/steps/lotse/steuerminderungen.py:351
 msgid "form.lotse.skip_reason.stmind_gem_haushalt.no_handwerker_haushaltsnahe"
 msgstr ""
 "Bitte überspringen Sie diese Angaben. Die Angabe zum gemeinsamen Haushalt"
 " ist nur relevant, wenn Sie Angaben zu haushaltsnaheh Tätigkeiten und "
 "Dienstleistungen und/oder Handwerkerleistungen machen."
 
-#: app/forms/steps/lotse/steuerminderungen.py:362
+#: app/forms/steps/lotse/steuerminderungen.py:365
 msgid "form.lotse.gem-haushalt-title"
 msgstr "Zusätzliche Angaben zum Haushalt bei Alleinstehenden"
 
-#: app/forms/steps/lotse/steuerminderungen.py:363
+#: app/forms/steps/lotse/steuerminderungen.py:366
 msgid "form.lotse.gem-haushalt-intro"
 msgstr ""
 "Steuerermäßigungen wie Haushaltsnahe Dienstleistungen werden nur "
@@ -2282,53 +2282,53 @@ msgstr ""
 "Haushalts an. Die Aufwendungen können jeweils nur vom wirtschaftlich "
 "belasteten Auftraggeber der Leistung geltend gemacht werden."
 
-#: app/forms/steps/lotse/steuerminderungen.py:368
+#: app/forms/steps/lotse/steuerminderungen.py:371
 msgid "form.lotse.step_gem_haushalt.label"
 msgstr "Zusätzliche Angaben zum Haushalt bei Alleinstehenden"
 
-#: app/forms/steps/lotse/steuerminderungen.py:374
+#: app/forms/steps/lotse/steuerminderungen.py:377
 msgid "form.lotse.field_gem_haushalt_count"
 msgstr "Anzahl der weiteren Personen im Haushalt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:375
+#: app/forms/steps/lotse/steuerminderungen.py:378
 msgid "form.lotse.field_gem_haushalt_count.data_label"
 msgstr "Anzahl der weiteren Personen im Haushalt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:379
+#: app/forms/steps/lotse/steuerminderungen.py:382
 msgid "form.lotse.field_gem_haushalt_entries"
 msgstr ""
 "Name, Vorname, Geburtsdatum der weiteren alleinstehenden Personen im "
 "Haushalt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:380
+#: app/forms/steps/lotse/steuerminderungen.py:383
 msgid "form.lotse.field_gem_haushalt_entries-help"
 msgstr ""
 "Alleinstehend sind Personen, die weder verheiratet noch verpartnert nach "
 "dem Lebenspartnerschaftsgesetz sind. "
 
-#: app/forms/steps/lotse/steuerminderungen.py:381
+#: app/forms/steps/lotse/steuerminderungen.py:384
 msgid "form.lotse.field_gem_haushalt_entries.data_label"
 msgstr ""
 "Name, Vorname, Geburtsdatum der weiteren alleinstehenden Personen im "
 "Haushalt"
 
-#: app/forms/steps/lotse/steuerminderungen.py:387
+#: app/forms/steps/lotse/steuerminderungen.py:390
 msgid "form.lotse.validation-gem-haushalt-count"
 msgstr ""
 "Sie haben weitere Personen angegeben. Bitte geben Sie hier die "
 "entsprechende Anzahl der Personen ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:394
+#: app/forms/steps/lotse/steuerminderungen.py:397
 msgid "form.lotse.validation-gem-haushalt-entries"
 msgstr ""
 "Sie haben angegeben, dass weitere Personen im Haushalt leben. Bitte geben"
 " Sie hier die die Daten der Personen ein."
 
-#: app/forms/steps/lotse/steuerminderungen.py:409
+#: app/forms/steps/lotse/steuerminderungen.py:413
 msgid "form.lotse.religion-title"
 msgstr "Steuern für Ihre Religionsgemeinschaft"
 
-#: app/forms/steps/lotse/steuerminderungen.py:410
+#: app/forms/steps/lotse/steuerminderungen.py:414
 msgid "form.lotse.religion-intro"
 msgstr ""
 "Zahlen Sie Steuern für eine Religionsgemeinschaft, können Sie diese hier "
@@ -2337,45 +2337,45 @@ msgstr ""
 "auf die Abgeltungssteuer bei Kapitalerträgen gezahlt wurde, ist <b>nicht "
 "absetzbar</b>."
 
-#: app/forms/steps/lotse/steuerminderungen.py:415
+#: app/forms/steps/lotse/steuerminderungen.py:419
 msgid "form.lotse.step_religion.label"
 msgstr "Steuern für Ihre Religionsgemeinschaft"
 
-#: app/forms/steps/lotse/steuerminderungen.py:421
+#: app/forms/steps/lotse/steuerminderungen.py:425
 msgid "form.lotse.field_religion_paid_summe"
 msgstr "Geleistete Zahlungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:423
+#: app/forms/steps/lotse/steuerminderungen.py:427
 msgid "form.lotse.field_religion_paid_summe-help"
 msgstr ""
 "Tragen Sie die Summe Ihrer im letzten Jahr gezahlten Kirchensteuer ein. "
 "Sie finden diese Daten z.B. auf ihrem Einkommensteuerbescheid und Ihrem "
 "Vorauszahlungsbescheid, sowie auf Ihrer Lohnsteuerbescheinigung."
 
-#: app/forms/steps/lotse/steuerminderungen.py:424
+#: app/forms/steps/lotse/steuerminderungen.py:428
 msgid "form.lotse.field_religion_paid_summe.data_label"
 msgstr "Geleistete Zahlungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:426
+#: app/forms/steps/lotse/steuerminderungen.py:430
 msgid "form.lotse.field_religion_reimbursed_summe"
 msgstr "Erhaltene Erstattungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:427
+#: app/forms/steps/lotse/steuerminderungen.py:431
 msgid "form.lotse.field_religion_reimbursed-help"
 msgstr ""
 "Haben Sie im letzten Jahr zu viel gezahlte Kirchensteuer erstattet "
 "bekommen, geben Sie das hier an. Die Summe der erstatteten Kirchensteuer "
 "finden Sie z.B. auf dem Steuerbescheid des Vorjahres."
 
-#: app/forms/steps/lotse/steuerminderungen.py:428
+#: app/forms/steps/lotse/steuerminderungen.py:432
 msgid "form.lotse.field_religion_reimbursed_summe.data_label"
 msgstr "Erhaltene Erstattungen"
 
-#: app/forms/steps/lotse/steuerminderungen.py:443
+#: app/forms/steps/lotse/steuerminderungen.py:447
 msgid "form.lotse.spenden-inland-title"
 msgstr "Spenden und Mitgliedsbeiträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:444
+#: app/forms/steps/lotse/steuerminderungen.py:448
 msgid "form.lotse.spenden-inland-intro"
 msgstr ""
 "Für einen Spendenabzug benötigen Sie grundsätzlich eine "
@@ -2384,17 +2384,17 @@ msgstr ""
 "Euro</b> reicht den meisten Finanzämtern eine Kopie der Abbuchung vom "
 "Kontoauszug aus."
 
-#: app/forms/steps/lotse/steuerminderungen.py:449
+#: app/forms/steps/lotse/steuerminderungen.py:453
 msgid "form.lotse.step_spenden.label"
 msgstr "Spenden und Mitgliedsbeiträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:454
+#: app/forms/steps/lotse/steuerminderungen.py:459
 msgid "form.lotse.spenden-inland"
 msgstr ""
 "Spenden und Mitgliedsbeiträge zur Förderung steuerbegünstigter Zwecke an "
 "Empfänger im Inland"
 
-#: app/forms/steps/lotse/steuerminderungen.py:456
+#: app/forms/steps/lotse/steuerminderungen.py:461
 msgid "form.lotse.spenden-help"
 msgstr ""
 "Spenden können nur steuermindernd berücksichtigt werden, wenn sie an "
@@ -2407,15 +2407,15 @@ msgstr ""
 " in Freizeitvereinen</b> wie Sportklubs, Gesangsvereine und Vereine für "
 "Heimatpflege, Tierzucht und Kleingartenverein.</p><p>"
 
-#: app/forms/steps/lotse/steuerminderungen.py:457
+#: app/forms/steps/lotse/steuerminderungen.py:462
 msgid "form.lotse.spenden-inland.data_label"
 msgstr "Spenden und Mitgliedsbeiträge"
 
-#: app/forms/steps/lotse/steuerminderungen.py:459
+#: app/forms/steps/lotse/steuerminderungen.py:464
 msgid "form.lotse.spenden-inland-parteien"
 msgstr "Spenden und Mitgliedsbeiträge an inländische politische Parteien"
 
-#: app/forms/steps/lotse/steuerminderungen.py:460
+#: app/forms/steps/lotse/steuerminderungen.py:465
 msgid "form.lotse.spenden-inland-parteien-help"
 msgstr ""
 "Spenden und Mitgliedsbeiträge an inländische politische Parteien und "
@@ -2425,29 +2425,29 @@ msgstr ""
 "die politische Partei von der staatlichen Parteienfinanzierung "
 "ausgeschlossen ist."
 
-#: app/forms/steps/lotse/steuerminderungen.py:461
+#: app/forms/steps/lotse/steuerminderungen.py:466
 msgid "form.lotse.spenden-inland-parteien.data_label"
 msgstr "an inländische politische Parteien"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:20
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:22
 msgid "form.lotse.confirm_data_privacy.required"
 msgstr ""
 "Bestätigen Sie, dass Sie mit den Datenschutzrichtlinien einverstanden "
 "sind, um fortfahren zu können."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:21
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:24
 msgid "form.lotse.confirm_terms_of_service.required"
 msgstr ""
 "Bestätigen Sie, dass Sie den Nutzungbedingungen zustimmen, um fortfahren "
 "zu können."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:25
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:34
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:28
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:37
 msgid "form.lotse.confirmation-title"
 msgstr "Bestätigung und Versand an Ihre Finanzverwaltung"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:26
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:35
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:29
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:38
 msgid "form.lotse.confirmation-intro"
 msgstr ""
 "Diese Erklärung ist eine Einkommensteuererklärung im Sinne des § 150 Abs."
@@ -2455,32 +2455,32 @@ msgstr ""
 "(EStG). Die mit der Erklärung angeforderten Daten werden aufgrund der §§ "
 "149 und 150 AO und der §§ 25 und 46 EStG erhoben."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:52
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:55
 msgid "form.lotse.confirmation.header-title"
 msgstr "Steuerformular - Versand - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:59
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:63
 msgid "form.lotse.filing.title"
 msgstr ""
 "Ihre Informationen wurden erfolgreich verschickt. Speichern Sie Ihre "
 "Nachweise für Ihre Unterlagen."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:60
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:64
 msgid "form.lotse.filing.intro"
 msgstr ""
 "Ihre Informationen wurden erfolgreich an Ihre Finanzverwaltung "
 "übermittelt. Bewahren Sie Ihre Nachweise für Nachfragen gut auf."
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:67
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:86
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:72
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:92
 msgid "form.lotse.filing.header-title"
 msgstr "Steuerformular - Abgabebestätigung - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:75
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:80
 msgid "form.lotse.filing.failure.header-title"
 msgstr "Steuerformular - Abgabebefehler - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:82
+#: app/forms/steps/lotse_multistep_flow_steps/confirmation_steps.py:87
 msgid "form.lotse.ack.alert.title"
 msgstr "Herzlichen Glückwunsch! Sie sind mit Ihrer Steuererklärung fertig!"
 
@@ -2516,16 +2516,16 @@ msgstr ""
 "und ggf. Ihr Partner bzw. Ihre Partnerin keine weiteren Einkünfte hatten,"
 " außer:"
 
-#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:59
+#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:60
 msgid "form.lotse.field_declaration_edaten.label"
 msgstr "Übernahme vorliegender Daten"
 
-#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:64
-#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:78
+#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:65
+#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:79
 msgid "form.lotse.declaration-edaten-title"
 msgstr "Einverständnis zur automatischen Übernahme vorliegender Daten"
 
-#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:65
+#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:66
 msgid "form.lotse.declaration-edaten-intro"
 msgstr ""
 "Da viele Informationen der Finanzverwaltung bereits vorliegen, müssen Sie"
@@ -2536,22 +2536,22 @@ msgstr ""
 "wurden, können Sie den Bescheiden entnehmen, die Sie von der jeweiligen "
 "Stelle per Post erhalten haben. Die Daten kommen aus der gleichen Quelle."
 
-#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:71
+#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:72
 msgid "form.lotse.field_declaration_edaten"
 msgstr ""
 "Ich bzw. wir sind damit einverstanden, dass die Festsetzung meiner / "
 "unserer Einkommensteuer anhand der elektronisch vorliegenden Daten "
 "erfolgt, die der Finanzbehörde vorliegen."
 
-#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:72
+#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:73
 msgid "form.lotse.declaration_edaten.required"
 msgstr "Bestätigen Sie, dass Sie einverstanden sind, um fortfahren zu können"
 
-#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:73
+#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:74
 msgid "form.lotse.field_declaration_edaten.data_label"
 msgstr "Einverständnis vorhanden"
 
-#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:104
+#: app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py:106
 msgid "form.lotse.session-note.title"
 msgstr "Hinweis zur Sitzung"
 
@@ -3105,58 +3105,58 @@ msgstr "Direkt zum Seiteninhalt"
 msgid "success_icon"
 msgstr "Abgehakt Icon auf grünem Kreis"
 
-#: app/templates/basis/footer.html:6
+#: app/templates/basis/footer.html:8
 msgid "footer.help-contact"
 msgstr "Hilfe und Kontakt"
 
-#: app/templates/basis/footer.html:9
+#: app/templates/basis/footer.html:11
 msgid "footer.information"
 msgstr "Informationen zum Service"
 
-#: app/templates/basis/footer.html:12
+#: app/templates/basis/footer.html:14
 msgid "footer.contact"
 msgstr "Kontakt und Feedback"
 
-#: app/templates/basis/footer.html:16 app/templates/basis/footer.html:18
+#: app/templates/basis/footer.html:18 app/templates/basis/footer.html:20
 msgid "footer.revocation"
 msgstr "Freischaltcode Stornierung"
 
-#: app/templates/basis/footer.html:24
+#: app/templates/basis/footer.html:27
 msgid "footer.about-product"
 msgstr "Über das Produkt"
 
-#: app/templates/basis/footer.html:27
+#: app/templates/basis/footer.html:30
 msgid "footer.about-steuerlotse"
 msgstr "Über den Steuerlotsen"
 
-#: app/templates/basis/footer.html:30
+#: app/templates/basis/footer.html:33
 msgid "footer.about-ds"
 msgstr "Über den Digital Service"
 
-#: app/templates/basis/footer.html:38
+#: app/templates/basis/footer.html:42
 msgid "ds4g_logo"
 msgstr "DigitalService4Germany"
 
-#: app/templates/basis/footer.html:42
+#: app/templates/basis/footer.html:46
 msgid "footer.about-steuerlotse-text"
 msgstr ""
 "Der Steuerlotse wurde von der DigitalService4Germany GmbH umgesetzt. Wir "
 "entwickeln digitale Lösungen für und mit der Bundesverwaltung. Im Zentrum"
 " stehen die Bedürfnisse der Nutzerinnen und Nutzer."
 
-#: app/templates/basis/footer.html:54
+#: app/templates/basis/footer.html:59
 msgid "footer.data-privacy"
 msgstr "Datenschutzerklärung"
 
-#: app/templates/basis/footer.html:55
+#: app/templates/basis/footer.html:60
 msgid "footer.agb"
 msgstr "Nutzungsbedingungen"
 
-#: app/templates/basis/footer.html:56
+#: app/templates/basis/footer.html:61
 msgid "footer.impressum"
 msgstr "Impressum"
 
-#: app/templates/basis/footer.html:57
+#: app/templates/basis/footer.html:62
 msgid "footer.accessibility"
 msgstr "Erklärung zur Barrierefreiheit"
 
@@ -4902,13 +4902,15 @@ msgstr "Kontakt"
 
 #: app/templates/content/imprint.html:14
 msgid "imprint.contact-text-p1"
-msgstr "E-Mail: <a href=\"mailto:kontakt@steuerlotse-rente.de\">kontakt@steuerlotse-rente.de</a>"
+msgstr ""
+"E-Mail: <a href=\"mailto:kontakt@steuerlotse-rente.de\">kontakt"
+"@steuerlotse-rente.de</a>"
 
-#: app/templates/content/imprint.html:16
+#: app/templates/content/imprint.html:15
 msgid "imprint.dispute-headline"
 msgstr "Informationspflichten gemäß Art. 14 ODR-VO, § 36 VSBG"
 
-#: app/templates/content/imprint.html:17
+#: app/templates/content/imprint.html:16
 msgid "imprint.dispute-text"
 msgstr ""
 "Die Europäische Kommission stellt eine Plattform zur Online-"
@@ -4920,11 +4922,11 @@ msgstr ""
 "verpflichtet, an Streitbeilegungsverfahren vor einer "
 "Verbraucherschlichtungsstelle teilzunehmen."
 
-#: app/templates/content/imprint.html:18
+#: app/templates/content/imprint.html:17
 msgid "imprint.liability-content-headline"
 msgstr "Haftung für Inhalte"
 
-#: app/templates/content/imprint.html:19
+#: app/templates/content/imprint.html:18
 msgid "imprint.liability-content-text-2"
 msgstr ""
 "Als Diensteanbieter im Sinne von § 2 Nr. 1 TMG sind wir gemäß § 7 Abs. 1 "
@@ -4934,7 +4936,7 @@ msgstr ""
 "nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit "
 "hinweisen."
 
-#: app/templates/content/imprint.html:20
+#: app/templates/content/imprint.html:19
 msgid "imprint.liability-content-text-1"
 msgstr ""
 "Verpflichtungen zur Entfernung oder Sperrung der Nutzung von "
@@ -4944,11 +4946,11 @@ msgstr ""
 "solche Rechtsverletzungen bekannt werden, werden wir die entsprechenden "
 "Inhalte umgehend entfernen."
 
-#: app/templates/content/imprint.html:21
+#: app/templates/content/imprint.html:20
 msgid "imprint.liability-links-headline"
 msgstr "Haftung für Verweise und Links"
 
-#: app/templates/content/imprint.html:22
+#: app/templates/content/imprint.html:21
 msgid "imprint.liability-links-text-p1"
 msgstr ""
 "Unser Angebot enthält Links zu externen Websites Dritter, auf deren "
@@ -4959,7 +4961,7 @@ msgstr ""
 " auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum "
 "Zeitpunkt der Verlinkung nicht erkennbar."
 
-#: app/templates/content/imprint.html:23
+#: app/templates/content/imprint.html:22
 msgid "imprint.liability-links-text-p2"
 msgstr ""
 "Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch "
@@ -4968,11 +4970,11 @@ msgstr ""
 "Seiten bekannt werden, werden wir die entsprechenden Links umgehend "
 "entfernen."
 
-#: app/templates/content/imprint.html:24
+#: app/templates/content/imprint.html:23
 msgid "imprint.copyright-headline"
 msgstr "Urheberrecht"
 
-#: app/templates/content/imprint.html:25
+#: app/templates/content/imprint.html:24
 msgid "imprint.copyright-text-1"
 msgstr ""
 "Die durch uns erstellten Inhalte und Werke auf diesen Seiten unterliegen "
@@ -4982,7 +4984,7 @@ msgstr ""
 "Autor:in bzw. Ersteller:in. Downloads und Kopien dieser Seite sind nur "
 "für den privaten, nicht kommerziellen Gebrauch gestattet."
 
-#: app/templates/content/imprint.html:26
+#: app/templates/content/imprint.html:25
 msgid "imprint.copyright-text-2"
 msgstr ""
 "Soweit die Inhalte auf dieser Seite nicht von uns erstellt wurden, werden"
@@ -4992,11 +4994,11 @@ msgstr ""
 "entsprechenden Hinweis. Bei Bekanntwerden von Rechtsverletzungen werden "
 "wir derartige Inhalte umgehend entfernen."
 
-#: app/templates/content/imprint.html:27
+#: app/templates/content/imprint.html:26
 msgid "imprint.responsible-headline"
 msgstr "Verantwortlich für den Inhalt gemäß § 18 Abs. 2 MStV"
 
-#: app/templates/content/imprint.html:28
+#: app/templates/content/imprint.html:27
 msgid "imprint.responsible-text"
 msgstr ""
 "DigitalService4Germany GmbH<br/>Frau Christina "
@@ -5072,54 +5074,62 @@ msgstr "vereinfachte Steuererklärung dank vorliegender Daten"
 msgid "landing.hero-list-item-3"
 msgstr "kostenlos und ohne Download"
 
-#: app/templates/content/landing_page.html:81
+#: app/templates/content/landing_page.html:70
+msgid "landing.hero-check-use-desc"
+msgstr "Möchten Sie wissen, ob Sie den Steuerlotsen nutzen können?"
+
+#: app/templates/content/landing_page.html:71
+msgid "landing.hero-check-use-button"
+msgstr "Jetzt prüfen"
+
+#: app/templates/content/landing_page.html:83
 msgid "landing.hero-image.alt-text"
 msgstr ""
 "Bilder von Rentnerinnen und Rentnern beim Ausfüllen ihrer digitalen "
 "Steuererklärung."
 
-#: app/templates/content/landing_page.html:91
+#: app/templates/content/landing_page.html:93
 msgid "landing.card1.title"
 msgstr "Herausfinden, ob Sie den Steuerlotsen nutzen können"
 
-#: app/templates/content/landing_page.html:92
+#: app/templates/content/landing_page.html:94
 msgid "landing.card1.desc"
 msgstr ""
 "Prüfen Sie durch die Beantwortung weniger Fragen, ob Sie die "
 "Voraussetzungen für die Nutzung des Steuerlotsen erfüllen."
 
-#: app/templates/content/landing_page.html:99
+#: app/templates/content/landing_page.html:101
 msgid "landing.card2.title"
 msgstr "Registrieren und Freischaltcode beantragen"
 
-#: app/templates/content/landing_page.html:100
+#: app/templates/content/landing_page.html:102
 msgid "landing.card2.desc"
 msgstr ""
 "Mit Ihrer Registrierung beantragen Sie einen Freischaltcode. Dieser wird "
 "Ihnen nach erfolgreicher Beantragung von Ihrer Finanzverwaltung "
 "zugeschickt. "
 
-#: app/templates/content/landing_page.html:107
+#: app/templates/content/landing_page.html:109
 msgid "landing.card3.title"
 msgstr "Mit Freischaltcode anmelden und Steuererklärung machen"
 
-#: app/templates/content/landing_page.html:108
+#: app/templates/content/landing_page.html:110
 msgid "landing.card3.desc"
 msgstr ""
 "Sie sind vorbereitet und haben Ihren Freischaltcode erhalten? Dann können"
 " Sie mit Ihrer Steuererklärung 2021 beginnen."
 
-#: app/templates/content/landing_page.html:124
+#: app/templates/content/landing_page.html:126
 msgid "landing.interviews-headline"
 msgstr "Helfen Sie uns den Steuerlotsen zu verbessern"
 
-#: app/templates/content/landing_page.html:125
+#: app/templates/content/landing_page.html:127
 msgid "landing.interviews-text"
 msgstr ""
 "Der Steuerlotse wird kontinuierlich weiterentwickelt. Wir möchten lernen,"
 " wie gut Ihnen unser Service hilft und was wir noch verbessern können."
 
-#: app/templates/content/landing_page.html:126
+#: app/templates/content/landing_page.html:128
 msgid "landing.interviews-link"
 msgstr "Mehr erfahren"
 

--- a/webapp/client/cypress/integration/landingPage.spec.js
+++ b/webapp/client/cypress/integration/landingPage.spec.js
@@ -1,0 +1,10 @@
+describe("Landing page", () => {
+  it("Clicking button to eligibility check", () => {
+    cy.visit("/");
+    // Clicking button
+    cy.get("a").contains("Jetzt prüfen").click();
+
+    // Should redirect to first step of eligibility steps
+    cy.url().should("include", "/eligibility/step/marital_status");
+  });
+});

--- a/webapp/tests/forms/flows/test_eligibility_step_chooser.py
+++ b/webapp/tests/forms/flows/test_eligibility_step_chooser.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -27,6 +27,7 @@ from app.forms.steps.eligibility_steps import EligibilityStartDisplaySteuerlotse
     IncomeOtherEligibilityFailureDisplaySteuerlotseStep, ForeignCountriesEligibilityFailureDisplaySteuerlotseStep, \
     SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep, SeparatedJointTaxesEligibilityInputFormSteuerlotseStep, \
     EligibilityMaybeDisplaySteuerlotseStep
+from tests.forms.mock_steuerlotse_steps import MockStartStep, MockFirstInputStep
 
 
 @pytest.fixture
@@ -41,39 +42,39 @@ class TestEligibilityChooserInit(unittest.TestCase):
 
     def setUp(self):
         self.testing_steps = [
-                EligibilityStartDisplaySteuerlotseStep,
-                MaritalStatusInputFormSteuerlotseStep,
-                SeparatedEligibilityInputFormSteuerlotseStep,
-                SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep,
-                SeparatedJointTaxesEligibilityInputFormSteuerlotseStep,
-                MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep,
-                MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep,
-                UserAElsterAccountEligibilityInputFormSteuerlotseStep,
-                UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep,
-                DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep,
-                SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep,
-                SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep,
-                PensionDecisionEligibilityInputFormSteuerlotseStep,
-                InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep,
-                MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep,
-                TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep,
-                CheaperCheckDecisionEligibilityInputFormSteuerlotseStep,
-                EmploymentDecisionEligibilityInputFormSteuerlotseStep,
-                MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep,
-                IncomeOtherDecisionEligibilityInputFormSteuerlotseStep,
-                ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep,
-                EligibilitySuccessDisplaySteuerlotseStep,
-                EligibilityMaybeDisplaySteuerlotseStep,
-                MarriedJointTaxesEligibilityFailureDisplaySteuerlotseStep,
-                MarriedAlimonyEligibilityFailureDisplaySteuerlotseStep,
-                DivorcedJointTaxesEligibilityFailureDisplaySteuerlotseStep,
-                SingleAlimonyEligibilityFailureDisplaySteuerlotseStep,
-                PensionEligibilityFailureDisplaySteuerlotseStep,
-                TaxedInvestmentIncomeEligibilityFailureDisplaySteuerlotseStep,
-                CheaperCheckEligibilityFailureDisplaySteuerlotseStep,
-                MarginalEmploymentIncomeEligibilityFailureDisplaySteuerlotseStep,
-                IncomeOtherEligibilityFailureDisplaySteuerlotseStep,
-                ForeignCountriesEligibilityFailureDisplaySteuerlotseStep,
+            EligibilityStartDisplaySteuerlotseStep,
+            MaritalStatusInputFormSteuerlotseStep,
+            SeparatedEligibilityInputFormSteuerlotseStep,
+            SeparatedLivedTogetherEligibilityInputFormSteuerlotseStep,
+            SeparatedJointTaxesEligibilityInputFormSteuerlotseStep,
+            MarriedJointTaxesDecisionEligibilityInputFormSteuerlotseStep,
+            MarriedAlimonyDecisionEligibilityInputFormSteuerlotseStep,
+            UserAElsterAccountEligibilityInputFormSteuerlotseStep,
+            UserBElsterAccountDecisionEligibilityInputFormSteuerlotseStep,
+            DivorcedJointTaxesDecisionEligibilityInputFormSteuerlotseStep,
+            SingleAlimonyDecisionEligibilityInputFormSteuerlotseStep,
+            SingleElsterAccountDecisionEligibilityInputFormSteuerlotseStep,
+            PensionDecisionEligibilityInputFormSteuerlotseStep,
+            InvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep,
+            MinimalInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep,
+            TaxedInvestmentIncomeDecisionEligibilityInputFormSteuerlotseStep,
+            CheaperCheckDecisionEligibilityInputFormSteuerlotseStep,
+            EmploymentDecisionEligibilityInputFormSteuerlotseStep,
+            MarginalEmploymentIncomeDecisionEligibilityInputFormSteuerlotseStep,
+            IncomeOtherDecisionEligibilityInputFormSteuerlotseStep,
+            ForeignCountriesDecisionEligibilityInputFormSteuerlotseStep,
+            EligibilitySuccessDisplaySteuerlotseStep,
+            EligibilityMaybeDisplaySteuerlotseStep,
+            MarriedJointTaxesEligibilityFailureDisplaySteuerlotseStep,
+            MarriedAlimonyEligibilityFailureDisplaySteuerlotseStep,
+            DivorcedJointTaxesEligibilityFailureDisplaySteuerlotseStep,
+            SingleAlimonyEligibilityFailureDisplaySteuerlotseStep,
+            PensionEligibilityFailureDisplaySteuerlotseStep,
+            TaxedInvestmentIncomeEligibilityFailureDisplaySteuerlotseStep,
+            CheaperCheckEligibilityFailureDisplaySteuerlotseStep,
+            MarginalEmploymentIncomeEligibilityFailureDisplaySteuerlotseStep,
+            IncomeOtherEligibilityFailureDisplaySteuerlotseStep,
+            ForeignCountriesEligibilityFailureDisplaySteuerlotseStep,
         ]
         self.endpoint_correct = "eligibility"
 
@@ -152,3 +153,19 @@ class TestEligibilityStepChooserDeterminePrevStep(unittest.TestCase):
         prev_step = self.step_chooser.determine_prev_step(given_step_name, {})
 
         self.assertEqual('step-0', prev_step.name)
+
+
+@pytest.mark.usefixtures('test_request_context')
+class TestGetPossibleRedirect:
+    @pytest.fixture
+    def eligibility_step_chooser(self):
+        eligibility_step_chooser = EligibilityStepChooser(endpoint='eligibility')
+        eligibility_step_chooser.steps = {MockStartStep.name: MockStartStep,
+                                          MockFirstInputStep.name: MockFirstInputStep}
+        eligibility_step_chooser.first_step = MockStartStep
+        eligibility_step_chooser.step_order = [MockStartStep.name, MockFirstInputStep.name]
+        yield eligibility_step_chooser
+
+    def test_if_step_name_is_first_input_then_return_first_after_start(self, eligibility_step_chooser):
+        step_to_redirect_to = eligibility_step_chooser._get_possible_redirect('first_input_step', {})
+        assert step_to_redirect_to == MockFirstInputStep.name

--- a/webapp/tests/forms/mock_steuerlotse_steps.py
+++ b/webapp/tests/forms/mock_steuerlotse_steps.py
@@ -17,6 +17,15 @@ class MockStartStep(SteuerlotseStep):
         super(MockStartStep, self).__init__(header_title=header_title, default_data=default_data, render_info=render_info, *args, **kwargs)
 
 
+class MockFirstInputStep(SteuerlotseStep):
+    name = 'mock_first_input_step'
+    title = 'The first input after start',
+    intro = 'The one where the empire thinks of striking'
+
+    def __init__(self, header_title=None, default_data=None, render_info=None, *args, **kwargs):
+        super(MockFirstInputStep, self).__init__(header_title=header_title, default_data=default_data, render_info=render_info, *args, **kwargs)
+
+
 class MockMiddleStep(SteuerlotseStep):
     name = 'mock_middle_step'
     title = 'The Middle',


### PR DESCRIPTION
# Short Description
- In order to promote the conversion rate, a new bold text and button is added to the start page. This buttons links to the first step (now marital_status) of the eligibility steps

# Changes
- Added new elements on the landing page.
- For bold text, bootstrap class is used, in addition to the already-being-used p-class
- For the button the component html is used. I also added a new pseudo-step-name called "start_next" so that we can always link to the 1st step without specifying an static name (like "marital_status"). This way we can avoid unexpected redirects in the case that the marital status page someday is not the first page of the eligibility process anymore.

# Feedback
- Is that ok so?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
