### PR TITLE
STL-2259-QA Fixes for Vorbereiten Page

### DIFF
--- a/webapp/client/src/components/AccordionComponent.js
+++ b/webapp/client/src/components/AccordionComponent.js
@@ -31,9 +31,18 @@ const CardHeaderElement = styled.div`
 const ExpandButton = styled.button`
   border: 0;
   background: inherit;
-
   &:focus {
     outline: 0;
+  }
+
+  &.text-left:focus-visible {
+    color: var(--focus-text-color) !important;
+    outline: none;
+    box-shadow: none;
+    background: linear-gradient(
+      var(--focus-color) calc(100% - 4px),
+      var(--focus-text-color) 4px
+    );
   }
 `;
 
@@ -83,7 +92,7 @@ export default function AccordionComponent({ title, intro, items }) {
                 <ExpandButton className="col text-left">
                   <CardHeaderSpan>{item.title}</CardHeaderSpan>
                 </ExpandButton>
-                <ExpandButton className="col-1">
+                <ExpandButton tabIndex={-1} className="col-1">
                   {toggle === index ? (
                     <img src={minusIcon} alt="collapse" />
                   ) : (

--- a/webapp/client/src/components/TileCard.js
+++ b/webapp/client/src/components/TileCard.js
@@ -7,7 +7,6 @@ const LinkCard = styled.a`
   background-color: white;
   color: var(--text-color);
   text-decoration: none !important;
-  outline: none !important;
   text-align: center;
   height: 188px;
   min-width: 274px;
@@ -18,7 +17,6 @@ const LinkCard = styled.a`
   &:focus {
     color: var(--text-color);
     text-decoration: none !important;
-    outline: none !important;
   }
 
   &:hover {


### PR DESCRIPTION
# Short Description
Some fixes for the Vorbereiten page. Adds our custom focus state for the accordion title and default focus outline for the tile cards.

# Changes
- adds tabIndex of -1 for the expand button on the accordion
- removes outline:none for the tile cards css
- adds our custom focus visible style for the accordion title

# Feedback
- any

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
