### PR TITLE
STL-2372-QA Fixes

### DIFF
--- a/webapp/app/routes.py
+++ b/webapp/app/routes.py
@@ -307,7 +307,7 @@ def register_request_handlers(app):
     @add_caching_headers
     def index():
         return render_react_landing_page_template(
-            props=LandingPageProps().camelized_dict(),
+            props=LandingPageProps(plausible_domain=Config.PLAUSIBLE_DOMAIN).camelized_dict(),
             component='LandingPage')
 
     @app.route('/sofunktionierts')

--- a/webapp/client/src/components/AccordionComponent.js
+++ b/webapp/client/src/components/AccordionComponent.js
@@ -59,20 +59,22 @@ const CardHeaderSpan = styled.span`
 `;
 
 const AccordionHeadline = styled.h2`
-  margin-bottom: 0;
+  margin-bottom: ${(props) => (props.variant ? "var(--spacing-07)" : "0")};
 `;
 
 const AccordionStyled = styled(Accordion)`
   padding-top: var(--spacing-03);
 `;
 
-export default function AccordionComponent({ title, intro, items }) {
+export default function AccordionComponent({ title, intro, items, variant }) {
   const [toggle, setToggle] = useState();
 
   return (
     <>
       {title.length > 0 && (
-        <AccordionHeadline className="mt-5">{title}</AccordionHeadline>
+        <AccordionHeadline className="mt-5" variant={variant}>
+          {title}
+        </AccordionHeadline>
       )}
       {intro.length > 0 && <p className="mt-3 pb-2">{intro}</p>}
       <AccordionStyled>
@@ -94,9 +96,9 @@ export default function AccordionComponent({ title, intro, items }) {
                 </ExpandButton>
                 <ExpandButton tabIndex={-1} className="col-1">
                   {toggle === index ? (
-                    <img src={minusIcon} alt="collapse" />
+                    <img src={minusIcon} alt="Einklappen Icon" />
                   ) : (
-                    <img src={plusIcon} alt="expand" />
+                    <img src={plusIcon} alt="Ausklappen Icon" />
                   )}
                 </ExpandButton>
               </Accordion.Toggle>
@@ -114,6 +116,7 @@ export default function AccordionComponent({ title, intro, items }) {
 
 AccordionComponent.propTypes = {
   title: PropTypes.string,
+  variant: PropTypes.bool,
   intro: PropTypes.string,
   items: PropTypes.arrayOf(
     PropTypes.exact({
@@ -126,4 +129,5 @@ AccordionComponent.propTypes = {
 AccordionComponent.defaultProps = {
   title: "",
   intro: "",
+  variant: false,
 };

--- a/webapp/client/src/components/ButtonAnchor.js
+++ b/webapp/client/src/components/ButtonAnchor.js
@@ -93,6 +93,7 @@ const Button = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  margin-bottom: ${(props) => props.marginVariant && "var(--spacing-03)"};
   font-size: var(--text-medium);
   font-family: var(--font-bold);
   line-height: 1;
@@ -214,6 +215,7 @@ export default function ButtonAnchor({
   external,
   disabled,
   className,
+  marginVariant,
 }) {
   const relation = [];
   let target = false;
@@ -236,6 +238,7 @@ export default function ButtonAnchor({
       target={target || undefined}
       rel={url && !download ? relation : undefined}
       onClick={onClick}
+      marginVariant={marginVariant}
     >
       {children}
     </Button>
@@ -259,6 +262,7 @@ ButtonAnchor.propTypes = {
   variant: PropTypes.oneOf(["primary", "outline"]),
   disabled: PropTypes.bool,
   className: PropTypes.string,
+  marginVariant: PropTypes.bool,
 };
 
 ButtonAnchor.defaultProps = {
@@ -271,4 +275,5 @@ ButtonAnchor.defaultProps = {
   buttonStyle: "default",
   disabled: false,
   className: undefined,
+  marginVariant: false,
 };

--- a/webapp/client/src/components/CardsComponent.js
+++ b/webapp/client/src/components/CardsComponent.js
@@ -7,11 +7,15 @@ const Wrapper = styled.div`
   background-color: var(--bg-highlight-color);
   display: flex;
   padding: 3rem 2rem 0 2rem;
-  gap: var(--spacing-06);
+  gap: var(--spacing-03);
+
+  @media (max-width: 1024px) {
+    padding-top: var(--spacing-06a);
+  }
 
   @media (max-width: 767px) {
     flex-direction: column;
-    padding: 0;
+    padding: var(--spacing-03) 0;
   }
 
   @media (max-width: 500px) {
@@ -63,7 +67,7 @@ export default function CardsComponent({ cards }) {
         <Card href={card.url} key={index}>
           <h2>{card.header}</h2>
           <p>{card.text}</p>
-          <img src={ArrowLeft} alt="arrow pointing left" />
+          <img src={ArrowLeft} alt="Pfeil nach rechts" />
         </Card>,
       ])}
     </Wrapper>

--- a/webapp/client/src/lib/translations.js
+++ b/webapp/client/src/lib/translations.js
@@ -1102,7 +1102,7 @@ const translations = {
           "Der Steuerlotse kann zurzeit nur für die Abgabe einer Steuererklärung für das Steuerjahr 2021 verwendet werden. Für alle früheren Steuerjahre können Sie beispielsweise auf <elsterLink>Mein ELSTER</elsterLink> oder in einigen Bundesländern auch auf das <simplifiedPaperFormLink>vereinfachte Papierformular</simplifiedPaperFormLink> zurückgreifen.",
       },
     },
-    ButtonLabel: "Zum Informationsseite",
+    ButtonLabel: "Zur Informationsseite",
     InformationButtonPlausibleGoal: "Zur Informationsseite",
   },
   freeTaxDeclarationForPensioners: {

--- a/webapp/client/src/pages/LandingPage.js
+++ b/webapp/client/src/pages/LandingPage.js
@@ -14,6 +14,10 @@ const LandingPageHeroWrapper = styled.div`
   @media (max-width: 1023px) {
     flex-direction: column;
   }
+
+  @media (max-width: 768px) {
+    padding-left: 1rem;
+  }
 `;
 
 const LandingPageHeroContentWrapper = styled.div`
@@ -123,17 +127,26 @@ export default function LandingPage({ plausibleDomain }) {
             url="/eligibility/step/first_input_step"
             plausibleGoal={t("LandingPage.Hero.plausibleGoal")}
             plausibleDomain={plausibleDomain}
+            marginVariant
           >
             {t("LandingPage.Hero.checkUseButton")}
           </ButtonAnchor>
         </LandingPageHeroContentWrapper>
         <Figure>
-          <img
-            srcSet="../images/hero-image-small.png 1155w,
-                                ../images/hero-image-big.png 2048w"
-            src="../images/hero-image-small.png"
-            alt="Bilder von Rentnerinnen und Rentnern beim Ausfüllen ihrer digitalen Steuererklärung."
-          />
+          <picture>
+            <source
+              media="(min-width: 1024px)"
+              srcSet="../images/hero-image-big.png"
+            />
+            <source
+              media="(min-width: 320px)"
+              srcSet="../images/hero-image-small.png"
+            />
+            <img
+              src="../images/hero-image-small.png"
+              alt="Bilder von Rentnerinnen und Rentnern beim Ausfüllen ihrer digitalen Steuererklärung."
+            />
+          </picture>
         </Figure>
       </LandingPageHeroWrapper>
       <CardsComponent cards={cardsInfo} />
@@ -141,6 +154,7 @@ export default function LandingPage({ plausibleDomain }) {
         <AccordionComponent
           title={t("LandingPage.Accordion.heading")}
           items={faqAnchorList}
+          variant
         />
         <ButtonAnchorLandingPage
           url="/sofunktionierts"


### PR DESCRIPTION
# Short Description
- Adjustments after QA

# Changes
- adds pluasibleDomain props to the landingPage route
- adds alt text for icons on cards and on accordion
- Changing from using `img` with `srcSet` to using `picture` and `source` solving the issue of the image not changing on changing screen sizes.

# Feedback
- any?

# How to review this Pull Request
[Link to Confluence](https://digitalservice4germany.atlassian.net/wiki/spaces/STL/pages/117637157/Development+Process#Approve-or-comment) (internal)
