### PR TITLE
S tl 1961 add cta plausible insights

### DIFF
--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -5,6 +5,10 @@
       <a class="{% if  float_right %} float-right {% endif %} btn btn-primary" href="{{ url }}">{{ text }}</a>
 {%- endmacro %}
 
+{% macro primaryButtonWithTracking(text, url, target, source, float_right=False) -%}
+      <a class="{% if  float_right %} float-right {% endif %} btn btn-primary" href="{{ url }}" onclick="plausible('{{ url_target }}', {props: {method: '{{ source }}'}})">{{ text }}</a>
+{%- endmacro %}
+
 {% macro primaryButtonWithIcon(text, url, icon, target) -%}
     <a class="btn btn-primary" href="{{ url}}" target="{{target | default('_blank', true)}}">{{ text }} {{icon}}</a>
 {%- endmacro %}

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -6,7 +6,11 @@
 {%- endmacro %}
 
 {% macro primaryButtonWithTracking(text, url, target, source, float_right=False) -%}
+    {% if plausible_domain %}
       <a class="{% if  float_right %} float-right {% endif %} btn btn-primary" href="{{ url }}" onclick="plausible('{{ url_target }}', {props: {method: '{{ source }}'}})">{{ text }}</a>
+    {% else %}
+        {{ primaryButton(text, url, float_right) }}
+    {% endif %}
 {%- endmacro %}
 
 {% macro primaryButtonWithIcon(text, url, icon, target) -%}

--- a/webapp/app/templates/content/landing_page.html
+++ b/webapp/app/templates/content/landing_page.html
@@ -68,7 +68,7 @@
                             <li class="mt-1">{{ _('landing.hero-list-item-3') }}</li>
                         </ul>
                         <p class="mt-4 font-weight-bold">{{ _('landing.hero-check-use-desc') }}</p>
-                        {{ components.primaryButton( text=_('landing.hero-check-use-button'), url=url_for('eligibility', step='first_input_step')) }}
+                        {{ components.primaryButtonWithTracking( text=_('landing.hero-check-use-button'), url=url_for('eligibility', step='first_input_step'), target=_('internal-linking.source.target.eligibility'), source=_('internal-linking.source.landing.cta')) }}
                     </div>
                         <div class="hero__inner_image">
                             <picture>

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-03-07 08:01+0000\n"
+"POT-Creation-Date: 2022-03-07 11:32+0100\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -3042,31 +3042,31 @@ msgstr ""
 "Bitte prüfen Sie die Steuer-Identifikationsnummer. Die Angabe muss mit "
 "der Nummer identisch sein, die Sie zum Anmelden eingegeben haben."
 
-#: app/templates/components.html:16
+#: app/templates/components.html:20
 msgid "form.lotse.summary-button-edit"
 msgstr "Ändern"
 
-#: app/templates/components.html:114 app/templates/components.html:122
+#: app/templates/components.html:118 app/templates/components.html:126
 msgid "form.optional"
 msgstr "optional"
 
-#: app/templates/components.html:139
+#: app/templates/components.html:143
 msgid "errors.warning-image.aria-label"
 msgstr "Fehlermeldung"
 
-#: app/templates/components.html:169
+#: app/templates/components.html:173
 msgid "plus.alt.text"
 msgstr "Plus-Zeichen"
 
-#: app/templates/components.html:172
+#: app/templates/components.html:176
 msgid "minus.alt.text"
 msgstr "Minus-Zeichen"
 
-#: app/templates/components.html:246
+#: app/templates/components.html:250
 msgid "button.help"
 msgstr "Weitere Informationen"
 
-#: app/templates/components.html:255
+#: app/templates/components.html:259
 msgid "button.close.aria-label"
 msgstr "Schließen"
 
@@ -5079,6 +5079,14 @@ msgstr "Möchten Sie wissen, ob Sie den Steuerlotsen nutzen können?"
 #: app/templates/content/landing_page.html:71
 msgid "landing.hero-check-use-button"
 msgstr "Jetzt prüfen"
+
+#: app/templates/content/landing_page.html:71
+msgid "internal-linking.source.target.eligibility"
+msgstr "Nutzung prüfen"
+
+#: app/templates/content/landing_page.html:71
+msgid "internal-linking.source.landing.cta"
+msgstr "Landingpage CTA"
 
 #: app/templates/content/landing_page.html:83
 msgid "landing.hero-image.alt-text"


### PR DESCRIPTION
# Short Description
We want to get more insights into the usage of the call to action button on the landing page. This follows [this Plausible tutorial](https://plausible.io/docs/internal-link-click-tracking) to implement exactly that. 

I added a separate component for that which allows us to set a primaryButton with a target and a source. This should allow us to re-use the plausible functionality at other places.

# Feedback
- What do you think about the separate component?
- Do you see anything else?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
