### PR TITLE
STL-2162 feat: configure plausible for goal zurueck zur uebersicht

### DIFF
--- a/webapp/app/forms/steps/lotse/fahrtkostenpauschale.py
+++ b/webapp/app/forms/steps/lotse/fahrtkostenpauschale.py
@@ -18,6 +18,7 @@ from app.forms.steps.lotse.lotse_step import LotseFormSteuerlotseStep
 from app.model.disability_data import DisabilityModel
 from app.templates.react_template import render_react_template
 
+from app.config import Config
 
 def calculate_fahrtkostenpauschale(has_pflegegrad: str = None, disability_degree: int = None,
                                    has_merkzeichen_bl: bool = False, has_merkzeichen_tbl: bool = False,
@@ -128,7 +129,8 @@ class StepFahrtkostenpauschalePersonA(StepFahrtkostenpauschale):
             },
             fahrtkostenpauschale_amount=self.get_fahrtkostenpauschale(self.stored_data),
             fields=form_fields_dict(self.render_info.form),
-            prev_url=self.render_info.prev_url
+            prev_url=self.render_info.prev_url,
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='FahrtkostenpauschalePersonAPage',
@@ -181,7 +183,8 @@ class StepFahrtkostenpauschalePersonB(StepFahrtkostenpauschale):
             },
             fahrtkostenpauschale_amount=self.get_fahrtkostenpauschale(self.stored_data),
             fields=form_fields_dict(self.render_info.form),
-            prev_url=self.render_info.prev_url
+            prev_url=self.render_info.prev_url,
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='FahrtkostenpauschalePersonBPage',

--- a/webapp/app/forms/steps/lotse/has_disability.py
+++ b/webapp/app/forms/steps/lotse/has_disability.py
@@ -15,6 +15,8 @@ from app.model.components import HasDisabilityPersonBProps, HasDisabilityPersonA
 from app.model.components.helpers import form_fields_dict
 from app.templates.react_template import render_react_template
 
+from app.config import Config
+
 
 class StepDisabilityPersonB(LotseFormSteuerlotseStep):
     name = 'has_disability_person_b'
@@ -43,7 +45,8 @@ class StepDisabilityPersonB(LotseFormSteuerlotseStep):
                 'show_overview_button': bool(self.render_info.overview_url),
             },
             fields=form_fields_dict(self.render_info.form),
-            prev_url=self.render_info.prev_url
+            prev_url=self.render_info.prev_url,
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='HasDisabilityPersonBPage',
@@ -80,7 +83,8 @@ class StepDisabilityPersonA(LotseFormSteuerlotseStep):
             },
             num_users=get_number_of_users(self.stored_data),
             fields=form_fields_dict(self.render_info.form),
-            prev_url=self.render_info.prev_url
+            prev_url=self.render_info.prev_url,
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='HasDisabilityPersonAPage',

--- a/webapp/app/forms/steps/lotse/merkzeichen.py
+++ b/webapp/app/forms/steps/lotse/merkzeichen.py
@@ -19,6 +19,8 @@ from app.model.components import MerkzeichenProps
 from app.model.components.helpers import form_fields_dict
 from app.templates.react_template import render_react_template
 
+from app.config import Config
+
 
 class StepMerkzeichenPersonA(LotseFormSteuerlotseStep):
     name = 'merkzeichen_person_a'
@@ -99,6 +101,7 @@ class StepMerkzeichenPersonA(LotseFormSteuerlotseStep):
             },
             fields=form_fields_dict(self.render_info.form),
             prev_url=self.render_info.prev_url,
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='MerkzeichenPersonAPage',
@@ -172,6 +175,7 @@ class StepMerkzeichenPersonB(LotseFormSteuerlotseStep):
             },
             fields=form_fields_dict(self.render_info.form),
             prev_url=self.render_info.prev_url,
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='MerkzeichenPersonBPage',

--- a/webapp/app/forms/steps/lotse/pauschbetrag.py
+++ b/webapp/app/forms/steps/lotse/pauschbetrag.py
@@ -17,6 +17,8 @@ from app.forms.steps.lotse.has_disability import HasDisabilityPersonAPreconditio
 from app.model.disability_data import DisabilityModel
 from app.templates.react_template import render_react_template
 
+from app.config import Config
+
 
 def calculate_pauschbetrag(has_pflegegrad=None, disability_degree=None, has_merkzeichen_bl=False,
                            has_merkzeichen_tbl=False, has_merkzeichen_h=False):
@@ -139,7 +141,8 @@ class StepPauschbetragPersonA(LotseFormSteuerlotseStep):
             },
             pauschbetrag=self.get_pauschbetrag(self.stored_data),
             fields=form_fields_dict(self.render_info.form),
-            prev_url=self.render_info.prev_url
+            prev_url=self.render_info.prev_url,
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='PauschbetragPersonAPage',
@@ -201,7 +204,8 @@ class StepPauschbetragPersonB(LotseFormSteuerlotseStep):
             },
             pauschbetrag=self.get_pauschbetrag(self.stored_data),
             fields=form_fields_dict(self.render_info.form),
-            prev_url=self.render_info.prev_url
+            prev_url=self.render_info.prev_url,
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='PauschbetragPersonBPage',

--- a/webapp/app/forms/steps/lotse/personal_data.py
+++ b/webapp/app/forms/steps/lotse/personal_data.py
@@ -25,6 +25,8 @@ from app.model.components.helpers import form_fields_dict
 from app.model.form_data import show_person_b, FamilienstandModel, JointTaxesModel
 from app.templates.react_template import render_react_template
 
+from app.config import Config
+
 
 class StepSteuernummer(LotseFormSteuerlotseStep):
     name = 'steuernummer'
@@ -163,7 +165,8 @@ class StepSteuernummer(LotseFormSteuerlotseStep):
             fields=form_fields_dict(self.render_info.form),
             prev_url=self.render_info.prev_url,
             tax_office_list=self.render_info.form.tax_offices,
-            number_of_users=2 if show_person_b(self.stored_data) else 1
+            number_of_users=2 if show_person_b(self.stored_data) else 1,
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='TaxNumberPage',
@@ -388,6 +391,7 @@ class StepTelephoneNumber(LotseFormSteuerlotseStep):
             },
             fields=form_fields_dict(self.render_info.form),
             prev_url=self.render_info.prev_url,
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='TelephoneNumberPage',

--- a/webapp/app/forms/steps/lotse/steuerminderungen.py
+++ b/webapp/app/forms/steps/lotse/steuerminderungen.py
@@ -20,6 +20,8 @@ from app.model.components.helpers import form_fields_dict
 from app.model.form_data import FamilienstandModel, JointTaxesModel
 from app.templates.react_template import render_react_template
 
+from app.config import Config
+
 
 class StepSelectStmind(LotseFormSteuerlotseStep):
     name = 'select_stmind'
@@ -62,7 +64,8 @@ class StepSelectStmind(LotseFormSteuerlotseStep):
                 'show_overview_button': bool(self.render_info.overview_url)
             },
             fields=form_fields_dict(self.render_info.form),
-            prev_url=self.render_info.prev_url
+            prev_url=self.render_info.prev_url,
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='StmindSelectionPage',

--- a/webapp/app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py
+++ b/webapp/app/forms/steps/lotse_multistep_flow_steps/declaration_steps.py
@@ -12,6 +12,8 @@ from app.model.components import DeclarationIncomesProps, DeclarationEDatenProps
 from app.model.components.helpers import form_fields_dict
 from app.templates.react_template import render_react_template
 
+from app.config import Config
+
 
 class StepDeclarationIncomes(FormStep):
     name = 'decl_incomes'
@@ -44,6 +46,7 @@ class StepDeclarationIncomes(FormStep):
                 'show_overview_button': bool(render_info.overview_url),
             },
             fields=form_fields_dict(render_info.form),
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='DeclarationIncomesPage',
@@ -85,6 +88,7 @@ class StepDeclarationEdaten(FormStep):
             },
             prev_url=render_info.prev_url,
             fields=form_fields_dict(render_info.form),
+            plausible_domain=Config.PLAUSIBLE_DOMAIN
         ).camelized_dict()
 
         return render_react_template(component='DeclarationEDatenPage',

--- a/webapp/app/model/components/__init__.py
+++ b/webapp/app/model/components/__init__.py
@@ -92,11 +92,10 @@ class RegistrationProps(StepFormProps):
     data_privacy_link: str
 
 
-class UnlockCodeSuccessProps(ComponentProps):
+class UnlockCodeSuccessProps(ComponentProps, ComponentPlausibleProps):
     prev_url: Optional[str]
     steuer_erklaerung_link: str
     vorbereitungs_hilfe_link: str
-    plausible_domain: Optional[str]
 
 
 class UnlockCodeFailureProps(ComponentProps):
@@ -115,11 +114,11 @@ class RevocationFailureProps(ComponentProps):
     prev_url: Optional[str]
 
 
-class DeclarationIncomesProps(StepFormProps):
+class DeclarationIncomesProps(StepFormProps, ComponentPlausibleProps):
     pass
 
 
-class DeclarationEDatenProps(StepFormProps):
+class DeclarationEDatenProps(StepFormProps, ComponentPlausibleProps):
     prev_url: str
 
 
@@ -139,24 +138,24 @@ class FilingFailureProps(ComponentProps):
     error_details: List[str]
 
 
-class TaxNumberStepFormProps(StepFormProps):
+class TaxNumberStepFormProps(StepFormProps, ComponentPlausibleProps):
     tax_office_list: List[Dict]
     number_of_users: int
 
 
-class HasDisabilityPersonAProps(StepFormProps):
+class HasDisabilityPersonAProps(StepFormProps, ComponentPlausibleProps):
     num_users: int
 
 
-class HasDisabilityPersonBProps(StepFormProps):
+class HasDisabilityPersonBProps(StepFormProps, ComponentPlausibleProps):
     pass
 
 
-class MerkzeichenProps(StepFormProps):
+class MerkzeichenProps(StepFormProps, ComponentPlausibleProps):
     pass
 
 
-class PauschbetragProps(StepFormProps):
+class PauschbetragProps(StepFormProps, ComponentPlausibleProps):
     pauschbetrag: str
 
 
@@ -165,15 +164,15 @@ class NoPauschbetragProps(StepDisplayProps):
     overviewUrl: str
 
 
-class FahrtkostenpauschaleProps(StepFormProps):
+class FahrtkostenpauschaleProps(StepFormProps, ComponentPlausibleProps):
     fahrtkostenpauschale_amount: int
 
 
-class TelephoneNumberProps(StepFormProps):
+class TelephoneNumberProps(StepFormProps, ComponentPlausibleProps):
     pass
 
 
-class SelectStMindProps(StepFormProps):
+class SelectStMindProps(StepFormProps, ComponentPlausibleProps):
     pass
 
 

--- a/webapp/app/model/components/__init__.py
+++ b/webapp/app/model/components/__init__.py
@@ -19,7 +19,8 @@ class FormProps(ComponentProps):
     csrf_token: str
     show_overview_button: bool
     next_button_label: Optional[str]
-    
+
+
 class ComponentPlausibleProps(ComponentProps):
     plausible_domain: Optional[str]
 
@@ -92,10 +93,11 @@ class RegistrationProps(StepFormProps):
     data_privacy_link: str
 
 
-class UnlockCodeSuccessProps(ComponentProps, ComponentPlausibleProps):
+class UnlockCodeSuccessProps(ComponentProps):
     prev_url: Optional[str]
     steuer_erklaerung_link: str
     vorbereitungs_hilfe_link: str
+    plausible_domain: Optional[str]
 
 
 class UnlockCodeFailureProps(ComponentProps):
@@ -114,12 +116,13 @@ class RevocationFailureProps(ComponentProps):
     prev_url: Optional[str]
 
 
-class DeclarationIncomesProps(StepFormProps, ComponentPlausibleProps):
-    pass
+class DeclarationIncomesProps(StepFormProps):
+    plausible_domain: Optional[str]
 
 
-class DeclarationEDatenProps(StepFormProps, ComponentPlausibleProps):
+class DeclarationEDatenProps(StepFormProps):
     prev_url: str
+    plausible_domain: Optional[str]
 
 
 class ConfirmationProps(StepFormProps):
@@ -138,25 +141,28 @@ class FilingFailureProps(ComponentProps):
     error_details: List[str]
 
 
-class TaxNumberStepFormProps(StepFormProps, ComponentPlausibleProps):
+class TaxNumberStepFormProps(StepFormProps):
     tax_office_list: List[Dict]
     number_of_users: int
+    plausible_domain: Optional[str]
 
 
-class HasDisabilityPersonAProps(StepFormProps, ComponentPlausibleProps):
+class HasDisabilityPersonAProps(StepFormProps):
     num_users: int
+    plausible_domain: Optional[str]
 
 
-class HasDisabilityPersonBProps(StepFormProps, ComponentPlausibleProps):
-    pass
+class HasDisabilityPersonBProps(StepFormProps):
+    plausible_domain: Optional[str]
 
 
-class MerkzeichenProps(StepFormProps, ComponentPlausibleProps):
-    pass
+class MerkzeichenProps(StepFormProps):
+    plausible_domain: Optional[str]
 
 
-class PauschbetragProps(StepFormProps, ComponentPlausibleProps):
+class PauschbetragProps(StepFormProps):
     pauschbetrag: str
+    plausible_domain: Optional[str]
 
 
 class NoPauschbetragProps(StepDisplayProps):
@@ -164,16 +170,17 @@ class NoPauschbetragProps(StepDisplayProps):
     overviewUrl: str
 
 
-class FahrtkostenpauschaleProps(StepFormProps, ComponentPlausibleProps):
+class FahrtkostenpauschaleProps(StepFormProps):
     fahrtkostenpauschale_amount: int
+    plausible_domain: Optional[str]
 
 
-class TelephoneNumberProps(StepFormProps, ComponentPlausibleProps):
-    pass
+class TelephoneNumberProps(StepFormProps):
+    plausible_domain: Optional[str]
 
 
-class SelectStMindProps(StepFormProps, ComponentPlausibleProps):
-    pass
+class SelectStMindProps(StepFormProps):
+    plausible_domain: Optional[str]
 
 
 class StepSessionNoteProps(ComponentProps):
@@ -185,8 +192,10 @@ class StepSubmitAcknowledgeProps(ComponentPlausibleProps):
     prev_url: str
     logout_url: str
 
+
 class InfoTaxReturnForPensionersProps(ComponentPlausibleProps):
     pass
+
 
 class AmbassadorInfoMaterialProps(ComponentPlausibleProps):
     pass

--- a/webapp/client/src/components/AnchorButton.test.js
+++ b/webapp/client/src/components/AnchorButton.test.js
@@ -11,8 +11,9 @@ const REQUIRED_PROPS = {
 function setup(optionalProps) {
   const utils = render(<AnchorButton {...REQUIRED_PROPS} {...optionalProps} />);
   const buttonText = screen.getByText("anchor text");
+  const user = userEvent.setup();
 
-  return { ...utils, button: buttonText };
+  return { ...utils, button: buttonText, user };
 }
 
 describe("AnchorButton", () => {
@@ -49,10 +50,8 @@ describe("AnchorButton", () => {
 });
 
 describe("AnchorButton with plausible", () => {
-  const user = userEvent.setup();
-
   it("should call plausible with goal", async () => {
-    const { button } = setup({
+    const { button, user } = setup({
       plausibleDomain: "domain/some/link/path",
       plausibleGoal: "plausible_goal",
     });
@@ -68,7 +67,7 @@ describe("AnchorButton with plausible", () => {
   });
 
   it("should call plausible with goal and props", async () => {
-    const { button } = setup({
+    const { button, user } = setup({
       plausibleDomain: "domain/some/link/path",
       plausibleGoal: "plausible_goal",
       plausibleProps: { method: "plausible_props" },
@@ -87,7 +86,7 @@ describe("AnchorButton with plausible", () => {
   });
 
   it("should not call plausible without domain given", async () => {
-    const { button } = setup();
+    const { button, user } = setup();
 
     window.plausible = jest.fn();
 

--- a/webapp/client/src/components/StepForm.js
+++ b/webapp/client/src/components/StepForm.js
@@ -45,7 +45,4 @@ StepForm.propTypes = {
 
 StepForm.defaultProps = {
   ...StepNavButtons.defaultProps,
-  plausibleGoal: null,
-  plausibleProps: undefined,
-  plausibleDomain: null,
 };

--- a/webapp/client/src/components/StepForm.js
+++ b/webapp/client/src/components/StepForm.js
@@ -8,6 +8,9 @@ export default function StepForm({
   explanatoryButtonText,
   showOverviewButton,
   nextButtonLabel,
+  plausibleGoal,
+  plausibleDomain,
+  plausibleProps,
 }) {
   return (
     <form noValidate method="POST" action={action}>
@@ -17,6 +20,9 @@ export default function StepForm({
         explanatoryButtonText={explanatoryButtonText}
         showOverviewButton={showOverviewButton}
         nextButtonLabel={nextButtonLabel}
+        plausibleGoal={plausibleGoal}
+        plausibleDomain={plausibleDomain}
+        plausibleProps={plausibleProps}
       />
     </form>
   );
@@ -32,8 +38,14 @@ StepForm.propTypes = {
     PropTypes.element,
   ]),
   nextButtonLabel: PropTypes.string,
+  plausibleGoal: PropTypes.string,
+  plausibleProps: PropTypes.shape({ method: PropTypes.string }),
+  plausibleDomain: PropTypes.string,
 };
 
 StepForm.defaultProps = {
   ...StepNavButtons.defaultProps,
+  plausibleGoal: null,
+  plausibleProps: undefined,
+  plausibleDomain: null,
 };

--- a/webapp/client/src/components/StepNavButtons.js
+++ b/webapp/client/src/components/StepNavButtons.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import styled, { css } from "styled-components";
+import addPlausibleGoal from "../lib/helpers";
 
 const Row = styled.div`
   margin-top: var(--spacing-09);
@@ -155,11 +156,16 @@ export default function StepNavButtons({
   nextButtonLabel,
   nextUrl,
   isForm,
+  plausibleGoal,
+  plausibleDomain,
+  plausibleProps,
 }) {
   const { t } = useTranslation();
-
   const overviewLabel = t("form.backToOverview");
   const nextLabel = nextButtonLabel || t("form.next");
+  const handleClick = () => {
+    addPlausibleGoal(plausibleDomain, plausibleGoal, { props: plausibleProps });
+  };
 
   return (
     <Row className="form-row">
@@ -168,6 +174,7 @@ export default function StepNavButtons({
           type="submit"
           className="btn mr-2"
           name="overview_button"
+          onClick={handleClick}
         >
           {overviewLabel}
         </OutlineButton>
@@ -178,6 +185,7 @@ export default function StepNavButtons({
           href={overviewUrl}
           className="btn mr-2"
           name="overview_link"
+          onClick={handleClick}
         >
           {overviewLabel}
         </OutlineLink>
@@ -211,6 +219,9 @@ StepNavButtons.propTypes = {
   ]),
   nextUrl: PropTypes.string,
   isForm: PropTypes.bool,
+  plausibleGoal: PropTypes.string,
+  plausibleProps: PropTypes.shape({ method: PropTypes.string }),
+  plausibleDomain: PropTypes.string,
 };
 
 StepNavButtons.defaultProps = {
@@ -220,4 +231,7 @@ StepNavButtons.defaultProps = {
   explanatoryButtonText: undefined,
   nextUrl: undefined,
   isForm: true,
+  plausibleGoal: "Zurück zur Übersicht",
+  plausibleProps: undefined,
+  plausibleDomain: null,
 };

--- a/webapp/client/src/components/StepNavButtons.test.js
+++ b/webapp/client/src/components/StepNavButtons.test.js
@@ -1,49 +1,118 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import StepNavButtons from "./StepNavButtons";
 
-describe("a StepNavButtons without props", () => {
-  beforeEach(() => {
-    render(<StepNavButtons />);
+function setup(optionalProps) {
+  const utils = render(<StepNavButtons {...optionalProps} />);
+  const user = userEvent.setup();
+
+  return { ...utils, user };
+}
+
+describe("StepNavButtons", () => {
+  it("should render a button with the default button text", () => {
+    setup();
+
+    expect(screen.getByText(/Weiter/)).toBeInTheDocument();
+    expect(screen.getByText(/Weiter/).tagName).toEqual("BUTTON");
   });
 
-  it("should render a button with the default button text", () => {
-    expect(screen.getByText("Weiter")).toBeInTheDocument();
-    expect(screen.getByText("Weiter").tagName).toEqual("BUTTON");
+  it("should render a button with a custom button text", () => {
+    setup({
+      nextButtonLabel: "neeeeeext",
+    });
+
+    expect(screen.getByText(/neeeeeext/)).toBeInTheDocument();
+    expect(screen.queryByText(/Weiter/)).not.toBeInTheDocument();
   });
 
   it("should not render an overview link", () => {
-    expect(screen.queryByText("Zurück zur Übersicht")).not.toBeInTheDocument();
-  });
-});
+    setup();
 
-describe("a StepNavButtons with a nextButtonLabel", () => {
-  beforeEach(() => {
-    render(<StepNavButtons nextButtonLabel="neeeeeext" />);
+    expect(screen.queryByText(/Zurück zur Übersicht/)).not.toBeInTheDocument();
   });
 
-  it("should render a button with the custom button text", () => {
-    expect(screen.getByText("neeeeeext")).toBeInTheDocument();
-  });
-});
+  it("should render a button to go to the overview if showOverviewButton is true", () => {
+    setup({
+      showOverviewButton: true,
+    });
 
-describe("a StepNavButtons with an overview button", () => {
-  beforeEach(() => {
-    render(<StepNavButtons showOverviewButton />);
-  });
-
-  it("should render a button to go to the overview", () => {
-    expect(screen.getByText("Zurück zur Übersicht")).toBeInTheDocument();
-    expect(screen.getByText("Zurück zur Übersicht").tagName).toEqual("BUTTON");
-  });
-});
-
-describe("a StepNavButtons with an explanatoryButtonText", () => {
-  beforeEach(() => {
-    render(<StepNavButtons explanatoryButtonText="some text" />);
+    expect(screen.getByText(/Zurück zur Übersicht/)).toBeInTheDocument();
+    expect(screen.getByText(/Zurück zur Übersicht/).tagName).toEqual("BUTTON");
   });
 
-  it("should render the explanatory button text", () => {
+  it("should not call plausible on showOverviewButton click without domain given", async () => {
+    const { user } = setup({
+      showOverviewButton: true,
+      plausibleGoal: "plausible_goal",
+    });
+
+    window.plausible = jest.fn();
+
+    await user.click(screen.getByText(/Zurück zur Übersicht/));
+
+    expect(window.plausible).not.toHaveBeenCalled();
+  });
+
+  it("should call plausible on showOverviewButton click with default goal", async () => {
+    const { user } = setup({
+      showOverviewButton: true,
+      plausibleDomain: "domain/some/link/path",
+    });
+    const EXPECTED_PLAUSIBLE_GOAL = "Zurück zur Übersicht";
+
+    window.plausible = jest.fn();
+
+    await user.click(screen.getByText(/Zurück zur Übersicht/));
+
+    expect(window.plausible).toHaveBeenCalledWith(EXPECTED_PLAUSIBLE_GOAL, {
+      props: undefined,
+    });
+  });
+
+  it("should call plausible on showOverviewButton click with custom goal", async () => {
+    const { user } = setup({
+      showOverviewButton: true,
+      plausibleDomain: "domain/some/link/path",
+      plausibleGoal: "plausible_goal",
+    });
+    const EXPECTED_PLAUSIBLE_GOAL = "plausible_goal";
+
+    window.plausible = jest.fn();
+
+    await user.click(screen.getByText(/Zurück zur Übersicht/));
+
+    expect(window.plausible).toHaveBeenCalledWith(EXPECTED_PLAUSIBLE_GOAL, {
+      props: undefined,
+    });
+  });
+
+  it("should call plausible on showOverviewButton click with goal and props", async () => {
+    const { user } = setup({
+      showOverviewButton: true,
+      plausibleDomain: "domain/some/link/path",
+      plausibleGoal: "plausible_goal",
+      plausibleProps: { method: "plausible_props" },
+    });
+    const EXPECTED_PLAUSIBLE_GOAL = "plausible_goal";
+    const EXPECTED_PLAUSIBLE_PROPS = { props: { method: "plausible_props" } };
+
+    window.plausible = jest.fn();
+
+    await user.click(screen.getByText(/Zurück zur Übersicht/));
+
+    expect(window.plausible).toHaveBeenCalledWith(
+      EXPECTED_PLAUSIBLE_GOAL,
+      EXPECTED_PLAUSIBLE_PROPS
+    );
+  });
+
+  it("should render an explanatory button text", () => {
+    setup({
+      explanatoryButtonText: "some text",
+    });
+
     expect(screen.getByText(/some text/)).toBeInTheDocument();
   });
 });

--- a/webapp/client/src/lib/submitFormTestHelper.js
+++ b/webapp/client/src/lib/submitFormTestHelper.js
@@ -1,0 +1,18 @@
+export default function avoidSubmitForm() {
+  let emit;
+
+  beforeAll(() => {
+    // eslint-disable-next-line no-underscore-dangle
+    ({ emit } = window._virtualConsole);
+  });
+
+  beforeEach(() => {
+    // eslint-disable-next-line no-underscore-dangle
+    window._virtualConsole.emit = jest.fn();
+  });
+
+  afterAll(() => {
+    // eslint-disable-next-line no-underscore-dangle
+    window._virtualConsole.emit = emit;
+  });
+}

--- a/webapp/client/src/pages/DeclarationEDatenPage.js
+++ b/webapp/client/src/pages/DeclarationEDatenPage.js
@@ -12,8 +12,10 @@ export default function DeclarationEDatenPage({
   form,
   fields,
   prevUrl,
+  plausibleDomain,
 }) {
   const { t } = useTranslation();
+  const plausibleProps = { method: "CTA Übernahme vorliegender Daten" };
 
   return (
     <>
@@ -25,7 +27,11 @@ export default function DeclarationEDatenPage({
           t("lotse.declarationEdaten.intro2"),
         ]}
       />
-      <StepForm {...form}>
+      <StepForm
+        plausibleDomain={plausibleDomain}
+        plausibleProps={plausibleProps}
+        {...form}
+      >
         <FormFieldConsentBox
           autofocus
           required
@@ -54,4 +60,9 @@ DeclarationEDatenPage.propTypes = {
     declarationEdaten: checkboxPropType,
   }).isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+DeclarationEDatenPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/DeclarationEDatenPage.test.js
+++ b/webapp/client/src/pages/DeclarationEDatenPage.test.js
@@ -1,8 +1,9 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import { configure } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
 import DeclarationEDatenPage from "./DeclarationEDatenPage";
-import { Default as StepFormDefault } from "../stories/StepForm.stories";
+import avoidSubmitForm from "../lib/submitFormTestHelper";
 
 configure({ testIdAttribute: "id" });
 
@@ -11,7 +12,8 @@ const defaultProps = {
     title: "Title",
   },
   form: {
-    ...StepFormDefault.args,
+    action: "#form-submit",
+    csrfToken: "abc123imacsrftoken",
   },
   fields: {
     declarationEdaten: {
@@ -22,72 +24,99 @@ const defaultProps = {
   prevUrl: "/some/prev/path",
 };
 
-describe("DeclarationEDatenPage default", () => {
-  beforeEach(() => {
-    render(<DeclarationEDatenPage {...defaultProps} />);
-  });
+function setup(optionalProps) {
+  const utils = render(
+    <DeclarationEDatenPage {...defaultProps} {...optionalProps} />
+  );
+  const user = userEvent.setup();
+
+  return { ...utils, user };
+}
+
+describe("DeclarationEDatenPage", () => {
+  avoidSubmitForm();
 
   it("should render step title text", () => {
+    setup();
+
     expect(screen.getByText("Title")).toBeInTheDocument();
   });
 
   it("should render back button", () => {
+    setup();
+
     expect(screen.getByText("Zurück")).toBeInTheDocument();
   });
 
   it("should render checked value false", () => {
+    setup();
+
     expect(screen.getByTestId("declaration_edaten").checked).toBe(false);
-  });
-});
-
-const checkedProps = {
-  stepHeader: {
-    title: "title",
-  },
-  form: {
-    ...StepFormDefault.args,
-  },
-  fields: {
-    declarationEdaten: {
-      checked: true,
-      errors: [],
-    },
-  },
-  prevUrl: "/some/prev/path",
-};
-
-describe("With checked checkbox", () => {
-  beforeEach(() => {
-    render(<DeclarationEDatenPage {...checkedProps} />);
   });
 
   it("should render checked value true", () => {
+    setup({
+      fields: {
+        declarationEdaten: {
+          checked: true,
+          errors: [],
+        },
+      },
+    });
+
     expect(screen.getByTestId("declaration_edaten").checked).toBe(true);
-  });
-});
-
-const errorProps = {
-  stepHeader: {
-    title: "title",
-  },
-  form: {
-    ...StepFormDefault.args,
-  },
-  fields: {
-    declarationEdaten: {
-      checked: false,
-      errors: ["Error1"],
-    },
-  },
-  prevUrl: "/some/prev/path",
-};
-
-describe("With error value", () => {
-  beforeEach(() => {
-    render(<DeclarationEDatenPage {...errorProps} />);
   });
 
   it("should render error value", () => {
+    setup({
+      fields: {
+        declarationEdaten: {
+          checked: false,
+          errors: ["Error1"],
+        },
+      },
+    });
+
     expect(screen.getByText("Error1")).toBeInTheDocument();
+  });
+
+  it("should call plausible on showOverviewButton click with default goal", async () => {
+    const { user } = setup({
+      form: {
+        action: "#form-submit",
+        csrfToken: "abc123imacsrftoken",
+        showOverviewButton: true,
+      },
+      plausibleDomain: "domain/some/link/path",
+    });
+    const EXPECTED_PLAUSIBLE_GOAL = "Zurück zur Übersicht";
+    const EXPECTED_PLAUSIBLE_PROPS = {
+      props: { method: "CTA Übernahme vorliegender Daten" },
+    };
+
+    window.plausible = jest.fn();
+
+    await user.click(screen.getByText(/Zurück zur Übersicht/));
+
+    expect(window.plausible).toHaveBeenCalledWith(
+      EXPECTED_PLAUSIBLE_GOAL,
+      EXPECTED_PLAUSIBLE_PROPS
+    );
+  });
+
+  it("should not call plausible if no plausible domain given", async () => {
+    const { user } = setup({
+      form: {
+        action: "#form-submit",
+        csrfToken: "abc123imacsrftoken",
+        showOverviewButton: true,
+      },
+    });
+
+    window.plausible = jest.fn();
+
+    await user.click(screen.getByText(/Zurück zur Übersicht/));
+
+    expect(window.plausible).not.toHaveBeenCalled();
   });
 });

--- a/webapp/client/src/pages/DeclarationEDatenPage.test.js
+++ b/webapp/client/src/pages/DeclarationEDatenPage.test.js
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { configure } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import DeclarationEDatenPage from "./DeclarationEDatenPage";
-import avoidSubmitForm from "../lib/submitFormTestHelper";
+import avoidNotImplementedFormSubmitError from "../test-helper/submitFormTestHelper";
 
 configure({ testIdAttribute: "id" });
 
@@ -34,7 +34,7 @@ function setup(optionalProps) {
 }
 
 describe("DeclarationEDatenPage", () => {
-  avoidSubmitForm();
+  avoidNotImplementedFormSubmitError();
 
   it("should render step title text", () => {
     setup();

--- a/webapp/client/src/pages/DeclarationIncomesPage.js
+++ b/webapp/client/src/pages/DeclarationIncomesPage.js
@@ -26,8 +26,14 @@ const IntroList = styled.ul`
   }
 `;
 
-export default function DeclarationIncomesPage({ stepHeader, form, fields }) {
+export default function DeclarationIncomesPage({
+  stepHeader,
+  form,
+  fields,
+  plausibleDomain,
+}) {
   const { t } = useTranslation();
+  const plausibleProps = { method: "CTA Eingabe zu weiteren Einkünften" };
 
   return (
     <>
@@ -38,7 +44,11 @@ export default function DeclarationIncomesPage({ stepHeader, form, fields }) {
         <li>{t("lotse.declarationIncomes.listItem2")}</li>
         <li>{t("lotse.declarationIncomes.listItem3")}</li>
       </IntroList>
-      <StepForm {...form}>
+      <StepForm
+        plausibleDomain={plausibleDomain}
+        plausibleProps={plausibleProps}
+        {...form}
+      >
         <FormFieldConsentBox
           autofocus
           required
@@ -67,4 +77,9 @@ DeclarationIncomesPage.propTypes = {
   fields: PropTypes.exact({
     declarationIncomes: checkboxPropType,
   }).isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+DeclarationIncomesPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/FahrtkostenpauschalePage.js
+++ b/webapp/client/src/pages/FahrtkostenpauschalePage.js
@@ -17,6 +17,8 @@ export default function FahrtkostenpauschalePage({
   fields,
   prevUrl,
   fahrtkostenpauschaleAmount,
+  plausibleDomain,
+  plausibleProps,
 }) {
   const { t } = useTranslation();
 
@@ -44,7 +46,11 @@ export default function FahrtkostenpauschalePage({
           components={{ bold: <b /> }}
         />
       </DetailsSeparated>
-      <StepForm {...form}>
+      <StepForm
+        plausibleDomain={plausibleDomain}
+        plausibleProps={plausibleProps}
+        {...form}
+      >
         <FormFieldRadioGroup
           fieldName={fields.requestsFahrtkostenpauschale.name}
           fieldId={fields.requestsFahrtkostenpauschale.name}
@@ -83,4 +89,11 @@ FahrtkostenpauschalePage.propTypes = {
   }).isRequired,
   fahrtkostenpauschaleAmount: PropTypes.string.isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleProps: PropTypes.shape({ method: PropTypes.string }),
+  plausibleDomain: PropTypes.string,
+};
+
+FahrtkostenpauschalePage.defaultProps = {
+  plausibleProps: undefined,
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/FahrtkostenpauschalePage.test.js
+++ b/webapp/client/src/pages/FahrtkostenpauschalePage.test.js
@@ -1,15 +1,17 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import FahrtkostenpauschalePage from "./FahrtkostenpauschalePage";
-import { Default as StepFormDefault } from "../stories/StepForm.stories";
+import avoidSubmitForm from "../lib/submitFormTestHelper";
 
-const props = {
+const defaultProps = {
   stepHeader: {
     title: "Title",
     intro: "Intro",
   },
   form: {
-    ...StepFormDefault.args,
+    action: "#form-submit",
+    csrfToken: "abc123imacsrftoken",
   },
   fields: {
     requestsFahrtkostenpauschale: {
@@ -21,35 +23,54 @@ const props = {
   prevUrl: "/some/prev/path",
 };
 
+function setup(optionalProps) {
+  const utils = render(
+    <FahrtkostenpauschalePage {...defaultProps} {...optionalProps} />
+  );
+  const user = userEvent.setup();
+
+  return { ...utils, user };
+}
+
 describe("FahrtkostenpauschalePage default", () => {
-  beforeEach(() => {
-    render(<FahrtkostenpauschalePage {...props} />);
-  });
+  avoidSubmitForm();
 
   it("should render step title text", () => {
+    setup();
+
     expect(screen.getByText("Title")).toBeInTheDocument();
   });
 
   it("should ignore step intro text", () => {
+    setup();
+
     expect(screen.queryByText("Intro")).not.toBeInTheDocument();
   });
 
   it("should ignore field option texts", () => {
+    setup();
+
     expect(screen.queryByLabelText("Ja")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Nein")).not.toBeInTheDocument();
   });
 
   it("should render yes no fields", () => {
+    setup();
+
     expect(screen.getByDisplayValue("yes")).toBeInTheDocument();
     expect(screen.getByDisplayValue("no")).toBeInTheDocument();
   });
 
   it("should render fahrtkosten choice fields", () => {
+    setup();
+
     expect(screen.getByText("Pauschale beantragen")).toBeInTheDocument();
     expect(screen.getByText("Pauschale nicht beantragen")).toBeInTheDocument();
   });
 
   it("should link to the previous page", () => {
+    setup();
+
     expect(screen.getByText("Zurück").closest("a")).toHaveAttribute(
       "href",
       expect.stringContaining("/some/prev/path")
@@ -57,62 +78,76 @@ describe("FahrtkostenpauschalePage default", () => {
   });
 });
 
-describe("With yes preselected", () => {
-  beforeEach(() => {
-    const yesProps = {
-      ...props,
-      fields: {
-        requestsFahrtkostenpauschale: {
-          selectedValue: "yes",
-          options: [
-            {
-              value: "yes",
-              displayName: "Ja",
-            },
-            {
-              value: "no",
-              displayName: "Nein",
-            },
-          ],
-          errors: [],
-          name: "requests_fahrtkostenpauschale",
-        },
+it("should render with preselected value yes checked", () => {
+  setup({
+    fields: {
+      requestsFahrtkostenpauschale: {
+        selectedValue: "yes",
+        options: [
+          {
+            value: "yes",
+            displayName: "Ja",
+          },
+          {
+            value: "no",
+            displayName: "Nein",
+          },
+        ],
+        errors: [],
+        name: "requests_fahrtkostenpauschale",
       },
-    };
-    render(<FahrtkostenpauschalePage {...yesProps} />);
+    },
   });
-  it("should render selected value yes", () => {
-    expect(screen.getByDisplayValue("yes").checked).toBe(true);
-    expect(screen.getByDisplayValue("no").checked).toBe(false);
-  });
+
+  expect(screen.getByDisplayValue("yes").checked).toBe(true);
+  expect(screen.getByDisplayValue("no").checked).toBe(false);
 });
 
-describe("With no preselected", () => {
-  beforeEach(() => {
-    const noProps = {
-      ...props,
-      fields: {
-        requestsFahrtkostenpauschale: {
-          selectedValue: "no",
-          options: [
-            {
-              value: "yes",
-              displayName: "Ja",
-            },
-            {
-              value: "no",
-              displayName: "Nein",
-            },
-          ],
-          errors: [],
-          name: "requests_fahrtkostenpauschale",
-        },
+it("should render with pre selected value no checked", () => {
+  setup({
+    fields: {
+      requestsFahrtkostenpauschale: {
+        selectedValue: "no",
+        options: [
+          {
+            value: "yes",
+            displayName: "Ja",
+          },
+          {
+            value: "no",
+            displayName: "Nein",
+          },
+        ],
+        errors: [],
+        name: "requests_fahrtkostenpauschale",
       },
-    };
-    render(<FahrtkostenpauschalePage {...noProps} />);
+    },
   });
-  it("should render selected value no", () => {
-    expect(screen.getByDisplayValue("yes").checked).toBe(false);
-    expect(screen.getByDisplayValue("no").checked).toBe(true);
+
+  expect(screen.getByDisplayValue("yes").checked).toBe(false);
+  expect(screen.getByDisplayValue("no").checked).toBe(true);
+});
+
+it("should call plausible on showOverviewButton click with default goal", async () => {
+  const { user } = setup({
+    form: {
+      action: "#form-submit",
+      csrfToken: "abc123imacsrftoken",
+      showOverviewButton: true,
+    },
+    plausibleDomain: "domain/some/link/path",
   });
+  const EXPECTED_PLAUSIBLE_GOAL = "Zurück zur Übersicht";
+  const EXPECTED_PLAUSIBLE_PROPS = {
+    props: undefined,
+  };
+
+  window.plausible = jest.fn();
+
+  await user.click(screen.getByText(/Zurück zur Übersicht/));
+
+  expect(window.plausible).toHaveBeenCalledWith(
+    EXPECTED_PLAUSIBLE_GOAL,
+    EXPECTED_PLAUSIBLE_PROPS
+  );
 });

--- a/webapp/client/src/pages/FahrtkostenpauschalePage.test.js
+++ b/webapp/client/src/pages/FahrtkostenpauschalePage.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FahrtkostenpauschalePage from "./FahrtkostenpauschalePage";
-import avoidSubmitForm from "../lib/submitFormTestHelper";
+import avoidNotImplementedFormSubmitError from "../test-helper/submitFormTestHelper";
 
 const defaultProps = {
   stepHeader: {
@@ -33,7 +33,7 @@ function setup(optionalProps) {
 }
 
 describe("FahrtkostenpauschalePage default", () => {
-  avoidSubmitForm();
+  avoidNotImplementedFormSubmitError();
 
   it("should render step title text", () => {
     setup();

--- a/webapp/client/src/pages/FahrtkostenpauschalePersonAPage.js
+++ b/webapp/client/src/pages/FahrtkostenpauschalePersonAPage.js
@@ -9,9 +9,16 @@ export default function FahrtkostenpauschalePersonAPage({
   fields,
   prevUrl,
   fahrtkostenpauschaleAmount,
+  plausibleDomain,
 }) {
+  const plausibleProps = {
+    method: "CTA Behinderungsbedingte Fahrtkostenpauschale für Person A",
+  };
+
   return (
     <FahrtkostenpauschalePage
+      plausibleDomain={plausibleDomain}
+      plausibleProps={plausibleProps}
       {...{ stepHeader, form, prevUrl, fahrtkostenpauschaleAmount }}
       fields={{
         requestsFahrtkostenpauschale: {
@@ -36,4 +43,9 @@ FahrtkostenpauschalePersonAPage.propTypes = {
   }).isRequired,
   fahrtkostenpauschaleAmount: PropTypes.number.isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+FahrtkostenpauschalePersonAPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/FahrtkostenpauschalePersonBPage.js
+++ b/webapp/client/src/pages/FahrtkostenpauschalePersonBPage.js
@@ -9,9 +9,16 @@ export default function FahrtkostenpauschalePersonBPage({
   fields,
   prevUrl,
   fahrtkostenpauschaleAmount,
+  plausibleDomain,
 }) {
+  const plausibleProps = {
+    method: "CTA Behinderungsbedingte Fahrtkostenpauschale für Person B",
+  };
+
   return (
     <FahrtkostenpauschalePage
+      plausibleDomain={plausibleDomain}
+      plausibleProps={plausibleProps}
       {...{ stepHeader, form, prevUrl, fahrtkostenpauschaleAmount }}
       fields={{
         requestsFahrtkostenpauschale: {
@@ -36,4 +43,9 @@ FahrtkostenpauschalePersonBPage.propTypes = {
   }).isRequired,
   fahrtkostenpauschaleAmount: PropTypes.number.isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+FahrtkostenpauschalePersonBPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/HasDisabilityPage.js
+++ b/webapp/client/src/pages/HasDisabilityPage.js
@@ -14,6 +14,8 @@ export default function HasDisabilityPage({
   stepHeader,
   headerIntro,
   prevUrl,
+  plausibleDomain,
+  plausibleProps,
 }) {
   const { t } = useTranslation();
 
@@ -24,7 +26,11 @@ export default function HasDisabilityPage({
     <>
       <StepHeaderButtons url={prevUrl} />
       <FormHeader title={stepHeader.title} intro={headerIntro} />
-      <StepForm {...form}>
+      <StepForm
+        plausibleDomain={plausibleDomain}
+        plausibleProps={plausibleProps}
+        {...form}
+      >
         <DetailsSeparated
           title={t("lotse.hasDisability.details.title")}
           detailsId={`${fields.hasDisability.name}_detail`}
@@ -69,4 +75,11 @@ HasDisabilityPage.propTypes = {
     hasDisability: extendedFieldPropType,
   }).isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleProps: PropTypes.shape({ method: PropTypes.string }),
+  plausibleDomain: PropTypes.string,
+};
+
+HasDisabilityPage.defaultProps = {
+  plausibleProps: undefined,
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/HasDisabilityPersonAPage.js
+++ b/webapp/client/src/pages/HasDisabilityPersonAPage.js
@@ -10,8 +10,12 @@ export default function HasDisabilityPersonAPage({
   fields,
   prevUrl,
   numUsers,
+  plausibleDomain,
 }) {
   const { t } = useTranslation();
+  const plausibleProps = {
+    method: "Behinderung oder Pflegebedürftigkeit für Person A",
+  };
 
   const translationBold = function translationBold(key) {
     return <Trans t={t} i18nKey={key} components={{ bold: <b /> }} />;
@@ -25,6 +29,8 @@ export default function HasDisabilityPersonAPage({
 
   return (
     <HasDisabilityPage
+      plausibleDomain={plausibleDomain}
+      plausibleProps={plausibleProps}
       {...{ stepHeader, form, prevUrl }}
       headerIntro={headerIntro}
       fields={{
@@ -52,4 +58,9 @@ HasDisabilityPersonAPage.propTypes = {
   }).isRequired,
   prevUrl: PropTypes.string.isRequired,
   numUsers: PropTypes.number.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+HasDisabilityPersonAPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/HasDisabilityPersonBPage.js
+++ b/webapp/client/src/pages/HasDisabilityPersonBPage.js
@@ -9,8 +9,12 @@ export default function HasDisabilityPersonBPage({
   form,
   fields,
   prevUrl,
+  plausibleDomain,
 }) {
   const { t } = useTranslation();
+  const plausibleProps = {
+    method: "Behinderung oder Pflegebedürftigkeit für Person B",
+  };
 
   const translationBold = function translationBold(key) {
     return <Trans t={t} i18nKey={key} components={{ bold: <b /> }} />;
@@ -18,6 +22,8 @@ export default function HasDisabilityPersonBPage({
 
   return (
     <HasDisabilityPage
+      plausibleDomain={plausibleDomain}
+      plausibleProps={plausibleProps}
       {...{ stepHeader, form, prevUrl }}
       headerIntro={translationBold("lotse.hasDisability.intro_person_b")}
       fields={{
@@ -44,4 +50,9 @@ HasDisabilityPersonBPage.propTypes = {
     personBHasDisability: fieldPropType,
   }).isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+HasDisabilityPersonBPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/MerkzeichenPage.js
+++ b/webapp/client/src/pages/MerkzeichenPage.js
@@ -13,14 +13,25 @@ import FormFieldIntegerInput from "../components/FormFieldIntegerInput";
 import FormFieldCheckBox from "../components/FormFieldCheckBox";
 import FieldLabelForSeparatedFields from "../components/FieldLabelForSeparatedFields";
 
-export default function MerkzeichenPage({ stepHeader, form, fields, prevUrl }) {
+export default function MerkzeichenPage({
+  stepHeader,
+  form,
+  fields,
+  prevUrl,
+  plausibleDomain,
+  plausibleProps,
+}) {
   const { t } = useTranslation();
 
   return (
     <>
       <StepHeaderButtons url={prevUrl} />
       <FormHeader {...stepHeader} />
-      <StepForm {...form}>
+      <StepForm
+        plausibleDomain={plausibleDomain}
+        plausibleProps={plausibleProps}
+        {...form}
+      >
         <FormFieldYesNo
           fieldName={fields.hasPflegegrad.name}
           fieldId={fields.hasPflegegrad.name}
@@ -112,4 +123,11 @@ MerkzeichenPage.propTypes = {
     hasMerkzeichenAg: extendedCheckboxPropType,
   }).isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleProps: PropTypes.shape({ method: PropTypes.string }),
+  plausibleDomain: PropTypes.string,
+};
+
+MerkzeichenPage.defaultProps = {
+  plausibleProps: undefined,
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/MerkzeichenPersonAPage.js
+++ b/webapp/client/src/pages/MerkzeichenPersonAPage.js
@@ -9,11 +9,18 @@ export default function MerkzeichenPersonAPage({
   form,
   fields,
   prevUrl,
+  plausibleDomain,
 }) {
   const { t } = useTranslation();
+  const plausibleProps = {
+    method:
+      "CTA Angaben zur festgestellten Behinderung oder Pflegebedürftigkeit Person A",
+  };
 
   return (
     <MerkzeichenPage
+      plausibleDomain={plausibleDomain}
+      plausibleProps={plausibleProps}
       {...{ stepHeader, form, prevUrl }}
       fields={{
         hasPflegegrad: {
@@ -92,4 +99,9 @@ MerkzeichenPersonAPage.propTypes = {
     personAHasMerkzeichenAg: checkboxPropType,
   }).isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+MerkzeichenPersonAPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/MerkzeichenPersonBPage.js
+++ b/webapp/client/src/pages/MerkzeichenPersonBPage.js
@@ -9,11 +9,18 @@ export default function MerkzeichenPersonBPage({
   form,
   fields,
   prevUrl,
+  plausibleDomain,
 }) {
   const { t } = useTranslation();
+  const plausibleProps = {
+    method:
+      "CTA Angaben zur festgestellten Behinderung oder Pflegebedürftigkeit Person B",
+  };
 
   return (
     <MerkzeichenPage
+      plausibleDomain={plausibleDomain}
+      plausibleProps={plausibleProps}
       {...{ stepHeader, form, prevUrl }}
       fields={{
         hasPflegegrad: {
@@ -92,4 +99,9 @@ MerkzeichenPersonBPage.propTypes = {
     personBHasMerkzeichenAg: checkboxPropType,
   }).isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+MerkzeichenPersonBPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/PauschbetragPage.js
+++ b/webapp/client/src/pages/PauschbetragPage.js
@@ -17,6 +17,8 @@ export default function PauschbetragPage({
   fields,
   pauschbetrag,
   prevUrl,
+  plausibleDomain,
+  plausibleProps,
 }) {
   const { t } = useTranslation();
 
@@ -59,7 +61,11 @@ export default function PauschbetragPage({
           <p key={4}>{t("lotse.pauschbetrag.details.p4")}</p>,
         ]}
       </DetailsSeparated>
-      <StepForm {...form}>
+      <StepForm
+        plausibleDomain={plausibleDomain}
+        plausibleProps={plausibleProps}
+        {...form}
+      >
         <FormFieldRadioGroup
           fieldName={fields.requestsPauschbetrag.name}
           fieldId={fields.requestsPauschbetrag.name}
@@ -103,4 +109,11 @@ PauschbetragPage.propTypes = {
   }).isRequired,
   pauschbetrag: PropTypes.string.isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleProps: PropTypes.shape({ method: PropTypes.string }),
+  plausibleDomain: PropTypes.string,
+};
+
+PauschbetragPage.defaultProps = {
+  plausibleProps: undefined,
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/PauschbetragPersonAPage.js
+++ b/webapp/client/src/pages/PauschbetragPersonAPage.js
@@ -9,9 +9,16 @@ export default function PauschbetragPersonAPage({
   fields,
   pauschbetrag,
   prevUrl,
+  plausibleDomain,
 }) {
+  const plausibleProps = {
+    method: "CTA Pauschbetrag für Menschen mit Behinderung für Person A",
+  };
+
   return (
     <PauschbetragPage
+      plausibleDomain={plausibleDomain}
+      plausibleProps={plausibleProps}
       {...{ stepHeader, form, pauschbetrag, prevUrl }}
       fields={{
         requestsPauschbetrag: {
@@ -36,4 +43,9 @@ PauschbetragPersonAPage.propTypes = {
   }).isRequired,
   pauschbetrag: PropTypes.string.isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+PauschbetragPersonAPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/PauschbetragPersonBPage.js
+++ b/webapp/client/src/pages/PauschbetragPersonBPage.js
@@ -9,9 +9,16 @@ export default function PauschbetragPersonBPage({
   fields,
   pauschbetrag,
   prevUrl,
+  plausibleDomain,
 }) {
+  const plausibleProps = {
+    method: "CTA Pauschbetrag für Menschen mit Behinderung für Person B",
+  };
+
   return (
     <PauschbetragPage
+      plausibleDomain={plausibleDomain}
+      plausibleProps={plausibleProps}
       {...{ stepHeader, form, pauschbetrag, prevUrl }}
       fields={{
         requestsPauschbetrag: {
@@ -38,4 +45,9 @@ PauschbetragPersonBPage.propTypes = {
   }).isRequired,
   pauschbetrag: PropTypes.string.isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+PauschbetragPersonBPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/StmindSelectionPage.js
+++ b/webapp/client/src/pages/StmindSelectionPage.js
@@ -17,14 +17,20 @@ export default function StmindSelectionPage({
   form,
   fields,
   prevUrl,
+  plausibleDomain,
 }) {
   const { t } = useTranslation();
+  const plausibleProps = { method: "CTA Steuermindernde Aufwendungen" };
 
   return (
     <>
       <StepHeaderButtons url={prevUrl} />
       <FormHeader {...stepHeader} />
-      <StepForm {...form}>
+      <StepForm
+        plausibleDomain={plausibleDomain}
+        plausibleProps={plausibleProps}
+        {...form}
+      >
         <SelectableCard
           autofocus
           fieldName="stmind_select_vorsorge"
@@ -96,4 +102,9 @@ StmindSelectionPage.propTypes = {
     stmindSelectReligion: checkboxPropType,
   }).isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+StmindSelectionPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/TaxNumberPage.js
+++ b/webapp/client/src/pages/TaxNumberPage.js
@@ -187,8 +187,10 @@ export default function TaxNumberPage({
   prevUrl,
   taxOfficeList,
   numberOfUsers,
+  plausibleDomain,
 }) {
   const { t } = useTranslation();
+  const plausibleProps = { method: "CTA Steuernummer" };
 
   const [taxNumberPageData, changeTaxNumberPageData] = useReducer(
     reduceTaxNumberPageData,
@@ -316,7 +318,11 @@ export default function TaxNumberPage({
     <>
       <StepHeaderButtons url={prevUrl} />
       <FormHeader {...stepHeader} />
-      <StepForm {...form}>
+      <StepForm
+        plausibleDomain={plausibleDomain}
+        plausibleProps={plausibleProps}
+        {...form}
+      >
         <FormRowCentered>
           <FormFieldYesNo
             fieldName="steuernummer_exists"
@@ -378,4 +384,9 @@ TaxNumberPage.propTypes = {
     })
   ).isRequired,
   numberOfUsers: PropTypes.number.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+TaxNumberPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/pages/TelephoneNumberPage.js
+++ b/webapp/client/src/pages/TelephoneNumberPage.js
@@ -12,14 +12,20 @@ export default function TelephoneNumberPage({
   form,
   fields,
   prevUrl,
+  plausibleDomain,
 }) {
   const { t } = useTranslation();
+  const plausibleProps = { method: "CTA Telefonnummer für Rückfragen" };
 
   return (
     <>
       <StepHeaderButtons url={prevUrl} />
       <FormHeader {...stepHeader} />
-      <StepForm {...form}>
+      <StepForm
+        plausibleDomain={plausibleDomain}
+        plausibleProps={plausibleProps}
+        {...form}
+      >
         <FormFieldTextInput
           fieldName="telephone_number"
           fieldId="telephone_number"
@@ -50,4 +56,9 @@ TelephoneNumberPage.propTypes = {
     telephoneNumber: fieldPropType,
   }).isRequired,
   prevUrl: PropTypes.string.isRequired,
+  plausibleDomain: PropTypes.string,
+};
+
+TelephoneNumberPage.defaultProps = {
+  plausibleDomain: null,
 };

--- a/webapp/client/src/test-helper/submitFormTestHelper.js
+++ b/webapp/client/src/test-helper/submitFormTestHelper.js
@@ -1,4 +1,6 @@
-export default function avoidSubmitForm() {
+// avoid Error: Not implemented: HTMLFormElement.prototype.submit
+
+export default function avoidNotImplementedFormSubmitError() {
   let emit;
 
   beforeAll(() => {


### PR DESCRIPTION
# Short Description
- configure plausible for goal _zurueck zur uebersicht_


# Changes
- adds plausible props to step form + step nav buttons with default goal
- adds and refactor tests
- adds plausible props to react pages 
- adds two example tests for pages
- adds test helper to avoid Console Error: Not implemented: HTMLFormElement.prototype.submit in some tests
- extends page props models

# Feedback
- Are two page tests enough? (In fact the functionality will take place on the step nav button)
- Do you have a better idea to avoid the console error?

# HINT
- Maybe we should refactor the components to avoid DRY and deep prop chaining in a future task - e.g. component composition over inheritance?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
