### PR TITLE
STL-2163 feat: configure plausible for aendern on confirmation page

### DIFF
--- a/webapp/app/forms/flows/lotse_flow.py
+++ b/webapp/app/forms/flows/lotse_flow.py
@@ -304,14 +304,14 @@ class LotseMultiStepFlow(MultiStepFlow):
 
                 curr_section.data[curr_step.name] = Section(curr_step.get_label(stored_data),
                                                             self.url_for_step(curr_step.name, _has_link_overview=True),
-                                                            step_data)
+                                                            step_data, name=curr_step.name)
 
         return sections
 
     def _create_section_from_section_link(self, section_link, data=None, _has_link_overview=True):
         return Section(section_link.label,
                        self.url_for_step(section_link.beginning_step,
-                                         _has_link_overview=_has_link_overview),
+                                         _has_link_overview=_has_link_overview, name=None),
                        data)
 
     @staticmethod

--- a/webapp/app/forms/flows/multistep_flow.py
+++ b/webapp/app/forms/flows/multistep_flow.py
@@ -10,14 +10,14 @@ from app.config import Config
 from app.data_access.storage.session_storage import SessionStorage
 from app.forms.steps.step import FormStep
 
-from app.helper.plausible_helper import get_plausible_data
+from app.helper.plausible_helper import plausible_data_cta
 
 logger = logging.getLogger(__name__)
 
 
 class RenderInfo(object):
     def __init__(self, step_title, step_intro, form, prev_url, next_url, submit_url, overview_url, header_title=None,
-                 stored_data=None, data_is_valid=False, plausible_data=None):
+                 stored_data=None, data_is_valid=False, step_name=None):
         self.step_title = step_title
         self.step_intro = step_intro
         self.header_title = None
@@ -32,7 +32,7 @@ class RenderInfo(object):
         self.additional_info = {}
         self.stored_data = stored_data
         self.data_is_valid = data_is_valid
-        self.plausible_data = plausible_data
+        self.step_name = step_name
 
     def __eq__(self, other):
         if isinstance(other, RenderInfo):
@@ -95,12 +95,12 @@ class MultiStepFlow:
         prev_step, step, next_step = self._generate_steps(step_name)
 
         render_info = RenderInfo(step_title=step.title, step_intro=step.intro, form=None,
-                                 plausible_data=get_plausible_data(step_name, Config.PLAUSIBLE_DOMAIN),
+                                 step_name=step_name,
                                  prev_url=self.url_for_step(prev_step.name) if prev_step else None,
                                  next_url=self.url_for_step(next_step.name) if next_step else None,
                                  submit_url=self.url_for_step(step.name), overview_url=self.url_for_step(
                 self.overview_step.name) if self.has_link_overview and self.overview_step else None)
-
+        render_info.additional_info['section_plausible_data'] = plausible_data_cta
         render_info, stored_data = self._handle_specifics_for_step(step, render_info, stored_data)
         self.form_storage.override_data(stored_data, data_identifier="form_data")
 

--- a/webapp/app/forms/steps/lotse/confirmation.py
+++ b/webapp/app/forms/steps/lotse/confirmation.py
@@ -13,7 +13,6 @@ from flask_babel import lazy_gettext as _l, _
 from app.forms.steps.lotse_multistep_flow_steps.confirmation_steps import StepConfirmation
 from app.model.form_data import MandatoryFieldMissingValidationError
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -43,9 +42,9 @@ class StepSummary(LotseFormSteuerlotseStep):
             self.render_info.next_url = self.url_for_step(StepSummary.name)
         # TODO move this to a more sensible location!
         multistep_flow = LotseMultiStepFlow(endpoint='lotse')
-        self.render_info.additional_info['section_steps'] = multistep_flow._get_overview_data(self.stored_data,
-                                                                                              missing_fields)
+        self.render_info.additional_info['section_steps'] = multistep_flow._get_overview_data(self.stored_data, missing_fields)
         self.render_info.overview_url = None
+
 
         if not missing_fields and self.should_update_data and self.render_info.data_is_valid:
             create_audit_log_confirmation_entry('Confirmed complete correct data', request.remote_addr,

--- a/webapp/app/forms/steps/step.py
+++ b/webapp/app/forms/steps/step.py
@@ -8,7 +8,8 @@ SectionLink = namedtuple(
 
 Section = namedtuple(
     typename='Section',
-    field_names=['label', 'url', 'data']
+    field_names=['label', 'url', 'data', 'name'],
+    defaults=(None, None, None, None,)
 )
 
 

--- a/webapp/app/forms/steps/steuerlotse_step.py
+++ b/webapp/app/forms/steps/steuerlotse_step.py
@@ -10,9 +10,8 @@ from app.forms import SteuerlotseBaseForm
 from app.forms.flows.multistep_flow import RenderInfo
 from app.data_access.storage.session_storage import SessionStorage
 
-from app.helper.plausible_helper import get_plausible_data
 
-from app.config import Config
+from app.helper.plausible_helper import plausible_data_cta
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +56,7 @@ class SteuerlotseStep(object):
         self.render_info.overview_url = self.url_for_step(self.overview_step.name) \
             if self.has_link_overview and self.overview_step else None
         self.render_info.header_title = self.header_title
+        self.render_info.additional_info['section_plausible_data'] = plausible_data_cta
 
     @classmethod
     def prepare_render_info(cls, stored_data, *args, **kwargs):
@@ -71,7 +71,7 @@ class SteuerlotseStep(object):
             next_url=None,
             submit_url=None,
             header_title=None,
-            plausible_data=get_plausible_data(cls.name, Config.PLAUSIBLE_DOMAIN),
+            step_name=cls.name,
             overview_url=None)
 
     def _main_handle(self):

--- a/webapp/app/helper/plausible_helper.py
+++ b/webapp/app/helper/plausible_helper.py
@@ -1,49 +1,163 @@
-from flask_babel import lazy_gettext as _l
+from app.config import Config
 
+aendern = 'ändern'
+uebersicht = 'Zurück zur Übersicht'
+domain = Config.PLAUSIBLE_DOMAIN
 
-def get_plausible_data(step_name, domain):
-    plausible_data = {
-        'plausible_domain': domain,
-        'plausible_target': _l('plausible.target.goal'),
-        'plausible_source': ''
-    }
-
-    if step_name == 'familienstand':
-        plausible_data['plausible_source'] = _l('plausible.source.step.familienstand')
-        return plausible_data
-
-    if step_name == 'iban':
-        plausible_data['plausible_source'] = _l('plausible.source.step.iban')
-        return plausible_data
-
-    if step_name == 'person_a':
-        plausible_data['plausible_source'] = _l('plausible.source.step.person_a')
-        return plausible_data
-
-    if step_name == 'person_b':
-        plausible_data['plausible_source'] = _l('plausible.source.step.person_b')
-        return plausible_data
-
-    if step_name == 'vorsorge':
-        plausible_data['plausible_source'] = _l('plausible.source.step.vorsorge')
-        return plausible_data
-
-    if step_name == 'ausserg_bela':
-        plausible_data['plausible_source'] = _l('plausible.source.step.ausserg_bela')
-        return plausible_data
-
-    if step_name == 'haushaltsnahe_handwerker':
-        plausible_data['plausible_source'] = _l('plausible.source.step.haushaltsnahe_handwerker')
-        return plausible_data
-
-    if step_name == 'gem_haushalt':
-        plausible_data['plausible_source'] = _l('plausible.source.step.gem_haushalt')
-        return plausible_data
-
-    if step_name == 'religion':
-        plausible_data['plausible_source'] = _l('plausible.source.step.religion')
-        return plausible_data
-
-    if step_name == 'spenden':
-        plausible_data['plausible_source'] = _l('plausible.source.step.spenden')
-        return plausible_data
+plausible_data_cta = {
+    'decl_incomes_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Eingabe zu weiteren Einkünften'
+    },
+    'decl_edaten_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Übernahme vorliegender Daten'
+    },
+    'steuernummer_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Steuernummer'
+    },
+    'familienstand': {
+        'domain': domain,
+        'target': uebersicht,
+        'source': 'CTA Familienstand'
+    },
+    'familienstand_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Familienstand'
+    },
+    'iban': {
+        'domain': domain,
+        'target': uebersicht,
+        'source': 'CTA Bankverbindung'
+    },
+    'iban_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Bankverbindung'
+    },
+    'person_a': {
+        'domain': domain,
+        'target': uebersicht,
+        'source': 'CTA Person A'
+    },
+    'person_a_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Person A'
+    },
+    'has_disability_person_a_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'Behinderung oder Pflegebedürftigkeit für Person A'
+    },
+    'merkzeichen_person_a_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Angaben zur festgestellten Behinderung oder Pflegebedürftigkeit Person A'
+    },
+    'person_a_requests_pauschbetrag_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Pauschbetrag für Menschen mit Behinderung für Person A'
+    },
+    'person_a_requests_fahrtkostenpauschale_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Behinderungsbedingte Fahrtkostenpauschale für Person A'
+    },
+    'person_b': {
+        'domain': domain,
+        'target': uebersicht,
+        'source': 'CTA Person B'
+    },
+    'person_b_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Person B'
+    },
+    'has_disability_person_b_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'Behinderung oder Pflegebedürftigkeit für Person B'
+    },
+    'merkzeichen_person_b_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Angaben zur festgestellten Behinderung oder Pflegebedürftigkeit Person B'
+    },
+    'person_b_requests_pauschbetrag_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Pauschbetrag für Menschen mit Behinderung für Person B'
+    },
+    'person_b_requests_fahrtkostenpauschale_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Behinderungsbedingte Fahrtkostenpauschale für Person B'
+    },
+    'vorsorge': {
+        'domain': domain,
+        'target': uebersicht,
+        'source': 'CTA Vorsorgeaufwendungen'
+    },
+    'vorsorge_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Vorsorgeaufwendungen'
+    },
+    'ausserg_bela': {
+        'domain': domain,
+        'target': uebersicht,
+        'source': 'CTA Krankheitskosten und weitere außergewöhnliche Belastungen'
+    },
+    'ausserg_bela_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Krankheitskosten und weitere außergewöhnliche Belastungen'
+    },
+    'haushaltsnahe_handwerker': {
+        'domain': domain,
+        'target': uebersicht,
+        'source': 'CTA Haushaltsnahe Dienstleistungen und Handwerkerleistungen'
+    },
+    'haushaltsnahe_handwerker_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Haushaltsnahe Dienstleistungen und Handwerkerleistungen'
+    },
+    'religion': {
+        'domain': domain,
+        'target': uebersicht,
+        'source': 'CTA Steuern für Ihre Religionsgemeinschaft'
+    },
+    'religion_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Steuern für Ihre Religionsgemeinschaft'
+    },
+    'spenden': {
+        'domain': domain,
+        'target': uebersicht,
+        'source': 'CTA Spenden und Mitgliedsbeiträge'
+    },
+    'spenden_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Spenden und Mitgliedsbeiträge'
+    },
+    'telefonnummer_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Telefonnummer für Rückfragen'
+    },
+    'select_stmind_summary': {
+        'domain': domain,
+        'target': aendern,
+        'source': 'CTA Steuermindernde Aufwendungen'
+    },
+}

--- a/webapp/app/templates/components.html
+++ b/webapp/app/templates/components.html
@@ -21,9 +21,15 @@
     <a class="btn btn-outline-secondary" href="{{ url}}">{{ text }}</a>
 {%- endmacro %}
 
+{% macro editButtonWithTracking(url, plausible_data, text=_('form.lotse.summary-button-edit'), float_right=False) -%}
+      <a class="{% if  float_right %} float-right {% endif %} edit-button" href="{{ url }}"
+         onclick="plausible('{{ plausible_data.target }}', {props: {method: '{{plausible_data.source }}'}})">{{ text }}</a>
+{%- endmacro %}
+
 {% macro editButton(url, text=_('form.lotse.summary-button-edit'), float_right=False) -%}
       <a class="{% if  float_right %} float-right {% endif %} edit-button" href="{{ url }}">{{ text }}</a>
 {%- endmacro %}
+
 
 {% macro backLink(text, url) -%}
       <a class='back-link' href="{{ url }}">

--- a/webapp/app/templates/lotse/display_summary.html
+++ b/webapp/app/templates/lotse/display_summary.html
@@ -4,34 +4,40 @@
 
 {# TODO Restructure how the summary is displayed #}
 {% block form_content %}
-{% for section in render_info.additional_info.section_steps.values() -%}
-  <h2 class="mb-0 mt-5 h5 text-uppercase">{{ section.label }}</h2>
-  {% for step in section.data.values() -%}
-    <div class="my-4 px-0">
-      <div class="card">
-        <div class="card-header unstyled-card-header d-sm-flex justify-content-between align-items-center">
-          <h3 class="mb-0 h5 bold">{{ step.label }}</h3>
-          {{ components.editButton(url=step.url) }}
-        </div>
-        <div class="card-body pt-2">
-          <ul class="list-unstyled mb-0 margin-only-between">
-              {% if step.data -%}
-                {% for label, value in step.data.items() -%}
-                {% if value is not none %}
-                    <li class="row">
-                      <div class="col-sm-6 bold">{{ label }}:</div>
-                      <div class="col-sm ">{{ value }} </div>
-                    </li>
-                {% endif %}
-                {% endfor %}
-              {% else -%}
-              {% endif -%}
-          </ul>
-        </div>
-      </div>
-    </div>
-  {% endfor -%}
-{% endfor -%}
+    {% for section in render_info.additional_info.section_steps.values() -%}
+        <h2 class="mb-0 mt-5 h5 text-uppercase">{{ section.label }}</h2>
+        {% for step in section.data.values() -%}
+            <div class="my-4 px-0">
+                <div class="card">
+                    <div class="card-header unstyled-card-header d-sm-flex justify-content-between align-items-center">
+                        <h3 class="mb-0 h5 bold">{{ step.label }}</h3>
+                        {% set set_name = step.name ~ '_summary' %}
+                        {% if set_name in render_info.additional_info['section_plausible_data'] %}
+                            {% set plausible_data = render_info.additional_info['section_plausible_data'].get(set_name) %}
+                            {{ components.editButtonWithTracking(url=step.url,plausible_data=plausible_data) }}
+                        {% else %}
+                            {{ components.editButton(url=step.url) }}
+                        {% endif %}
+                    </div>
+                    <div class="card-body pt-2">
+                        <ul class="list-unstyled mb-0 margin-only-between">
+                            {% if step.data -%}
+                                {% for label, value in step.data.items() -%}
+                                    {% if value is not none %}
+                                        <li class="row">
+                                            <div class="col-sm-6 bold">{{ label }}:</div>
+                                            <div class="col-sm ">{{ value }} </div>
+                                        </li>
+                                    {% endif %}
+                                {% endfor %}
+                            {% else -%}
+                            {% endif -%}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        {% endfor -%}
+    {% endfor -%}
 
     {{ macros.render_field(form.confirm_complete_correct) }}
 

--- a/webapp/app/templates/macros.html
+++ b/webapp/app/templates/macros.html
@@ -117,13 +117,13 @@
 {% macro form_nav_buttons(render_info) -%}
     <div class="form-row nav-button-row">
         {% if render_info.overview_url %}
-            {% if render_info.plausible_data.plausible_domain %}
+            {% set plausible_data = render_info.additional_info['section_plausible_data'].get(render_info.step_name) %}
+            {% if plausible_data.plausible_domain %}
                 <button
                         type="submit"
                         class="btn btn-outline-primary mr-2"
                         name="overview_button"
-                        onclick="plausible('{{ render_info.plausible_data.plausible_target }}',
-                                {props: {method: '{{ render_info.plausible_data.plausible_source }}'}})">
+                        onclick="plausible('{{ plausible_data.target }}',{props: {method: '{{ plausible_data.source }}'}})">
                     {{ _('form.back_to_overview') }}
                 </button>
             {% else %}
@@ -145,11 +145,12 @@
 {% macro form_display_nav_buttons(render_info) -%}
     <div class="form-row mt-4">
         {% if render_info.overview_url %}
-            {% if render_info.plausible_data.plausible_domain %}
+            {% set plausible_data = render_info.additional_info['section_plausible_data'].get(render_info.step_name) %}
+            {% if plausible_data.plausible_domain %}
                 <a
                         class="btn btn-outline-secondary"
                         href="{{ url }}"
-                        onclick="plausible('{{ render_info.plausible_data.plausible_target }}', {props: {method: '{{ render_info.plausible_data.plausible_source }}'}})">{{ _('form.back_to_overview') }}
+                        onclick="plausible('{{ plausible_data.target }}',{props: {method: '{{ plausible_data.source }}'}})">
                 </a>
             {% else %}
                 <a class="btn btn-outline-secondary" href="{{ url }}">{{ _('form.back_to_overview') }}</a>

--- a/webapp/app/translations/de/LC_MESSAGES/messages.po
+++ b/webapp/app/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-04-14 07:57+0200\n"
+"POT-Creation-Date: 2022-04-19 00:49+0200\n"
 "PO-Revision-Date: 2020-09-17 11:35+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -1082,21 +1082,21 @@ msgstr ""
 "Steuererklärung bereits erfolgreich verschickt? Dann haben wir Ihren "
 "Freischaltcode automatisiert storniert und Sie müssen nichts weiter tun."
 
-#: app/forms/steps/lotse/confirmation.py:22
+#: app/forms/steps/lotse/confirmation.py:21
 msgid "form.lotse.summary-title"
 msgstr "Prüfen Sie Ihre Angaben"
 
-#: app/forms/steps/lotse/confirmation.py:23
+#: app/forms/steps/lotse/confirmation.py:22
 msgid "form.lotse.summary.header-title"
 msgstr "Steuerformular - Prüfung - Der Steuerlotse für Rente und Pension"
 
-#: app/forms/steps/lotse/confirmation.py:28
+#: app/forms/steps/lotse/confirmation.py:27
 msgid "form.lotse.field_confirm_complete_correct"
 msgstr ""
 "Hiermit bestätige ich, dass die Angaben überprüft wurden und dass sie "
 "vollständig und richtig sind."
 
-#: app/forms/steps/lotse/confirmation.py:29
+#: app/forms/steps/lotse/confirmation.py:28
 msgid "form.lotse.confirm_complete_correct.required"
 msgstr "Bestätigen Sie, dass Ihre Angaben korrekt sind, um fortfahren zu können."
 
@@ -3011,50 +3011,6 @@ msgstr ""
 "Der Grad der Behinderung wird in 5er-Schritten bis 100 festgesetzt. "
 "Korrigieren Sie Ihre Angabe."
 
-#: app/helper/plausible_helper.py:7
-msgid "plausible.target.goal"
-msgstr "Zurück zur Übersicht"
-
-#: app/helper/plausible_helper.py:12
-msgid "plausible.source.step.familienstand"
-msgstr "CTA Familienstand"
-
-#: app/helper/plausible_helper.py:16
-msgid "plausible.source.step.iban"
-msgstr "CTA Bankverbindung"
-
-#: app/helper/plausible_helper.py:20
-msgid "plausible.source.step.person_a"
-msgstr "CTA Person A"
-
-#: app/helper/plausible_helper.py:24
-msgid "plausible.source.step.person_b"
-msgstr "CTA Person B"
-
-#: app/helper/plausible_helper.py:28
-msgid "plausible.source.step.vorsorge"
-msgstr "CTA Vorsorgeaufwendungen"
-
-#: app/helper/plausible_helper.py:32
-msgid "plausible.source.step.ausserg_bela"
-msgstr "CTA Krankheitskosten und weitere außergewöhnliche Belastungen"
-
-#: app/helper/plausible_helper.py:36
-msgid "plausible.source.step.haushaltsnahe_handwerker"
-msgstr "CTA Haushaltsnahe Dienstleistungen und Handwerkerleistungen"
-
-#: app/helper/plausible_helper.py:40
-msgid "plausible.source.step.gem_haushalt"
-msgstr "CTA Familienstand"
-
-#: app/helper/plausible_helper.py:44
-msgid "plausible.source.step.religion"
-msgstr "CTA Steuern für Ihre Religionsgemeinschaft"
-
-#: app/helper/plausible_helper.py:48
-msgid "plausible.source.step.spenden"
-msgstr "CTA Spenden und Mitgliedsbeiträge"
-
 #: app/model/form_data.py:508
 msgid "form.lotse.input_invalid.mandatory_field_missing"
 msgid_plural "form.lotse.input_invalid.mandatory_field_missing"
@@ -3075,44 +3031,50 @@ msgstr ""
 "Bitte prüfen Sie die Steuer-Identifikationsnummer. Die Angabe muss mit "
 "der Nummer identisch sein, die Sie zum Anmelden eingegeben haben."
 
-#: app/templates/components.html:24
+#: app/templates/components.html:24 app/templates/components.html:29
+#, fuzzy
 msgid "form.lotse.summary-button-edit"
-msgstr "Ändern"
+msgstr "Prüfen Sie Ihre Angaben"
 
-#: app/templates/components.html:108 app/templates/components.html:116
+#: app/templates/components.html:114 app/templates/components.html:122
+#, fuzzy
 msgid "form.optional"
-msgstr "optional"
+msgstr "Ihre Steuererklärung"
 
-#: app/templates/components.html:133
+#: app/templates/components.html:139
+#, fuzzy
 msgid "errors.warning-image.aria-label"
-msgstr "Fehlermeldung"
+msgstr "Eintrag entfernen"
 
-#: app/templates/components.html:163
+#: app/templates/components.html:169
 msgid "plus.alt.text"
-msgstr "Plus-Zeichen"
+msgstr ""
 
-#: app/templates/components.html:166
+#: app/templates/components.html:172
+#, fuzzy
 msgid "minus.alt.text"
-msgstr "Minus-Zeichen"
+msgstr ""
+"Vertreten durch die Geschäftsführung: Frau Christina Lang, Herr Philipp "
+"Moeser"
 
-#: app/templates/components.html:240
+#: app/templates/components.html:246
 msgid "button.help"
-msgstr "Weitere Informationen"
+msgstr ""
 
-#: app/templates/components.html:249
+#: app/templates/components.html:255
 msgid "button.close.aria-label"
-msgstr "Schließen"
+msgstr ""
 
 #: app/templates/error/erica_error.html:8 app/templates/macros.html:7
 msgid "form.back"
 msgstr "Zurück"
 
-#: app/templates/macros.html:123 app/templates/macros.html:129
-#: app/templates/macros.html:149 app/templates/macros.html:152
+#: app/templates/macros.html:127 app/templates/macros.html:132
+#: app/templates/macros.html:156
 msgid "form.back_to_overview"
 msgstr "Zurück zur Übersicht"
 
-#: app/templates/macros.html:137 app/templates/macros.html:160
+#: app/templates/macros.html:140 app/templates/macros.html:164
 msgid "form.next"
 msgstr "Weiter"
 
@@ -5479,4 +5441,28 @@ msgstr "Zurück zur Steuererklärung"
 #~ msgstr ""
 #~ "Steuerformular - Abgabebestätigung - Der "
 #~ "Steuerlotse für Rente und Pension"
+
+#~ msgid "plausible.source.summary.step.familienstand"
+#~ msgstr "CTA Familienstand"
+
+#~ msgid "form.lotse.summary-button-edit"
+#~ msgstr "Ändern"
+
+#~ msgid "form.optional"
+#~ msgstr "optional"
+
+#~ msgid "errors.warning-image.aria-label"
+#~ msgstr "Fehlermeldung"
+
+#~ msgid "plus.alt.text"
+#~ msgstr "Plus-Zeichen"
+
+#~ msgid "minus.alt.text"
+#~ msgstr "Minus-Zeichen"
+
+#~ msgid "button.help"
+#~ msgstr "Weitere Informationen"
+
+#~ msgid "button.close.aria-label"
+#~ msgstr "Schließen"
 

--- a/webapp/node.Development.Dockerfile
+++ b/webapp/node.Development.Dockerfile
@@ -3,7 +3,6 @@ FROM node:14 as node
 WORKDIR /app/client
 
 RUN yarn install
-RUN npm install
 
 EXPOSE 3000
 

--- a/webapp/tests/forms/flows/test_lotse_flow.py
+++ b/webapp/tests/forms/flows/test_lotse_flow.py
@@ -1147,7 +1147,7 @@ class TestLotseGetOverviewData(unittest.TestCase):
                             flow.url_for_step(StepIban.name, _has_link_overview=True),
                             {str(debug_data['iban']): debug_data['iban'],
                                 str(debug_data['account_holder']): debug_data[
-                                    'account_holder']}
+                                    'account_holder']}, StepIban.name
                         )
                 }
             ),
@@ -1167,7 +1167,7 @@ class TestLotseGetOverviewData(unittest.TestCase):
                             str(debug_data['stmind_handwerker_summe']): debug_data[
                                 'stmind_handwerker_summe'],
                             str(debug_data['stmind_handwerker_lohn_etc_summe']): debug_data[
-                                'stmind_handwerker_lohn_etc_summe']}
+                                'stmind_handwerker_lohn_etc_summe']}, StepHaushaltsnaheHandwerker.name
                     )
                 }
             )
@@ -1197,7 +1197,7 @@ class TestLotseGetOverviewData(unittest.TestCase):
                             flow.url_for_step(StepIban.name, _has_link_overview=True),
                             {_l('form.lotse.field_iban.data_label'): mandatory_data_missing_value,
                                 _l(
-                                    'form.lotse.iban.account-holder.data_label'): mandatory_data_missing_value}
+                                    'form.lotse.iban.account-holder.data_label'): mandatory_data_missing_value}, StepIban.name
                         )
                 }
             ),
@@ -1218,7 +1218,7 @@ class TestLotseGetOverviewData(unittest.TestCase):
                                 str(debug_data['stmind_handwerker_summe']): debug_data[
                                     'stmind_handwerker_summe'],
                                 str(debug_data['stmind_handwerker_lohn_etc_summe']): debug_data[
-                                    'stmind_handwerker_lohn_etc_summe']}
+                                    'stmind_handwerker_lohn_etc_summe']}, StepHaushaltsnaheHandwerker.name
                         )
                 }
             )

--- a/webapp/tests/forms/steps/test_steuerlotse_step.py
+++ b/webapp/tests/forms/steps/test_steuerlotse_step.py
@@ -19,6 +19,8 @@ from tests.forms.mock_steuerlotse_steps import MockStartStep, MockMiddleStep, Mo
     MockStepWithPreconditionAndMessage, MockSecondPreconditionModelWithMessage
 from tests.utils import create_session_form_data
 
+from app.helper.plausible_helper import plausible_data_cta
+
 
 class TestSteuerlotseStepInit(unittest.TestCase):
     @pytest.fixture(autouse=True)
@@ -234,7 +236,8 @@ class TestSteuerlotseStepPreHandle(unittest.TestCase):
                                             next_url=None, submit_url=url_for(endpoint=correct_endpoint,
                                                                             step=steuerlotse_step.name,
                                                                             link_overview=steuerlotse_step.has_link_overview),
-                                            overview_url=None)
+                                            overview_url=None, step_name=steuerlotse_step.name)
+        expected_render_info.additional_info['section_plausible_data'] = plausible_data_cta
 
         self.assertEqual(expected_render_info, steuerlotse_step.render_info)
 
@@ -261,7 +264,8 @@ class TestSteuerlotseStepPreHandle(unittest.TestCase):
                                             submit_url=url_for(endpoint=correct_endpoint,
                                                                 step=steuerlotse_step.name,
                                                                 link_overview=steuerlotse_step.has_link_overview),
-                                            overview_url=None)
+                                            overview_url=None, step_name=steuerlotse_step.name)
+        expected_render_info.additional_info['section_plausible_data'] = plausible_data_cta
 
         self.assertEqual(expected_render_info, steuerlotse_step.render_info)
 
@@ -281,7 +285,8 @@ class TestSteuerlotseStepPreHandle(unittest.TestCase):
                                             next_url=None, submit_url=url_for(endpoint=correct_endpoint,
                                                                             step=steuerlotse_step.name,
                                                                             link_overview=steuerlotse_step.has_link_overview),
-                                            overview_url=overview_url)
+                                            overview_url=overview_url, step_name=steuerlotse_step.name)
+        expected_render_info.additional_info['section_plausible_data'] = plausible_data_cta
 
         steuerlotse_step._pre_handle()
 


### PR DESCRIPTION
# Short Description
- configure plausible for goal "ändern"

# Changes
- extends plausible helper to have the same implementation for both buttons _ändern_ and _zurück zu übersicht_
- add step name to use for plausible tracking
- move some translations out of translations to plausible helper because these are plausible keys that may not be altered accidentally or by translation 

# Feedback
- any


# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
