### PR TITLE
Fix acceptance test bug in IBAN input

### DIFF
--- a/acceptance_tests/cypress/integration/lotse_flow.spec.js
+++ b/acceptance_tests/cypress/integration/lotse_flow.spec.js
@@ -215,40 +215,6 @@ context('Acceptance tests', () => {
             cy.get('div[id=familienstand_zusammenveranlagung_field]').should('not.be.visible')
         })
 
-        it('Enter different tax number data ', () => {
-            cy.visit('/lotse/step/steuernummer?link_overview=True')
-
-            // Tax number exists
-            cy.get('label[for=steuernummer_exists-yes]').click()
-            cy.get('#steuernummer').should('not.exist');
-            cy.get('select[id=bufa_nr]').should('not.exist')
-            cy.get('label[for=request_new_tax_number]').should('not.exist')
-
-            // Select state
-            cy.get('select[id=bundesland]').select('BY')
-            cy.get('#steuernummer').should('be.visible')
-            cy.get('select[id=bufa_nr]').should('not.exist')
-            cy.get('label[for=request_new_tax_number]').should('not.exist')
-
-            // Tax number does not exist
-            cy.get('label[for=steuernummer_exists-no]').click()
-            cy.get('select[id=bundesland]').should('be.visible').and('have.value', 'BY')
-            cy.get('select[id=bufa_nr]').should('be.visible')
-            cy.get('label[for=request_new_tax_number]').should('not.exist')
-            cy.get('#steuernummer').should('not.exist');
-
-            // Select state
-            cy.get('select[id=bundesland]').select('BY')
-            cy.get('select[id=bufa_nr]').should('be.visible')
-            cy.get('label[for=request_new_tax_number]').should('not.exist')
-            cy.get('#steuernummer').should('not.exist');
-
-            //Select bufa_nr
-            cy.get('select[id=bufa_nr]').select('9203')
-            cy.get('label[for=request_new_tax_number]').should('be.visible')
-            cy.get('label[for=request_new_tax_number]').should('not.be.checked')
-        })
-
         context('Submitting tax returns', () => {
             beforeEach(() => {
                 // Step 1: accept opt-ins

--- a/acceptance_tests/cypress/integration/lotse_flow.spec.js
+++ b/acceptance_tests/cypress/integration/lotse_flow.spec.js
@@ -291,7 +291,7 @@ context('Acceptance tests', () => {
                 cy.get(submitBtnSelector).click()
 
                 cy.get('label[for=is_user_account_holder]').first().click()
-                cy.get('#iban').type(taxReturnData.iban)
+                cy.get('#iban').type(taxReturnData.iban, { delay: 50 })
                 cy.get(submitBtnSelector).click()
 
                 // Step 3
@@ -347,7 +347,7 @@ context('Acceptance tests', () => {
                 cy.get(submitBtnSelector).click()
 
                 cy.get('label[for=is_user_account_holder]').first().click()
-                cy.get('#iban').type(taxReturnData.iban)
+                cy.get('#iban').type(taxReturnData.iban, { delay: 50 })
                 cy.get(submitBtnSelector).click()
 
                 // Step 3
@@ -459,7 +459,7 @@ context('Acceptance tests', () => {
                 cy.get(submitBtnSelector).click()
 
                 cy.get('label[for=account_holder-0]').first().click()
-                cy.get('#iban').type(taxReturnData.iban)
+                cy.get('#iban').type(taxReturnData.iban, { delay: 50 })
                 cy.get(submitBtnSelector).click()
 
                 // Step 3

--- a/webapp/tests/elster_client/mock_erica.py
+++ b/webapp/tests/elster_client/mock_erica.py
@@ -84,7 +84,7 @@ class MockErica:
                 response = MockErica.get_tax_offices()
             elif _PYERIC_API_BASE_URL_01 + '/tax_number_validity' in args[0]:
                 sub_urls = args[0].split('/')
-                response = MockErica.is_valid_tax_number(state_abbreviation=sub_urls[2], tax_number=sub_urls[3])
+                response = MockErica.is_valid_tax_number(state_abbreviation=sub_urls[len(sub_urls)-2], tax_number=sub_urls[len(sub_urls)-1])
             elif args[0] == _PYERIC_API_BASE_URL_02 + '/post_job':
                 return MockErica.post_dummy_job()
             elif args[0] == _PYERIC_API_BASE_URL_02 + '/get_job':


### PR DESCRIPTION
# Short Description
Our acceptance test sometimes run into odd behavior and fail because the IBAN number is incorrect (s. this run for example). I had a look into that and ran them locally. After up to 24 runs, they would fail for the same reason. Although the input should be correct, I would receive an incorrect IBAN number in the backend with one digit placed incorrectly.
I assume that this is because of some timing issue with `cy.type()`. `type` simulates real typing and by default has a delay between input of different digits of 10 ms. We use masking for the IBAN input, which changes the input while typing. I assume that this sometimes changes at the wrong time and the digits get misplaced because of that. The misplaced digits were always at that point of the IBAN where we add a space. [This discussion](https://stackoverflow.com/questions/67416126/cypress-insert-wrong-data-from-json) also points in that direction.

To fix this problem I increased the delay for the IBAN input to 50ms (recommendation taken from discussion mentioned above). I ran the acceptance tests locally over 50 times without getting the error again. Therefore, I assume that this should fix it.

# Changes
- Add a delay to IBAN input
- Removed unneccessary tax number tests: We test that already in the component itself. This is still legacy code from before, when we did not have the functional tests.
- Fix MockErica tax_number_validity: It was hardcoded before and now it always takes the last to parameters.

# Feedback
- What to you think about the deleted acceptance tests and the changes to MockErica?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
