### PR TITLE
STL-2171 feat: configure plausible for zurueck-zur-uebersicht lotse steps

### DIFF
--- a/webapp/app/forms/flows/multistep_flow.py
+++ b/webapp/app/forms/flows/multistep_flow.py
@@ -10,11 +10,14 @@ from app.config import Config
 from app.data_access.storage.session_storage import SessionStorage
 from app.forms.steps.step import FormStep
 
+from app.helper.plausible_helper import get_plausible_data
+
 logger = logging.getLogger(__name__)
 
 
 class RenderInfo(object):
-    def __init__(self, step_title, step_intro, form, prev_url, next_url, submit_url, overview_url, header_title=None, stored_data=None, data_is_valid=False):
+    def __init__(self, step_title, step_intro, form, prev_url, next_url, submit_url, overview_url, header_title=None,
+                 stored_data=None, data_is_valid=False, plausible_data=None):
         self.step_title = step_title
         self.step_intro = step_intro
         self.header_title = None
@@ -29,6 +32,7 @@ class RenderInfo(object):
         self.additional_info = {}
         self.stored_data = stored_data
         self.data_is_valid = data_is_valid
+        self.plausible_data = plausible_data
 
     def __eq__(self, other):
         if isinstance(other, RenderInfo):
@@ -89,8 +93,10 @@ class MultiStepFlow:
             return redirect(redirected_step)
 
         prev_step, step, next_step = self._generate_steps(step_name)
+        plausible_data = get_plausible_data(step_name, Config.PLAUSIBLE_DOMAIN)
 
         render_info = RenderInfo(step_title=step.title, step_intro=step.intro, form=None,
+                                 plausible_data=plausible_data,
                                  prev_url=self.url_for_step(prev_step.name) if prev_step else None,
                                  next_url=self.url_for_step(next_step.name) if next_step else None,
                                  submit_url=self.url_for_step(step.name), overview_url=self.url_for_step(
@@ -137,7 +143,7 @@ class MultiStepFlow:
         # We do only want to update
         if self.default_data() and not set(self.default_data()[1]).intersection(set(form_data)):
             form_data = self.default_data()[1] | form_data  # updates form_data only with non_existent values
-            
+
         return form_data
 
     def _load_step(self, step_name):
@@ -178,5 +184,4 @@ class MultiStepFlow:
             if any([field.startswith(data_field_prefix) for data_field_prefix in data_field_prefixes]):
                 stored_data.pop(field)
         return stored_data
-
 

--- a/webapp/app/forms/flows/multistep_flow.py
+++ b/webapp/app/forms/flows/multistep_flow.py
@@ -93,10 +93,9 @@ class MultiStepFlow:
             return redirect(redirected_step)
 
         prev_step, step, next_step = self._generate_steps(step_name)
-        plausible_data = get_plausible_data(step_name, Config.PLAUSIBLE_DOMAIN)
 
         render_info = RenderInfo(step_title=step.title, step_intro=step.intro, form=None,
-                                 plausible_data=plausible_data,
+                                 plausible_data=get_plausible_data(step_name, Config.PLAUSIBLE_DOMAIN),
                                  prev_url=self.url_for_step(prev_step.name) if prev_step else None,
                                  next_url=self.url_for_step(next_step.name) if next_step else None,
                                  submit_url=self.url_for_step(step.name), overview_url=self.url_for_step(

--- a/webapp/app/forms/steps/steuerlotse_step.py
+++ b/webapp/app/forms/steps/steuerlotse_step.py
@@ -60,7 +60,6 @@ class SteuerlotseStep(object):
 
     @classmethod
     def prepare_render_info(cls, stored_data, *args, **kwargs):
-        plausible_data = get_plausible_data(cls.name, Config.PLAUSIBLE_DOMAIN)
         return RenderInfo(
             step_title=ngettext(cls.title, cls.title_multiple, num=cls.number_of_users(stored_data))
             if cls.title_multiple else cls.title,
@@ -72,7 +71,7 @@ class SteuerlotseStep(object):
             next_url=None,
             submit_url=None,
             header_title=None,
-            plausible_data=plausible_data,
+            plausible_data=get_plausible_data(cls.name, Config.PLAUSIBLE_DOMAIN),
             overview_url=None)
 
     def _main_handle(self):

--- a/webapp/app/forms/steps/steuerlotse_step.py
+++ b/webapp/app/forms/steps/steuerlotse_step.py
@@ -10,6 +10,10 @@ from app.forms import SteuerlotseBaseForm
 from app.forms.flows.multistep_flow import RenderInfo
 from app.data_access.storage.session_storage import SessionStorage
 
+from app.helper.plausible_helper import get_plausible_data
+
+from app.config import Config
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,6 +60,7 @@ class SteuerlotseStep(object):
 
     @classmethod
     def prepare_render_info(cls, stored_data, *args, **kwargs):
+        plausible_data = get_plausible_data(cls.name, Config.PLAUSIBLE_DOMAIN)
         return RenderInfo(
             step_title=ngettext(cls.title, cls.title_multiple, num=cls.number_of_users(stored_data))
             if cls.title_multiple else cls.title,
@@ -67,6 +72,7 @@ class SteuerlotseStep(object):
             next_url=None,
             submit_url=None,
             header_title=None,
+            plausible_data=plausible_data,
             overview_url=None)
 
     def _main_handle(self):

--- a/webapp/app/helper/plausible_helper.py
+++ b/webapp/app/helper/plausible_helper.py
@@ -1,0 +1,49 @@
+from flask_babel import lazy_gettext as _l
+
+
+def get_plausible_data(step_name, config):
+    plausible_data = {
+        'plausible_domain': config,
+        'plausible_target': _l('plausible.target.goal'),
+        'plausible_source': ''
+    }
+
+    if step_name == 'familienstand':
+        plausible_data['plausible_source'] = _l('plausible.source.step.familienstand')
+        return plausible_data
+
+    if step_name == 'iban':
+        plausible_data['plausible_source'] = _l('plausible.source.step.iban')
+        return plausible_data
+
+    if step_name == 'person_a':
+        plausible_data['plausible_source'] = _l('plausible.source.step.person_a')
+        return plausible_data
+
+    if step_name == 'person_b':
+        plausible_data['plausible_source'] = _l('plausible.source.step.person_b')
+        return plausible_data
+
+    if step_name == 'vorsorge':
+        plausible_data['plausible_source'] = _l('plausible.source.step.vorsorge')
+        return plausible_data
+
+    if step_name == 'ausserg_bela':
+        plausible_data['plausible_source'] = _l('plausible.source.step.ausserg_bela')
+        return plausible_data
+
+    if step_name == 'haushaltsnahe_handwerker':
+        plausible_data['plausible_source'] = _l('plausible.source.step.haushaltsnahe_handwerker')
+        return plausible_data
+
+    if step_name == 'gem_haushalt':
+        plausible_data['plausible_source'] = _l('plausible.source.step.gem_haushalt')
+        return plausible_data
+
+    if step_name == 'religion':
+        plausible_data['plausible_source'] = _l('plausible.source.step.religion')
+        return plausible_data
+
+    if step_name == 'spenden':
+        plausible_data['plausible_source'] = _l('plausible.source.step.spenden')
+        return plausible_data

--- a/webapp/app/helper/plausible_helper.py
+++ b/webapp/app/helper/plausible_helper.py
@@ -1,9 +1,9 @@
 from flask_babel import lazy_gettext as _l
 
 
-def get_plausible_data(step_name, config):
+def get_plausible_data(step_name, domain):
     plausible_data = {
-        'plausible_domain': config,
+        'plausible_domain': domain,
         'plausible_target': _l('plausible.target.goal'),
         'plausible_source': ''
     }

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -14,7 +14,7 @@
     <div class="section-intro">
         <h1 class="my-4">{{ title }}</h1>
         {%- if intro and not hide_intro %}
-            <p>{{intro}}</p>
+            <p>{{ intro }}</p>
         {% endif -%}
     </div>
 {%- endmacro %}
@@ -88,24 +88,25 @@
             {% set classes = classes + " field-error-found" %}
         {% endif %}
 
-        {% if d_block %}<div class="d-block">{% endif %}
-            {% if field.type == 'ConfirmationField' %}
-                {{ components.consent_box(field, classes=classes, position_details_after=position_details_after, first_field=first_field) }}
-            {% elif field.type == 'BooleanField' %}
-                {{ components.checkbox(field, classes=classes, position_details_after=position_details_after, first_field=first_field) }}
-            {% elif field.type == 'RadioField' %}
-                {{ components.radio_field(field, position_details_after=position_details_after, first_field=first_field) }}
-            {% elif field.type == 'LegacyYesNoField' %}
-                {{ components.yes_no_field(field, position_details_after=position_details_after, first_field=first_field) }}
-            {% elif field.type == 'LegacyIdNrField' or field.type == 'LegacySteuerlotseDateField' %}
-                {{ components.separated_field(field, position_details_after=position_details_after, first_field=first_field) }}
+        {% if d_block %}
+            <div class="d-block">{% endif %}
+        {% if field.type == 'ConfirmationField' %}
+            {{ components.consent_box(field, classes=classes, position_details_after=position_details_after, first_field=first_field) }}
+        {% elif field.type == 'BooleanField' %}
+            {{ components.checkbox(field, classes=classes, position_details_after=position_details_after, first_field=first_field) }}
+        {% elif field.type == 'RadioField' %}
+            {{ components.radio_field(field, position_details_after=position_details_after, first_field=first_field) }}
+        {% elif field.type == 'LegacyYesNoField' %}
+            {{ components.yes_no_field(field, position_details_after=position_details_after, first_field=first_field) }}
+        {% elif field.type == 'LegacyIdNrField' or field.type == 'LegacySteuerlotseDateField' %}
+            {{ components.separated_field(field, position_details_after=position_details_after, first_field=first_field) }}
+        {% else %}
+            {% if first_field or field.errors %}
+                {{ field(class=classes, autofocus=True) }}
             {% else %}
-                {% if first_field or field.errors %}
-                    {{ field(class=classes, autofocus=True) }}
-                {% else %}
-                    {{ field(class=classes) }}
-                {% endif %}
+                {{ field(class=classes) }}
             {% endif %}
+        {% endif %}
         {% if d_block %}</div>{% endif %}
         {% if not hide_errors %}{{ field_errors(field) }}{% endif %}
     </div>
@@ -116,9 +117,18 @@
 {% macro form_nav_buttons(render_info) -%}
     <div class="form-row nav-button-row">
         {% if render_info.overview_url %}
-            <button type="submit"
-                    class="btn btn-outline-primary mr-2"
-                    name="overview_button">{{ _('form.back_to_overview') }}</button>
+            {% if render_info.plausible_data.plausible_domain %}
+                <button type="submit"
+                        class="btn btn-outline-primary mr-2"
+                        name="overview_button">{{ _('form.back_to_overview') }}
+                        onclick="plausible('{{ render_info.plausible_data.plausible_target }}', {props: {method: '{{ render_info.plausible_data.plausible_source }}'}})"
+                </button>
+            {% else %}
+                <button type="submit"
+                        class="btn btn-outline-primary mr-2"
+                        name="overview_button">{{ _('form.back_to_overview') }}
+                </button>
+            {% endif %}
         {% endif %}
         {% if render_info.additional_info.next_button_label %}
             <button type="submit" class="btn btn-primary"
@@ -132,8 +142,15 @@
 {% macro form_display_nav_buttons(render_info) -%}
     <div class="form-row mt-4">
         {% if render_info.overview_url %}
-            <a class="btn btn-outline-primary mr-2"
-               href="{{ render_info.overview_url }}">{{ _('form.back_to_overview') }}</a>
+            {% if render_info.plausible_data.plausible_domain %}
+                <a
+                        class="btn btn-outline-secondary"
+                        href="{{ url }}"
+                        onclick="plausible('{{ render_info.plausible_data.plausible_target }}', {props: {method: '{{ render_info.plausible_data.plausible_source }}'}})">{{ _('form.back_to_overview') }}
+                </a>
+            {% else %}
+                <a class="btn btn-outline-secondary" href="{{ url }}">{{ _('form.back_to_overview') }}</a>
+            {% endif %}
         {% endif %}
         {% if render_info.additional_info.next_button_label %}
             <a class="btn btn-primary {% if not render_info.next_url %}invisible{% endif %}" name="next_button"

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-04-11 10:42+0200\n"
+"POT-Creation-Date: 2022-04-14 07:57+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -226,7 +226,7 @@ msgid "form.unlock-code-activation.title"
 msgstr "Aktivierung des Freischaltcodes"
 
 #: app/forms/flows/unlock_code_request_flow.py:55
-#: app/forms/steps/unlock_code_request_steps.py:48
+#: app/forms/steps/unlock_code_request_steps.py:50
 msgid "form.register"
 msgstr "Registrieren"
 
@@ -945,7 +945,7 @@ msgstr "Infos zur Abmeldung - Der Steuerlotse für Rente und Pension"
 #: app/forms/steps/lotse/personal_data.py:191
 #: app/forms/steps/lotse/personal_data.py:290
 #: app/forms/steps/unlock_code_activation_steps.py:20
-#: app/forms/steps/unlock_code_request_steps.py:21
+#: app/forms/steps/unlock_code_request_steps.py:23
 #: app/forms/steps/unlock_code_revocation_steps.py:22
 msgid "validate.missing-idnr"
 msgstr "Geben Sie Ihre Steuer-Identifikationsnummer ein."
@@ -973,47 +973,47 @@ msgstr "Anmelden - Der Steuerlotse für Rente und Pension"
 msgid "form.unlock-code-activation.failure-title"
 msgstr "Anmeldung fehlgeschlagen"
 
-#: app/forms/steps/unlock_code_request_steps.py:22
+#: app/forms/steps/unlock_code_request_steps.py:24
 msgid "validation-date-of-birth-missing"
 msgstr "Geben Sie Ihr Geburtsdatum ein."
 
-#: app/forms/steps/unlock_code_request_steps.py:25
+#: app/forms/steps/unlock_code_request_steps.py:27
 msgid "form.unlock-code-request.confirm_data_privacy.required"
 msgstr ""
 "Bestätigen Sie, dass Sie mit den Datenschutzrichtlinien einverstanden "
 "sind, um fortfahren zu können."
 
-#: app/forms/steps/unlock_code_request_steps.py:27
+#: app/forms/steps/unlock_code_request_steps.py:29
 msgid "form.unlock-code-request.confirm_terms_of_service.required"
 msgstr ""
 "Bestätigen Sie, dass Sie den Nutzungbedingungen zustimmen, um fortfahren "
 "zu können."
 
-#: app/forms/steps/unlock_code_request_steps.py:29
+#: app/forms/steps/unlock_code_request_steps.py:31
 msgid "form.unlock-code-request.confirm_eligibility.required"
 msgstr ""
 "Bestätigen Sie, dass Sie die Voraussetzungen zur Nutzung des Steuerlotsen"
 " erfüllen, um fortfahren zu können."
 
-#: app/forms/steps/unlock_code_request_steps.py:31
+#: app/forms/steps/unlock_code_request_steps.py:33
 msgid "form.unlock-code-request.confirm_e_data.required"
 msgstr "Bestätigen Sie, dass Sie einverstanden sind, um fortfahren zu können."
 
-#: app/forms/steps/unlock_code_request_steps.py:35
+#: app/forms/steps/unlock_code_request_steps.py:37
 msgid "form.unlock-code-request.input-title"
 msgstr "Registrieren und persönlichen Freischaltcode beantragen"
 
-#: app/forms/steps/unlock_code_request_steps.py:61
-#: app/forms/steps/unlock_code_request_steps.py:81
-#: app/forms/steps/unlock_code_request_steps.py:99
+#: app/forms/steps/unlock_code_request_steps.py:63
+#: app/forms/steps/unlock_code_request_steps.py:84
+#: app/forms/steps/unlock_code_request_steps.py:102
 msgid "form.unlock-code-request.header-title"
 msgstr "Registrieren - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/unlock_code_request_steps.py:69
+#: app/forms/steps/unlock_code_request_steps.py:71
 msgid "form.unlock-code-request.success-title"
 msgstr "Ihre Registrierung war erfolgreich!"
 
-#: app/forms/steps/unlock_code_request_steps.py:70
+#: app/forms/steps/unlock_code_request_steps.py:72
 msgid "form.unlock-code-request.success-intro"
 msgstr ""
 "Wir haben Ihren Antrag an Ihre Finanzverwaltung weitergeleitet. Sie "
@@ -1021,11 +1021,11 @@ msgstr ""
 "Freischaltcode erhalten haben. Es kann bis zu zwei Wochen dauern, bis Sie"
 " Ihren Brief erhalten."
 
-#: app/forms/steps/unlock_code_request_steps.py:89
+#: app/forms/steps/unlock_code_request_steps.py:92
 msgid "form.unlock-code-request.failure-title"
 msgstr "Registrierung fehlgeschlagen. Bitte prüfen Sie Ihre Angaben."
 
-#: app/forms/steps/unlock_code_request_steps.py:90
+#: app/forms/steps/unlock_code_request_steps.py:93
 msgid "form.unlock-code-request.failure-intro"
 msgstr ""
 "Haben Sie sich vielleicht bereits registriert? In diesem Fall können Sie "
@@ -3011,6 +3011,50 @@ msgstr ""
 "Der Grad der Behinderung wird in 5er-Schritten bis 100 festgesetzt. "
 "Korrigieren Sie Ihre Angabe."
 
+#: app/helper/plausible_helper.py:7
+msgid "plausible.target.goal"
+msgstr "Zurück zur Übersicht"
+
+#: app/helper/plausible_helper.py:12
+msgid "plausible.source.step.familienstand"
+msgstr "CTA Familienstand"
+
+#: app/helper/plausible_helper.py:16
+msgid "plausible.source.step.iban"
+msgstr "CTA Bankverbindung"
+
+#: app/helper/plausible_helper.py:20
+msgid "plausible.source.step.person_a"
+msgstr "CTA Person A"
+
+#: app/helper/plausible_helper.py:24
+msgid "plausible.source.step.person_b"
+msgstr "CTA Person B"
+
+#: app/helper/plausible_helper.py:28
+msgid "plausible.source.step.vorsorge"
+msgstr "CTA Vorsorgeaufwendungen"
+
+#: app/helper/plausible_helper.py:32
+msgid "plausible.source.step.ausserg_bela"
+msgstr "CTA Krankheitskosten und weitere außergewöhnliche Belastungen"
+
+#: app/helper/plausible_helper.py:36
+msgid "plausible.source.step.haushaltsnahe_handwerker"
+msgstr "CTA Haushaltsnahe Dienstleistungen und Handwerkerleistungen"
+
+#: app/helper/plausible_helper.py:40
+msgid "plausible.source.step.gem_haushalt"
+msgstr "CTA Familienstand"
+
+#: app/helper/plausible_helper.py:44
+msgid "plausible.source.step.religion"
+msgstr "CTA Steuern für Ihre Religionsgemeinschaft"
+
+#: app/helper/plausible_helper.py:48
+msgid "plausible.source.step.spenden"
+msgstr "CTA Spenden und Mitgliedsbeiträge"
+
 #: app/model/form_data.py:508
 msgid "form.lotse.input_invalid.mandatory_field_missing"
 msgid_plural "form.lotse.input_invalid.mandatory_field_missing"
@@ -3063,11 +3107,12 @@ msgstr "Schließen"
 msgid "form.back"
 msgstr "Zurück"
 
-#: app/templates/macros.html:121 app/templates/macros.html:136
+#: app/templates/macros.html:123 app/templates/macros.html:129
+#: app/templates/macros.html:149 app/templates/macros.html:152
 msgid "form.back_to_overview"
 msgstr "Zurück zur Übersicht"
 
-#: app/templates/macros.html:127 app/templates/macros.html:143
+#: app/templates/macros.html:137 app/templates/macros.html:160
 msgid "form.next"
 msgstr "Weiter"
 
@@ -5204,15 +5249,15 @@ msgid "form.eligibility.success-attention.heading"
 msgstr "Bitte beachten Sie"
 
 #: app/templates/eligibility/display_maybe.html:48
-#: app/templates/eligibility/display_success.html:42
+#: app/templates/eligibility/display_success.html:43
 msgid "form.eligibility.use-register-button"
 msgstr "Registrieren"
 
-#: app/templates/eligibility/display_success.html:42
+#: app/templates/eligibility/display_success.html:45
 msgid "tracking.eligibility.success.goal"
 msgstr "Registrierung"
 
-#: app/templates/eligibility/display_success.html:42
+#: app/templates/eligibility/display_success.html:46
 msgid "tracking.eligibility.success.method"
 msgstr "Registrierung CTA positiv NP"
 


### PR DESCRIPTION
# Short Description
- configure plausible for zurueck-zur-uebersicht lotse steps templates

# Changes
- provides get plausible data helper fct
- imports method to multistep_flow and steuerlotse_step to provide plausible data for each different step in render_info
- adds translations 
- extends macros for button/anchor _zurück zur übersicht_

# Feedback
- any

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
