### PR TITLE
STL-2211 Fix for larger text on Disability Costs info page

### DIFF
--- a/webapp/client/src/pages/DisabilityCostsInfoPage.js
+++ b/webapp/client/src/pages/DisabilityCostsInfoPage.js
@@ -12,6 +12,7 @@ import {
   Headline1,
   Headline2,
   Paragraph,
+  ParagraphLarge,
 } from "../components/ContentPagesGeneralStyling";
 
 export default function DisabilityCostsInfoPage() {
@@ -66,7 +67,9 @@ export default function DisabilityCostsInfoPage() {
         <StepHeaderButtons text={anchorBack.text} url={anchorBack.url} />
 
         <Headline1>{t("DisabilityCostsInfo.Section1.Heading")}</Headline1>
-        <Paragraph>{t("DisabilityCostsInfo.Section1.Text")}</Paragraph>
+        <ParagraphLarge>
+          {t("DisabilityCostsInfo.Section1.Text")}
+        </ParagraphLarge>
 
         <Headline2>{t("DisabilityCostsInfo.Section2.Heading")}</Headline2>
         <Paragraph>{t("DisabilityCostsInfo.Section2.Text")}</Paragraph>


### PR DESCRIPTION
# Short Description
- Makes the text under the heading larger

# Changes
- changes the styled component from `Paragraph` to `ParagrapLarge`

# Feedback
- any?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
