### PR TITLE
Stl 2232 fixes for share box content page

### DIFF
--- a/webapp/client/src/components/ButtonAnchor.js
+++ b/webapp/client/src/components/ButtonAnchor.js
@@ -85,91 +85,97 @@ const activeStates = css`
     return "none";
   }};
 `;
+const focusStates = css`
+  outline: ${({ variant }) => {
+    if (variant === "outline") {
+      return "none";
+    }
+    return "none";
+  }};
+`;
 
 const Button = styled.button`
-   {
-    box-sizing: border-box;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: var(--text-medium);
-    font-family: var(--font-bold);
-    line-height: 1;
-    text-decoration: none;
-    border: transparent;
-    height: ${({ buttonStyle }) => {
-      if (buttonStyle === "narrow") {
-        return "var(--button-height-narrow)";
-      }
-      return "var(--button-height)";
-    }};
-    padding: ${({ buttonStyle }) => {
-      if (buttonStyle === "narrow") {
-        return "10px 12px";
-      }
-      return "18px 20px";
-    }};
-    color: ${({ variant, disabled }) => {
-      if (disabled && variant === "outline") {
-        return "var(--button-disabled-outline-font-color)";
-      }
-      if (variant === "outline") {
-        return "var(--text-color)";
-      }
-      return "var(--inverse-text-color) !important"; // remove if possible
-    }};
-    background-color: ${({ variant, disabled }) => {
-      if (disabled && variant === "outline") {
-        return "var(--button-disabled-outline-bg-color)";
-      }
-      if (variant === "outline") {
-        return "var(--inverse-text-color)";
-      }
-      if (disabled) {
-        return "var(--button-disabled-bg-color)";
-      }
-      return "var(--link-color)";
-    }};
-    border: ${({ variant, disabled }) => {
-      if (disabled && variant === "outline") {
-        return "1px solid var(--button-outline-color)";
-      }
-      if (variant === "outline") {
-        return "1px solid var(--border-color)";
-      }
-      return "none";
-    }};
-
-    &:hover {
-      ${hoverStates};
+  box-sizing: border-box;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-medium);
+  font-family: var(--font-bold);
+  line-height: 1;
+  text-decoration: none;
+  border: transparent;
+  height: ${({ buttonStyle }) => {
+    if (buttonStyle === "narrow") {
+      return "var(--button-height-narrow)";
     }
-
-    &:focus-visible {
-      ${focusVisibleStates};
+    return "var(--button-height)";
+  }};
+  padding: ${({ buttonStyle }) => {
+    if (buttonStyle === "narrow") {
+      return "10px 12px";
     }
-
-    &:active {
-      ${activeStates};
+    return "18px 20px";
+  }};
+  color: ${({ variant, disabled }) => {
+    if (disabled && variant === "outline") {
+      return "var(--button-disabled-outline-font-color)";
     }
+    if (variant === "outline") {
+      return "var(--text-color)";
+    }
+    return "var(--inverse-text-color) !important"; // remove if possible
+  }};
+  background-color: ${({ variant, disabled }) => {
+    if (disabled && variant === "outline") {
+      return "var(--button-disabled-outline-bg-color)";
+    }
+    if (variant === "outline") {
+      return "var(--inverse-text-color)";
+    }
+    if (disabled) {
+      return "var(--button-disabled-bg-color)";
+    }
+    return "var(--link-color)";
+  }};
+  border: ${({ variant, disabled }) => {
+    if (disabled && variant === "outline") {
+      return "1px solid var(--button-outline-color)";
+    }
+    if (variant === "outline") {
+      return "1px solid var(--border-color)";
+    }
+    return "none";
+  }};
+
+  &:hover {
+    ${hoverStates};
+  }
+
+  &:focus-visible {
+    ${focusVisibleStates};
+  }
+
+  &:active {
+    ${activeStates};
+  }
+
+  &:focus {
+    ${focusStates}
   }
 `;
 const AnchorButtonText = styled.span`
-   {
-    padding: 0 4px;
-  }
+  padding: 0 4px;
 `;
 const AnchorButtonIcon = styled.span`
-   {
-    padding: 0 4px;
+  padding: 0 4px;
 
-    svg {
-      display: block;
-      margin: auto;
-      max-height: 36px;
-      max-width: 36px;
-    }
+  svg {
+    display: block;
+    margin: auto;
+    max-height: 36px;
+    max-width: 36px;
   }
 `;
 

--- a/webapp/client/src/components/ButtonAnchor.js
+++ b/webapp/client/src/components/ButtonAnchor.js
@@ -85,14 +85,6 @@ const activeStates = css`
     return "none";
   }};
 `;
-const focusStates = css`
-  outline: ${({ variant }) => {
-    if (variant === "outline") {
-      return "none";
-    }
-    return "none";
-  }};
-`;
 
 const Button = styled.button`
   box-sizing: border-box;
@@ -162,7 +154,7 @@ const Button = styled.button`
   }
 
   &:focus {
-    ${focusStates}
+    outline: none;
   }
 `;
 const AnchorButtonText = styled.span`

--- a/webapp/client/src/components/ContentPageBox.js
+++ b/webapp/client/src/components/ContentPageBox.js
@@ -68,24 +68,24 @@ export default function ContentPageBox({ boxText, anchor, plausibleDomain }) {
         <TextBox>
           <BoxText>{boxText.headerOne}</BoxText>
           <ButtonAnchor
-            url={anchor.eligibility.url}
-            plausibleGoal={anchor.eligibility.plausibleGoal}
+            url={anchor.buttonOne.url}
+            plausibleGoal={anchor.buttonOne.plausibleGoal}
             plausibleDomain={plausibleDomain}
           >
-            {anchor.eligibility.text}
+            {anchor.buttonOne.text}
           </ButtonAnchor>
           <BoxText className="mt-5">{boxText.headerTwo}</BoxText>
           <ButtonBox>
             <SecondaryAnchorButton
-              url={anchor.faq.url}
-              plausibleGoal={anchor.faq.plausibleGoal}
-              text={anchor.faq.text}
+              url={anchor.buttonTwo.url}
+              plausibleGoal={anchor.buttonTwo.plausibleGoal}
+              text={anchor.buttonTwo.text}
               plausibleDomain={plausibleDomain}
             />
             <SecondaryAnchorButton
-              url={anchor.contact.url}
-              plausibleGoal={anchor.contact.plausibleGoal}
-              text={anchor.contact.text}
+              url={anchor.buttonThree.url}
+              plausibleGoal={anchor.buttonThree.plausibleGoal}
+              text={anchor.buttonThree.text}
               plausibleDomain={plausibleDomain}
               className="mt-4 mt-md-0"
             />
@@ -103,17 +103,17 @@ ContentPageBox.propTypes = {
   },
   plausibleDomain: PropTypes.string,
   anchor: {
-    eligibility: {
+    buttonOne: {
       url: PropTypes.string,
       text: PropTypes.string,
       plausibleGoal: PropTypes.string,
     },
-    faq: {
+    buttonTwo: {
       url: PropTypes.string,
       text: PropTypes.string,
       plausibleGoal: PropTypes.string,
     },
-    contact: {
+    buttonThree: {
       url: PropTypes.string,
       text: PropTypes.string,
       plausibleGoal: PropTypes.string,
@@ -128,17 +128,17 @@ ContentPageBox.defaultProps = {
   },
   plausibleDomain: null,
   anchor: {
-    eligibility: {
+    buttonOne: {
       url: null,
       text: null,
       plausibleGoal: null,
     },
-    faq: {
+    buttonTwo: {
       url: null,
       text: null,
       plausibleGoal: null,
     },
-    contact: {
+    buttonThree: {
       url: null,
       text: null,
       plausibleGoal: null,

--- a/webapp/client/src/components/ContentPageBox.test.js
+++ b/webapp/client/src/components/ContentPageBox.test.js
@@ -10,15 +10,15 @@ function setup() {
     },
 
     anchor: {
-      eligibility: {
+      buttonOne: {
         url: "/eligibility/step/marital_status?link_overview=False",
         text: "Fragebogen starten",
       },
-      faq: {
+      buttonTwo: {
         url: "/sofunktionierts",
         text: "Häufig gestellte Fragen",
       },
-      contact: {
+      buttonThree: {
         url: "mailto:kontakt@steuerlotse-rente.de",
         text: "Kontaktieren Sie uns",
       },

--- a/webapp/client/src/components/SecondaryAnchorButton.js
+++ b/webapp/client/src/components/SecondaryAnchorButton.js
@@ -23,14 +23,12 @@ const AnchorSecondary = styled.a`
     color: var(--inverse-text-color);
     background-color: var(--link-color);
     outline: 0;
-    border-bottom: 4px solid var(--link-color);
   }
 
   &:hover {
     outline: 1px solid var(--link-hover-color);
     background: var(--link-hover-color);
     border: none;
-    border-bottom: 4px solid var(--link-hover-color);
     color: var(--inverse-text-color);
     text-decoration: none;
   }

--- a/webapp/client/src/components/SuccessStepsInfoBox.js
+++ b/webapp/client/src/components/SuccessStepsInfoBox.js
@@ -8,9 +8,11 @@ const Box = styled.div`
   background-color: var(--white);
   display: flex;
   margin-top: ${(props) =>
-    props.shareBoxSpacingVariant ? "var(--spacing-09)" : "var(--spacing-03)"};
+    props.shareBoxSpacingVariant
+      ? "calc(var(--spacing-09) + 4px)"
+      : "var(--spacing-03)"};
   margin-bottom: ${(props) =>
-    props.shareBoxSpacingVariant && "var(--spacing-09)"};
+    props.shareBoxSpacingVariant && "calc(var(--spacing-09) + 4px)"};
   border: 1px solid var(--beige-300);
 
   @media (max-width: 576px) {
@@ -28,6 +30,7 @@ const InnerBox = styled.div`
     props.className ? "32px 64px 48px 30px" : "32px 152px 48px 48px"};
   padding-bottom: ${(props) => props.textOnly && "32px"};
 
+  padding-bottom: ${(props) => props.shareBoxSpacingVariant && "40px"};
   padding-right: ${(props) => props.shareBoxSpacingVariant && "131px"};
 
   @media (max-width: 768px) {
@@ -108,7 +111,11 @@ export default function SuccessStepsInfoBox({
   return (
     <Box shareBoxSpacingVariant={shareBoxSpacingVariant}>
       {icon && <Icon src={icon.iconSrc} alt={icon.altText} />}
-      <InnerBox className={icon} textOnly={textOnly}>
+      <InnerBox
+        className={icon}
+        textOnly={textOnly}
+        shareBoxSpacingVariant={shareBoxSpacingVariant}
+      >
         <InnerBoxHeader>{header}</InnerBoxHeader>
         <InnerBoxText>{text}</InnerBoxText>
         {anchor && (

--- a/webapp/client/src/pages/InfoTaxReturnForPensionersPage.js
+++ b/webapp/client/src/pages/InfoTaxReturnForPensionersPage.js
@@ -47,17 +47,17 @@ const ShareBox = styled.div`
 export default function InfoTaxReturnForPensionersPage({ plausibleDomain }) {
   const { t } = useTranslation();
   const buttons = {
-    eligibility: {
+    buttonOne: {
       text: t("taxGuideQuestionBox.startQuestionnaire"),
       url: "/eligibility/step/marital_status?link_overview=False",
       plausibleGoal: "contentPage_startQuestionnaire_clicked",
     },
-    faq: {
+    buttonTwo: {
       text: t("taxGuideQuestionBox.faq"),
       url: "/sofunktionierts",
       plausibleGoal: "contentPage_faq_clicked",
     },
-    contact: {
+    buttonThree: {
       text: t("taxGuideQuestionBox.contactUs"),
       url: "mailto:kontakt@steuerlotse-rente.de",
       plausibleGoal: "contentPage_contactUs_clicked",


### PR DESCRIPTION
# Short Description
- Post QA adjustments - adjusting the margin and padding for the share box. Removing the blue outline for the copy link button. Renaming anchors to make the contentBox component reusable. 

# Changes
- increased margin for the shareBox
- reduced bottom padding for the shareBox
- added a focus state with an outline of none to remove the blue outline
- renamed anchor buttons in the contentPage so the contentBox component can be reused with other links/names
- adjusted tests for the contentPageBox with new generic button anchor names

# Feedback
- any

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
