### PR TITLE
STL-1905 | Remove dividing line when extended footer is disabled

### DIFF
--- a/webapp/app/templates/basis/footer.html
+++ b/webapp/app/templates/basis/footer.html
@@ -1,6 +1,11 @@
-<footer class="pt-4 pl-0 pr-0 ml-0 mr-0">
-    {% if (render_info and not render_info.additional_info['disable_extended_footer'])
-        or (not render_info and not disable_extended_footer) %}
+{% if (render_info and not render_info.additional_info['disable_extended_footer'])
+or (not render_info and not disable_extended_footer) %}
+    {% set disable_extended_footer = false %}
+{% else %}
+    {% set disable_extended_footer = true %}
+{% endif %}
+<footer class="pt-4 pl-0 pr-0 ml-0 mr-0 {{'border-0' if disable_extended_footer }}">
+    {% if not disable_extended_footer %}
     <div class="container-fluid pt-4 pb-3 pl-0 pr-0">
         <div class="footer-inner">
             <div class="row m-0">


### PR DESCRIPTION
# Short Description
- Dividing line was to be removed when the "extended footer" is disabled

# Changes
- Moved the if/else to the upper part, setting a variable that is now also used within the class name definition of the footer element.

# Feedback
- Any?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
