### PR TITLE
Stl 1867 weiterempfehlung

### DIFF
--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -282,12 +282,13 @@ const translations = {
       heading: "Wie geht es weiter?",
       text: "Ihre Steuererklärung wird von Ihrem Finanzamt bearbeitet. Sie bekommen Ihren Steuerbescheid per Post zugeschickt.",
     },
+    recommend: {
+      heading: "Empfehlen Sie uns weiter!",
+      text: "Wir möchten noch mehr Menschen bei Ihrer Steuererklärung helfen! Sie können uns dabei helfen, indem Sie den Steuerlotsen bekannter machen. Empfehlen Sie uns Ihren Bekannten und Freunden!",
+    },
     logout: {
       heading: "Wir löschen Ihr Nutzerkonto",
-      text1:
-        "Bitte beachten Sie, dass Sie Ihren Freischaltcode nicht erneut verwenden können. Wenn Sie unseren Service nächstes Jahr wieder nutzen möchten, können Sie sich einfach erneut registrieren.",
-      text2:
-        "Sie haben sich Ihr Transferticket notiert und Ihre Übersicht der übermittelten Daten gespeichert oder ausgedruckt? Dann melden Sie sich ab.",
+      text: "Bitte beachten Sie, dass Sie Ihren Freischaltcode nicht erneut verwenden können. Wenn Sie unseren Service nächstes Jahr wieder nutzen möchten, können Sie sich einfach erneut registrieren. Haben Sie Ihre Steuererklärung gespeichert? Dann können Sie sich abmelden.",
     },
   },
   dateField: {

--- a/webapp/client/src/pages/SubmitAcknowledgePage.js
+++ b/webapp/client/src/pages/SubmitAcknowledgePage.js
@@ -18,10 +18,10 @@ export default function SubmitAcknowledgePage({ prevUrl, logoutUrl }) {
       <StepHeaderButtons url={prevUrl} />
       <FormSuccessHeader {...stepHeader} />
       <h2 className="h4 mt-5">{t("submitAcknowledge.next-steps.heading")}</h2>
-      <p className="mb-5">{t("submitAcknowledge.next-steps.text")}</p>
-      <h2 className="h4 mt-4">{t("submitAcknowledge.recommend.heading")}</h2>
-      <p className="mb-5">{t("submitAcknowledge.recommend.text")}</p>
-      <h2 className="h4 mt-4">{t("submitAcknowledge.logout.heading")}</h2>
+      <p>{t("submitAcknowledge.next-steps.text")}</p>
+      <h2 className="h4 mt-5">{t("submitAcknowledge.recommend.heading")}</h2>
+      <p>{t("submitAcknowledge.recommend.text")}</p>
+      <h2 className="h4 mt-5">{t("submitAcknowledge.logout.heading")}</h2>
       <p className="mb-5">{t("submitAcknowledge.logout.text")}</p>
       <AnchorButton url={logoutUrl} text={t("form.logout.button")} />
     </>

--- a/webapp/client/src/pages/SubmitAcknowledgePage.js
+++ b/webapp/client/src/pages/SubmitAcknowledgePage.js
@@ -17,11 +17,12 @@ export default function SubmitAcknowledgePage({ prevUrl, logoutUrl }) {
     <>
       <StepHeaderButtons url={prevUrl} />
       <FormSuccessHeader {...stepHeader} />
-      <h2 className="h4 mt-4">{t("submitAcknowledge.next-steps.heading")}</h2>
-      <p>{t("submitAcknowledge.next-steps.text")}</p>
+      <h2 className="h4 mt-5">{t("submitAcknowledge.next-steps.heading")}</h2>
+      <p className="mb-5">{t("submitAcknowledge.next-steps.text")}</p>
+      <h2 className="h4 mt-4">{t("submitAcknowledge.recommend.heading")}</h2>
+      <p className="mb-5">{t("submitAcknowledge.recommend.text")}</p>
       <h2 className="h4 mt-4">{t("submitAcknowledge.logout.heading")}</h2>
-      <p>{t("submitAcknowledge.logout.text1")}</p>
-      <p>{t("submitAcknowledge.logout.text2")}</p>
+      <p className="mb-5">{t("submitAcknowledge.logout.text")}</p>
       <AnchorButton url={logoutUrl} text={t("form.logout.button")} />
     </>
   );

--- a/webapp/client/src/pages/SubmitAcknowledgePage.test.js
+++ b/webapp/client/src/pages/SubmitAcknowledgePage.test.js
@@ -1,22 +1,15 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import SubmitAcknowledgePage from "./SubmitAcknowledgePage";
+import { I18nextProvider } from "react-i18next";
+import i18n from "i18next";
 
 const MOCK_PROPS = {
   prevUrl: "/some/prev/path",
   logoutUrl: "/some/link/path",
 };
 
-const EXPECTED_HEADER = {
-  title: "Herzlichen Glückwunsch! Sie sind mit Ihrer Steuererklärung fertig!",
-};
-
 describe("SubmitAcknowledgePage", () => {
-  it("should render step header texts", () => {
-    render(<SubmitAcknowledgePage {...MOCK_PROPS} />);
-    expect(screen.getByText(EXPECTED_HEADER.title)).toBeInTheDocument();
-  });
-
   it("should link to the previous page", () => {
     render(<SubmitAcknowledgePage {...MOCK_PROPS} />);
     expect(screen.getByText("Zurück").closest("a")).toHaveAttribute(
@@ -31,5 +24,48 @@ describe("SubmitAcknowledgePage", () => {
       "href",
       expect.stringContaining(MOCK_PROPS.logoutUrl)
     );
+  });
+});
+
+describe("SubmitAcknowledgePage translations", () => {
+  let c;
+
+  const submitAcknowledge =
+    i18n.getDataByLanguage("de").translation.submitAcknowledge;
+
+  beforeEach(() => {
+    c = render(
+      <I18nextProvider i18n={i18n}>
+        <SubmitAcknowledgePage {...MOCK_PROPS} />
+      </I18nextProvider>
+    );
+  });
+
+  it("should render step header texts", () => {
+    expect(c.getByText(submitAcknowledge.successMessage)).toBeDefined();
+  });
+
+  it("should render next steps header", () => {
+    expect(c.getByText(submitAcknowledge["next-steps"].heading)).toBeDefined();
+  });
+
+  it("should render next steps text", () => {
+    expect(c.getByText(submitAcknowledge["next-steps"].text)).toBeDefined();
+  });
+
+  it("should render recommend header", () => {
+    expect(c.getByText(submitAcknowledge.recommend.heading)).toBeDefined();
+  });
+
+  it("should render recommend text", () => {
+    expect(c.getByText(submitAcknowledge.recommend.text)).toBeDefined();
+  });
+
+  it("should render logout header", () => {
+    expect(c.getByText(submitAcknowledge.logout.heading)).toBeDefined();
+  });
+
+  it("should render logout text", () => {
+    expect(c.getByText(submitAcknowledge.logout.text)).toBeDefined();
   });
 });

--- a/webapp/client/src/pages/SubmitAcknowledgePage.test.js
+++ b/webapp/client/src/pages/SubmitAcknowledgePage.test.js
@@ -28,13 +28,11 @@ describe("SubmitAcknowledgePage", () => {
 });
 
 describe("SubmitAcknowledgePage translations", () => {
-  let c;
-
-  const submitAcknowledge =
+  const submitAcknowledgeTexts =
     i18n.getDataByLanguage("de").translation.submitAcknowledge;
 
   beforeEach(() => {
-    c = render(
+    render(
       <I18nextProvider i18n={i18n}>
         <SubmitAcknowledgePage {...MOCK_PROPS} />
       </I18nextProvider>
@@ -42,30 +40,42 @@ describe("SubmitAcknowledgePage translations", () => {
   });
 
   it("should render step header texts", () => {
-    expect(c.getByText(submitAcknowledge.successMessage)).toBeDefined();
+    expect(
+      screen.getByText(submitAcknowledgeTexts.successMessage)
+    ).toBeDefined();
   });
 
   it("should render next steps header", () => {
-    expect(c.getByText(submitAcknowledge["next-steps"].heading)).toBeDefined();
+    expect(
+      screen.getByText(submitAcknowledgeTexts["next-steps"].heading)
+    ).toBeDefined();
   });
 
   it("should render next steps text", () => {
-    expect(c.getByText(submitAcknowledge["next-steps"].text)).toBeDefined();
+    expect(
+      screen.getByText(submitAcknowledgeTexts["next-steps"].text)
+    ).toBeDefined();
   });
 
   it("should render recommend header", () => {
-    expect(c.getByText(submitAcknowledge.recommend.heading)).toBeDefined();
+    expect(
+      screen.getByText(submitAcknowledgeTexts.recommend.heading)
+    ).toBeDefined();
   });
 
   it("should render recommend text", () => {
-    expect(c.getByText(submitAcknowledge.recommend.text)).toBeDefined();
+    expect(
+      screen.getByText(submitAcknowledgeTexts.recommend.text)
+    ).toBeDefined();
   });
 
   it("should render logout header", () => {
-    expect(c.getByText(submitAcknowledge.logout.heading)).toBeDefined();
+    expect(
+      screen.getByText(submitAcknowledgeTexts.logout.heading)
+    ).toBeDefined();
   });
 
   it("should render logout text", () => {
-    expect(c.getByText(submitAcknowledge.logout.text)).toBeDefined();
+    expect(screen.getByText(submitAcknowledgeTexts.logout.text)).toBeDefined();
   });
 });


### PR DESCRIPTION
# Short Description
- In order to motivate users to recommend the service, a new text is added to the acknowledgment page.

# Changes
- Added new block with title and text for the recommendation
- Updated also the text for the user data deletion (was't part of the ticket specification but in the figma prototype. In accordance to Nadine and Nicolai this changed should also be made)
- Added more spacing between info blocks, also agreed with Nadine
- Upgraded frontend test with translations access

# Feedback
- I realized that the test didn't test before the content but just the header and before I copy/paste the headers/texts I tried out a solution for importing the very same translations file. Wdyt?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
