### PR TITLE
Add more http sec header

### DIFF
--- a/webapp/app/routes.py
+++ b/webapp/app/routes.py
@@ -146,7 +146,18 @@ def register_request_handlers(app):
         if not Config.SET_SECURITY_HTTP_HEADERS:
             return response
 
-        response.headers['X-Content-Type-Options'] = 'no-sniff'
+        response.headers['X-Content-Type-Options'] = 'nosniff'
+        response.headers['X-Frame-Options'] = 'SAMEORIGIN'
+        response.headers['Referrer-Policy'] = 'same-origin'
+        response.headers['Permissions-Policy'] = 'Permissions-Policy: accelerometer=(), ambient-light-sensor=(), ' \
+                                                 'autoplay=(), battery=(), camera=(), cross-origin-isolated=(), ' \
+                                                 'display-capture=(), document-domain=(), encrypted-media=(), ' \
+                                                 'execution-while-not-rendered=(), execution-while-out-of-viewport=(' \
+                                                 '), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), ' \
+                                                 'magnetometer=(), microphone=(), midi=(), navigation-override=(), ' \
+                                                 'payment=(), picture-in-picture=(), publickey-credentials-get=(), ' \
+                                                 'screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), ' \
+                                                 'xr-spatial-tracking=() '
         response.headers['Content-Security-Policy'] = (
             "default-src 'self'; "
             "script-src 'self' 'unsafe-inline' plausible.io; "


### PR DESCRIPTION
# Short Description
While looking into http headers in Grundsteuer, I ran the analyze tool also on the steuerlotse webpage (s. [here](https://securityheaders.com/?q=steuerlotse-rente.de&followRedirects=on)) and it showed some missing and incorrect headers. 

# Changes
- Add missing headers
- Fix incorrect no-sniff attribute

# Feedback
- Does that make sense to? What do you think about the values I chose?
- I was not sure if there are any features that you need from the Permission-Policy. You might have to check that.

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
