### PR TITLE
STL-1958-Fixes consistent height for unlock code success page 

### DIFF
--- a/webapp/client/src/components/FormSuccessHeader.js
+++ b/webapp/client/src/components/FormSuccessHeader.js
@@ -6,7 +6,7 @@ const SuccessAlertArea = styled.div`
 
   .header-navigation,
   .header-navigation + & {
-    margin-top: var(--spacing-07);
+    margin-top: calc(var(--spacing-07) - 30px);
   }
 
   &.alert {


### PR DESCRIPTION
# Short Description
- hight of the formSuccessHeader box now matches that of the other content pages

# Changes
- adjusted the margin to account for the top padding of the box

# Feedback
- any

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
