### PR TITLE
Stl 2240 registration error page

### DIFF
--- a/webapp/app/forms/flows/unlock_code_request_flow.py
+++ b/webapp/app/forms/flows/unlock_code_request_flow.py
@@ -78,8 +78,6 @@ class UnlockCodeRequestMultiStepFlow(MultiStepFlow):
                     pass
                 except ElsterProcessNotSuccessful:
                     logger.info("Could not request unlock code for user", exc_info=True)
-                    render_info.next_url = self.url_for_step(UnlockCodeRequestInputStep.name)
-                    flash(_('flash.erica.dataConnectionError'), 'warn')
                     pass
                 except RequestException as e:
                     logger.error(f"Could not send a request to erica: {e}", exc_info=True)


### PR DESCRIPTION
# Short Description
- When the elster process is not successful after the registration we don't want to show a banner. We want to show the normal page like before the "Registration fehlgeschlagen" page

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
