### PR TITLE
STL-2164 feat: configure plausible for eligibility registration

### DIFF
--- a/webapp/app/templates/eligibility/display_success.html
+++ b/webapp/app/templates/eligibility/display_success.html
@@ -39,6 +39,13 @@
     {% endif %}
 
     <div class="spacing-b-11 row m-0">
-        {{ components.primaryButton( text=_('form.eligibility.use-register-button'), url=url_for('unlock_code_request')) }}
+        {{ components.primaryButtonWithTracking(
+                text=_('form.eligibility.use-register-button'),
+                url=url_for('unlock_code_request'),
+                target=_('tracking.eligibility.success.goal'),
+                source=_('tracking.eligibility.success.method'),
+                plausible_domain_set=plausible_domain is not none
+                )
+        }}
     </div>
 {% endblock %}

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-04-06 18:54+0200\n"
+"POT-Creation-Date: 2022-04-11 10:42+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -5207,6 +5207,14 @@ msgstr "Bitte beachten Sie"
 #: app/templates/eligibility/display_success.html:42
 msgid "form.eligibility.use-register-button"
 msgstr "Registrieren"
+
+#: app/templates/eligibility/display_success.html:42
+msgid "tracking.eligibility.success.goal"
+msgstr "Registrierung"
+
+#: app/templates/eligibility/display_success.html:42
+msgid "tracking.eligibility.success.method"
+msgstr "Registrierung CTA positiv NP"
 
 #: app/templates/eligibility/form_marital_status_input.html:7
 msgid "eligibility.marital_status.widowed_note"

--- a/webapp/client/src/components/AnchorButton.test.js
+++ b/webapp/client/src/components/AnchorButton.test.js
@@ -12,7 +12,7 @@ function setup(optionalProps) {
   const utils = render(<AnchorButton {...REQUIRED_PROPS} {...optionalProps} />);
   const buttonText = screen.getByText("anchor text");
 
-  return { ...utils, buttonText };
+  return { ...utils, button: buttonText };
 }
 
 describe("AnchorButton", () => {
@@ -23,28 +23,28 @@ describe("AnchorButton", () => {
   });
 
   it("should have a href attribute", () => {
-    const { buttonText } = setup();
+    const { button } = setup();
 
-    expect(buttonText.closest("a")).toHaveAttribute(
+    expect(button.closest("a")).toHaveAttribute(
       "href",
       expect.stringContaining(REQUIRED_PROPS.url)
     );
   });
 
   it("should not have a download attribute if isDownloadLink is false", () => {
-    const { buttonText } = setup({
+    const { button } = setup({
       isDownloadLink: false,
     });
 
-    expect(buttonText.closest("a")).not.toHaveAttribute("download");
+    expect(button.closest("a")).not.toHaveAttribute("download");
   });
 
   it("should have a download attribute if isDownloadLink is true", () => {
-    const { buttonText } = setup({
+    const { button } = setup({
       isDownloadLink: true,
     });
 
-    expect(buttonText.closest("a")).toHaveAttribute("download");
+    expect(button.closest("a")).toHaveAttribute("download");
   });
 });
 
@@ -52,15 +52,15 @@ describe("AnchorButton with plausible", () => {
   const user = userEvent.setup();
 
   it("should call plausible with goal", async () => {
-    const { buttonText } = setup({
+    const { button } = setup({
       plausibleDomain: "domain/some/link/path",
       plausibleGoal: "plausible_goal",
     });
     const EXPECTED_PLAUSIBLE_GOAL = "plausible_goal";
 
-    window.plausible = jest.fn().mockReturnValue({ plausible: jest.fn() });
+    window.plausible = jest.fn();
 
-    await user.click(buttonText);
+    await user.click(button);
 
     expect(window.plausible).toHaveBeenCalledWith(EXPECTED_PLAUSIBLE_GOAL, {
       props: undefined,
@@ -68,17 +68,17 @@ describe("AnchorButton with plausible", () => {
   });
 
   it("should call plausible with goal and props", async () => {
-    const { buttonText } = setup({
+    const { button } = setup({
       plausibleDomain: "domain/some/link/path",
       plausibleGoal: "plausible_goal",
-      plausibleProps: { method: "unlockCodeSuccess" },
+      plausibleProps: { method: "plausible_props" },
     });
     const EXPECTED_PLAUSIBLE_GOAL = "plausible_goal";
-    const EXPECTED_PLAUSIBLE_PROPS = { props: { method: "unlockCodeSuccess" } };
+    const EXPECTED_PLAUSIBLE_PROPS = { props: { method: "plausible_props" } };
 
-    window.plausible = jest.fn().mockReturnValue({ plausible: jest.fn() });
+    window.plausible = jest.fn();
 
-    await user.click(buttonText);
+    await user.click(button);
 
     expect(window.plausible).toHaveBeenCalledWith(
       EXPECTED_PLAUSIBLE_GOAL,
@@ -87,11 +87,11 @@ describe("AnchorButton with plausible", () => {
   });
 
   it("should not call plausible without domain given", async () => {
-    const { buttonText } = setup();
+    const { button } = setup();
 
-    window.plausible = jest.fn().mockReturnValue({ plausible: jest.fn() });
+    window.plausible = jest.fn();
 
-    await user.click(buttonText);
+    await user.click(button);
 
     expect(window.plausible).not.toHaveBeenCalled();
   });

--- a/webapp/client/src/components/SecondaryAnchorButton.test.js
+++ b/webapp/client/src/components/SecondaryAnchorButton.test.js
@@ -58,7 +58,7 @@ describe("Secondary Button add plausible", () => {
   it("should run the plausible function on click button", async () => {
     const user = userEvent.setup();
 
-    window.plausible = jest.fn().mockReturnValue({ plausible: jest.fn() });
+    window.plausible = jest.fn();
     render(<SecondaryAnchorButton {...MOCK_PROPS} />);
 
     await user.click(screen.getByText(MOCK_PROPS.text));

--- a/webapp/client/src/pages/UnlockCodeSuccessPage.test.js
+++ b/webapp/client/src/pages/UnlockCodeSuccessPage.test.js
@@ -16,8 +16,9 @@ function setup(optionalProps) {
   const downloadAnchor = screen.getByText("Vorbereitungshilfe");
   const downloadButton = screen.getByText("Vorbereitungshilfe herunterladen");
   const zurueckButton = screen.getByText("Zurück");
+  const user = userEvent.setup();
 
-  return { ...utils, downloadAnchor, downloadButton, zurueckButton };
+  return { ...utils, downloadAnchor, downloadButton, zurueckButton, user };
 }
 
 describe("UnlockCodeSuccessPage", () => {
@@ -62,7 +63,7 @@ describe("UnlockCodeSuccessPage", () => {
   });
 
   it("should call plausible with name and props, when user clicks on download button", async () => {
-    const { downloadButton } = setup({
+    const { downloadButton, user } = setup({
       plausibleDomain: "http://localhost:3000",
     });
 
@@ -73,7 +74,7 @@ describe("UnlockCodeSuccessPage", () => {
 
     window.plausible = jest.fn();
 
-    await userEvent.click(downloadButton);
+    await user.click(downloadButton);
 
     expect(window.plausible).toHaveBeenCalledWith(
       EXPECTED_PLAUSIBLE_GOAL,
@@ -82,7 +83,7 @@ describe("UnlockCodeSuccessPage", () => {
   });
 
   it("should call plausible with name and props, when user clicks on download link", async () => {
-    const { downloadAnchor } = setup({
+    const { downloadAnchor, user } = setup({
       plausibleDomain: "http://localhost:3000",
     });
 
@@ -93,7 +94,7 @@ describe("UnlockCodeSuccessPage", () => {
 
     window.plausible = jest.fn();
 
-    await userEvent.click(downloadAnchor);
+    await user.click(downloadAnchor);
 
     expect(window.plausible).toHaveBeenCalledWith(
       EXPECTED_PLAUSIBLE_GOAL,
@@ -102,15 +103,15 @@ describe("UnlockCodeSuccessPage", () => {
   });
 
   it("should not call plausible if no plausible domain given", async () => {
-    const { downloadButton, downloadAnchor } = setup();
+    const { downloadButton, downloadAnchor, user } = setup();
 
     window.plausible = jest.fn();
 
-    await userEvent.click(downloadButton);
+    await user.click(downloadButton);
 
     expect(window.plausible).not.toHaveBeenCalled();
 
-    await userEvent.click(downloadAnchor);
+    await user.click(downloadAnchor);
 
     expect(window.plausible).not.toHaveBeenCalled();
   });

--- a/webapp/client/src/pages/UnlockCodeSuccessPage.test.js
+++ b/webapp/client/src/pages/UnlockCodeSuccessPage.test.js
@@ -71,7 +71,7 @@ describe("UnlockCodeSuccessPage", () => {
       props: { method: "CTA Vorbereitungshilfe herunterladen" },
     };
 
-    window.plausible = jest.fn().mockReturnValue({ plausible: jest.fn() });
+    window.plausible = jest.fn();
 
     await userEvent.click(downloadButton);
 
@@ -91,7 +91,7 @@ describe("UnlockCodeSuccessPage", () => {
       props: { method: "CTA Vorbereitungshilfe" },
     };
 
-    window.plausible = jest.fn().mockReturnValue({ plausible: jest.fn() });
+    window.plausible = jest.fn();
 
     await userEvent.click(downloadAnchor);
 
@@ -104,7 +104,7 @@ describe("UnlockCodeSuccessPage", () => {
   it("should not call plausible if no plausible domain given", async () => {
     const { downloadButton, downloadAnchor } = setup();
 
-    window.plausible = jest.fn().mockReturnValue({ plausible: jest.fn() });
+    window.plausible = jest.fn();
 
     await userEvent.click(downloadButton);
 


### PR DESCRIPTION
# Short Description
- configure plausible for eligibility registration

# Changes
- add goals and props to eligibility success registration button
- rename variable buttonText to button in anchor button test
- remove unnecessary mockReturnValue from window.plausible

# Feedback

- any

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
