### PR TITLE
STL-2111 | Fix error permissions-policy | Fix error CSP for newslette…

### DIFF
--- a/webapp/app/routes.py
+++ b/webapp/app/routes.py
@@ -177,7 +177,7 @@ def register_request_handlers(app):
         response.headers['X-Content-Type-Options'] = 'nosniff'
         response.headers['X-Frame-Options'] = 'SAMEORIGIN'
         response.headers['Referrer-Policy'] = 'same-origin'
-        response.headers['Permissions-Policy'] = 'Permissions-Policy: accelerometer=(), ambient-light-sensor=(), ' \
+        response.headers['Permissions-Policy'] = 'accelerometer=(), ambient-light-sensor=(), ' \
                                                  'autoplay=(), battery=(), camera=(), cross-origin-isolated=(), ' \
                                                  'display-capture=(), document-domain=(), encrypted-media=(), ' \
                                                  'execution-while-not-rendered=(), execution-while-out-of-viewport=(' \
@@ -186,11 +186,14 @@ def register_request_handlers(app):
                                                  'payment=(), picture-in-picture=(), publickey-credentials-get=(), ' \
                                                  'screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), ' \
                                                  'xr-spatial-tracking=() '
+        additional_connect_src = ""
+        if request.path == '/unlock_code_request/step/unlock_code_success':
+            additional_connect_src = "'self'"
         response.headers['Content-Security-Policy'] = (
             "default-src 'self'; "
             "script-src 'self' 'unsafe-inline' plausible.io; "
             "style-src 'self' 'unsafe-inline'; "
-            "connect-src plausible.io; "
+            "connect-src " + additional_connect_src + " plausible.io; "
             "object-src 'none'; "
         )
         return response


### PR DESCRIPTION
# Short Description
- Fix browser console error because of not readable permissions policy.
- Fix in the CSP for doing a frontend fetch from the NewsletterBox component

# Changes
- The error with the permissions policy must exist for a long time. On production the error is shown in the console browser (tested on Chrome and Firefox). 
- For the error of the NewsletterBox component I have adjust the connect-src, the directive that restricts the URLs which can be loaded using script interfaces (fetch() is one of the restricted API). I added a condition in the @app.after.request so that 'self' is added when the page for the unlock_code_success is loaded. This way the same URL is served as an origin and the fetch call can be made

# Feedback
- Is this the correct way or we should completely avoid using fetch() in a react component to call the backend directly?
- I found [this](https://stackoverflow.com/a/56647408) entry in stackoverflow quite helpful

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
