### PR TITLE
feature/STL-1776: use keyboard focus only

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -5,7 +5,7 @@ services:
     env_file:
       - ".env"
     build:
-      context: "./erica_app"
+      context: "https://github.com/digitalservice4germany/erica.git#docker-dev"
       dockerfile: "Development.Dockerfile"
       args:
         - ERICA_BUCKET_NAME=$ERICA_BUCKET_NAME
@@ -14,8 +14,6 @@ services:
         - ENDPOINT_URL=$ENDPOINT_URL
         - ELSTER_DATENLIEFERANT=$ELSTER_DATENLIEFERANT
         - ELSTER_HERSTELLER_ID=$ELSTER_HERSTELLER_ID
-    volumes:
-      - "./erica_app:/app"
     expose:
       - 8000
     ports:
@@ -33,7 +31,6 @@ services:
     links:
       - postgres
       - redis
-      - erica
 
   migrations:
     env_file:

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-02-23 11:55+0100\n"
+"POT-Creation-Date: 2022-02-28 08:03+0000\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -187,7 +187,7 @@ msgstr "Ja"
 msgid "switch.no"
 msgstr "Nein"
 
-#: app/forms/flows/eligibility_step_chooser.py:46
+#: app/forms/flows/eligibility_step_chooser.py:47
 msgid "form.eligibility.title"
 msgstr "Prüfung: Kann ich die vereinfachte Steuererklärung nutzen?"
 

--- a/webapp/client/public/css/base.css
+++ b/webapp/client/public/css/base.css
@@ -120,7 +120,7 @@ input.form-control:hover {
   border: 2px solid var(--hover-border-color);
 }
 
-input.form-control:focus {
+input.form-control:focus-visible {
   border: 2px solid var(--border-color);
   box-shadow: 0 0 0 2px var(--focus-color);
 }
@@ -142,7 +142,7 @@ input.form-control.field-error-found {
   min-height: 55px;
 }
 
-.steuerlotse-select:focus {
+.steuerlotse-select:focus-visible {
   border: 2px solid var(--focus-border-color);
   box-shadow: 0 0 0 2px var(--focus-color);
 }
@@ -281,6 +281,12 @@ ol li::before {
          move the style definition to assorted.css. */
 .list-unstyled li a {
   color: var(--text-color);
+}
+
+.btn:focus, .btn-primary:focus, .btn-secondary:focus,
+.btn-primary:not(:disabled):not(.disabled):active:focus,
+.btn-secondary:not(:disabled):not(.disabled).active:focus {
+  box-shadow: none;
 }
 
 .btn-outline-secondary {

--- a/webapp/client/public/css/components.css
+++ b/webapp/client/public/css/components.css
@@ -16,6 +16,11 @@
     border-bottom: 4px solid var(--link-color);
 }
 
+.btn-primary:not(:disabled):not(.disabled):active:focus {
+    outline: none;
+    box-shadow: none;
+    background-color: var(--link-color);
+}
 
 .btn-primary:not(:disabled):not(.disabled):active, a.btn-primary:not(:disabled):not(.disabled):active{
     background: var(--link-color) !important;
@@ -31,13 +36,9 @@
     border-bottom: 4px solid var(--link-hover-color);
 }
 
-
-
-.btn-primary:focus, a.btn-primary:focus{
+.btn-primary:focus-visible, a.btn-primary:focus-visible{
     color: var(--focus-text-color);
-
     background: var(--focus-color);
-
     outline: none;
     box-shadow: none;
     border: 0;
@@ -73,34 +74,36 @@
     border: 1px solid var(--link-hover-color);
 }
 
-.btn-outline-primary:focus, a.btn-outline-primary:focus{
+.btn-outline-primary:focus-visible, a.btn-outline-primary:focus-visible {
     color: var(--focus-color);
-
     outline:none;
     box-shadow: none;
     border: 1px solid var(--focus-border-color);
 }
 
-
-.btn-help  {
+.btn-help {
     background: var(--link-color);
     color: var(--inverse-text-color) !important;
     text-decoration: none;
 }
 
-.btn-help:hover  {
+.btn-help:hover {
     background: var(--link-hover-color);
     color: var(--inverse-text-color) !important;
     text-decoration: none;
 }
 
-.btn-help:focus  {
+.btn-help:focus {
+    box-shadow: none;
+}
+
+.btn-help:focus-visible {
     background: var(--focus-color);
     color: var(--text-color) !important;
     text-decoration: none;
 }
 
-.remove-button{
+.remove-button {
     cursor: pointer;
     margin-left: 5px;
     padding: .375rem .75rem;
@@ -117,7 +120,7 @@
     background: var(--link-hover-color);
 }
 
-.remove-button:focus{
+.remove-button:focus-visible{
     text-decoration: none;
     color: var(--text-color) !important;
     background: var(--focus-color);
@@ -162,7 +165,7 @@
     display: inline;
 }
 
-.accordion .card-header:focus-within button span {
+.accordion .card-header:focus-within button:focus-visible span {
     color: var(--text-color);
     background: var(--focus-color);
     border-bottom: 4px solid var(--focus-border-color);
@@ -245,11 +248,9 @@
     color: var(--link-hover-color);
 }
 
-.details-card .card-header button:focus span {
+.details-card .card-header button:focus-visible span {
     color: var(--focus-text-color);
-
     background: var(--focus-color);
-
     outline:none;
     box-shadow: none;
     border: 0;
@@ -479,7 +480,7 @@ a.back-link:focus a.back-link:active{
     opacity: 0;
 }
 
-.checkbox input:focus + label {
+.checkbox input:focus-visible + label {
     box-shadow: 0 0 0 3px var(--focus-color);
     background-color: var(--focus-color);
 }
@@ -513,7 +514,7 @@ a.back-link:focus a.back-link:active{
     border: 1px solid var(--border-color) !important;
 }
 
-.switch-yes:focus, .switch-no:focus {
+.switch-yes:focus-visible, .switch-no:focus-visible {
     color: var(--focus-text-color) !important;
     background: var(--focus-color) !important;
 
@@ -529,8 +530,7 @@ a.back-link:focus a.back-link:active{
     border: 1px solid var(--link-color) !important;
 }
 
-.switch-yes:active, .switch-no:active,
-.switch-yes.active:focus, .switch-no.active:focus {
+.switch-yes.active:focus-visible, .switch-no.active:focus-visible {
     box-shadow: 0 0 0 3px var(--focus-color) !important;
 }
 
@@ -539,7 +539,6 @@ a.back-link:focus a.back-link:active{
     background: var(--link-hover-color) !important;
     border: 1px solid var(--link-hover-color) !important;
 }
-
 
 /* RADIO BUTTONS */
 input[type="radio"] {
@@ -573,11 +572,11 @@ input[type="radio"]:checked + label:hover::before {
     background: url("/icons/radio_button_checked_hover.svg") no-repeat center;
 }
 
-input[type="radio"]:not(:checked):focus + label::before {
+input[type="radio"]:not(:checked):focus-visible + label::before {
     background: url("/icons/radio_button_focus.svg") no-repeat center;
 }
 
-input[type="radio"]:checked:focus + label::before {
+input[type="radio"]:checked:focus-visible + label::before {
     background: url("/icons/radio_button_checked_focus.svg") no-repeat center;
 }
 

--- a/webapp/client/src/components/AnchorButton.js
+++ b/webapp/client/src/components/AnchorButton.js
@@ -29,7 +29,7 @@ const Anchor = styled.a`
     text-decoration: none;
   }
 
-  &:focus {
+  &:focus-visible {
     color: var(--focus-text-color);
     background: var(--focus-color);
     outline: none;

--- a/webapp/client/src/components/BackLink.js
+++ b/webapp/client/src/components/BackLink.js
@@ -16,7 +16,7 @@ const Anchor = styled.a`
     margin-right: 5px;
   }
 
-  &:focus {
+  &:focus-visible {
     span:last-child {
       background-color: var(--focus-color);
       border-bottom: 1px solid var(--text-color);

--- a/webapp/client/src/components/Details.js
+++ b/webapp/client/src/components/Details.js
@@ -65,7 +65,7 @@ const DetailsCard = styled.div`
     color: var(--link-hover-color);
   }
 
-  &.details-card .card-header button:focus span {
+  &.details-card .card-header button:focus-visible span {
     color: var(--focus-text-color);
     background: var(--focus-color);
   }

--- a/webapp/client/src/components/FormFieldCheckBox.js
+++ b/webapp/client/src/components/FormFieldCheckBox.js
@@ -14,7 +14,7 @@ const CheckBox = styled.div`
     opacity: 0;
   }
 
-  input:focus + label {
+  input:focus-visible + label {
     box-shadow: 0 0 0 3px var(--focus-color);
     background-color: var(--focus-color);
   }

--- a/webapp/client/src/components/FormFieldConsentBox.js
+++ b/webapp/client/src/components/FormFieldConsentBox.js
@@ -21,7 +21,7 @@ const ConsentBox = styled.div`
     opacity: 0;
   }
 
-  &.checkbox input:focus + label {
+  &.checkbox input:focus-visible + label {
     box-shadow: 0 0 0 3px var(--focus-color);
     background-color: var(--focus-color);
   }

--- a/webapp/client/src/components/FormFieldDropDown.js
+++ b/webapp/client/src/components/FormFieldDropDown.js
@@ -15,7 +15,7 @@ const DropDown = styled.select`
     min-height: 55px;
   }
 
-  .steuerlotse-select:focus {
+  .steuerlotse-select:focus-visible {
     border: 2px solid var(--focus-border-color);
     box-shadow: 0 0 0 2px var(--focus-color);
   }

--- a/webapp/client/src/components/FormFieldRadioGroup.js
+++ b/webapp/client/src/components/FormFieldRadioGroup.js
@@ -44,7 +44,7 @@ const Radio = styled.div`
     background: url(${radioButtonCheckedHover}) no-repeat center;
   }
 
-  input[type="radio"]:not(:checked):focus + label::before {
+  input[type="radio"]:not(:checked):focus-visible + label::before {
     background: url(${radioButtonFocus}) no-repeat center;
   }
 
@@ -52,7 +52,7 @@ const Radio = styled.div`
     background: url(${radioButtonHover}) no-repeat center;
   }
 
-  input[type="radio"]:checked:focus + label::before {
+  input[type="radio"]:checked:focus-visible + label::before {
     background: url(${radioButtonCheckedFocus}) no-repeat center;
   }
 

--- a/webapp/client/src/components/SelectableCard.js
+++ b/webapp/client/src/components/SelectableCard.js
@@ -29,7 +29,7 @@ const CardLabel = styled.label`
     overflow: hidden;
   }
 
-  input:focus + .checkmark {
+  input:focus-visible + .checkmark {
     box-shadow: 0 0 0 3px var(--focus-color);
     background-color: var(--focus-color);
   }

--- a/webapp/client/src/components/StepNavButtons.js
+++ b/webapp/client/src/components/StepNavButtons.js
@@ -36,11 +36,14 @@ const sharedButtonLinkStyle = css`
     border-bottom: 4px solid var(--link-hover-color);
   }
 
-  &:focus {
+  :focus {
+    background-color: var(--link-color);
+    border-bottom: 4px solid var(--link-color);
+  }
+
+  &:focus-visible {
     color: var(--focus-text-color);
-
-    background: var(--focus-color);
-
+    background-color: var(--focus-color);
     outline: none;
     box-shadow: none;
     border: 0;
@@ -90,7 +93,7 @@ const OutlineLink = styled.a`
     border: 1px solid var(--link-hover-color);
   }
 
-  :focus {
+  :focus-visible {
     color: var(--focus-color);
 
     outline: none;
@@ -125,9 +128,8 @@ const OutlineButton = styled.button`
     border: 1px solid var(--link-hover-color);
   }
 
-  :focus {
+  :focus-visible {
     color: var(--focus-color);
-
     outline: none;
     box-shadow: none;
     border: 1px solid var(--focus-border-color);


### PR DESCRIPTION
# Short Description
- use keyboard focus only for focusable elements

# Changes
- use focus-visible where possible to show focus style on keyboard input (tab) only
- Hint: We will let the yes/no form switch as it is (after consultation with UX); we have a dedicated task/ticket for refactoring this component
- change docker compose dev file to start all related projects within docker

# Feedback
- something missing?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
